### PR TITLE
Add Claude Code JSONL session import

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -22,6 +22,7 @@ import time
 from . import __version__
 from .hooks import hook_main
 from .http_proxy import HTTPProxyServer
+from .jsonl_import import cmd_import
 from .models import EventType, SessionMeta, TraceEvent
 from .proxy import MCPProxy
 from .replay import format_event, format_summary, list_sessions, replay_session
@@ -432,6 +433,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_setup.add_argument("--redact", action="store_true", help="enable secret redaction")
     p_setup.add_argument("--global", dest="global_config", action="store_true", help="output config for ~/.claude/settings.json (all projects)")
 
+    # import (Claude Code JSONL session logs)
+    p_import = sub.add_parser("import", help="import a Claude Code JSONL session log")
+    p_import.add_argument("path", nargs="?", help="path to .jsonl session file")
+    p_import.add_argument("--discover", action="store_true", help="list available Claude Code sessions")
+    p_import.add_argument("--claude-dir", default="~/.claude", help="Claude config directory (default: ~/.claude)")
+
     return parser
 
 
@@ -460,6 +467,7 @@ def main() -> None:
         "inspect": cmd_inspect,
         "export": cmd_export,
         "stats": cmd_stats,
+        "import": cmd_import,
     }
 
     handler = handlers.get(args.command)

--- a/src/agent_trace/jsonl_import.py
+++ b/src/agent_trace/jsonl_import.py
@@ -1,0 +1,452 @@
+"""Import Claude Code native JSONL session logs.
+
+Claude Code stores session logs as JSONL files in:
+    ~/.claude/projects/<encoded-project-path>/<session-id>.jsonl
+
+Each line is a JSON object with fields like:
+    type, message, uuid, parentUuid, sessionId, timestamp, etc.
+
+This module parses those logs and converts them into agent-trace's
+TraceEvent/SessionMeta format, so they can be replayed, exported,
+and analyzed with all existing agent-trace commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    """Import a Claude Code JSONL session log (CLI handler)."""
+    store = TraceStore(args.trace_dir)
+
+    if args.discover:
+        sessions = discover_claude_sessions(args.claude_dir)
+        if not sessions:
+            sys.stderr.write("No Claude Code sessions found.\n")
+            return 1
+
+        sys.stderr.write(f"\nFound {len(sessions)} Claude Code sessions:\n\n")
+        for s in sessions:
+            sys.stderr.write(
+                f"  {s['session_id'][:12]}  {s['size_kb']:>6} KB  {s['project']}\n"
+            )
+        sys.stderr.write("\nImport with: agent-strace import <path-to-session.jsonl>\n")
+        return 0
+
+    if not args.path:
+        sys.stderr.write("Usage: agent-strace import <session.jsonl>\n")
+        sys.stderr.write("       agent-strace import --discover\n")
+        return 1
+
+    try:
+        session_id = import_jsonl(args.path, store=store)
+    except FileNotFoundError as e:
+        sys.stderr.write(f"{e}\n")
+        return 1
+
+    meta = store.load_meta(session_id)
+    events = store.load_events(session_id)
+
+    sys.stderr.write(
+        f"Imported session {session_id}\n"
+        f"  {meta.tool_calls} tool calls, "
+        f"{meta.llm_requests} LLM requests, "
+        f"{meta.total_tokens} tokens\n"
+        f"  {len(events)} events\n"
+        f"  Replay with: agent-strace replay {session_id}\n"
+    )
+    return 0
+
+
+def _parse_iso_timestamp(ts: str) -> float:
+    """Convert ISO 8601 timestamp to Unix epoch seconds."""
+    from datetime import datetime
+
+    if not ts:
+        return 0.0
+    try:
+        # Handle Z suffix
+        ts = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts)
+        return dt.timestamp()
+    except (ValueError, OSError):
+        return 0.0
+
+
+def _extract_tool_calls(content: list[dict]) -> list[dict[str, Any]]:
+    """Extract tool_use blocks from message content."""
+    calls = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_use":
+            calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "name": block.get("name", ""),
+                    "input": block.get("input", {}),
+                    "caller": block.get("caller", {}),
+                }
+            )
+    return calls
+
+
+def _extract_tool_results(content: list[dict]) -> list[dict[str, Any]]:
+    """Extract tool_result blocks from message content."""
+    results = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_result":
+            text_parts = []
+            bc = block.get("content", "")
+            if isinstance(bc, str):
+                text_parts.append(bc)
+            elif isinstance(bc, list):
+                for sub in bc:
+                    if isinstance(sub, dict) and sub.get("type") == "text":
+                        text_parts.append(sub.get("text", ""))
+            results.append(
+                {
+                    "tool_use_id": block.get("tool_use_id", ""),
+                    "content": "\n".join(text_parts),
+                }
+            )
+    return results
+
+
+def _extract_text(content: Any) -> str:
+    """Extract text from message content (string or content blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return ""
+
+
+def import_jsonl(
+    path: str | Path,
+    store: TraceStore | None = None,
+    trace_dir: str = ".agent-traces",
+) -> str:
+    """Import a Claude Code JSONL session log into agent-trace format.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the .jsonl session file.
+    store : TraceStore, optional
+        Existing store to import into. Creates one if not provided.
+    trace_dir : str
+        Directory for trace storage (used if store is None).
+
+    Returns
+    -------
+    str
+        The session ID of the imported session.
+    """
+    path = Path(path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Session log not found: {path}")
+
+    if store is None:
+        store = TraceStore(trace_dir)
+
+    # First pass: extract metadata from first entry
+    session_id = ""
+    extra_meta: dict[str, str] = {}
+    first_ts = 0.0
+    last_ts = 0.0
+    entries: list[dict[str, Any]] = []
+
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            # Skip queue operations
+            if raw.get("type") in ("queue-operation",):
+                continue
+
+            entries.append(raw)
+
+            ts = _parse_iso_timestamp(raw.get("timestamp", ""))
+            if first_ts == 0.0 and ts > 0:
+                first_ts = ts
+            if ts > 0:
+                last_ts = ts
+
+            if not session_id:
+                session_id = raw.get("sessionId", "")
+                extra_meta["git_branch"] = raw.get("gitBranch", "")
+                extra_meta["version"] = raw.get("version", "")
+
+    if not session_id:
+        session_id = path.stem[:16]
+
+    # Create session
+    meta = SessionMeta(
+        session_id=session_id[:16],
+        started_at=first_ts,
+        agent_name="claude-code",
+        command=f"imported from {path.name} (branch: {extra_meta.get('git_branch', '')}, v{extra_meta.get('version', '')})",
+    )
+    store.create_session(meta)
+
+    # Second pass: convert entries to TraceEvents
+    for raw in entries:
+        entry_type = raw.get("type", "")
+        ts = _parse_iso_timestamp(raw.get("timestamp", ""))
+        msg = raw.get("message", {})
+        if not isinstance(msg, dict):
+            continue
+
+        content = msg.get("content", "")
+        usage = msg.get("usage", {})
+        model = msg.get("model", "")
+        is_sidechain = raw.get("isSidechain", False)
+
+        # User entry
+        if entry_type == "user":
+            text = _extract_text(content)
+
+            # Check for tool results in user messages
+            if isinstance(content, list):
+                tool_results = _extract_tool_results(content)
+                for tr in tool_results:
+                    preview = tr["content"][:200] if tr["content"] else ""
+                    event = TraceEvent(
+                        event_type=EventType.TOOL_RESULT,
+                        timestamp=ts,
+                        session_id=meta.session_id,
+                        data={
+                            "tool_use_id": tr["tool_use_id"],
+                            "content_preview": preview,
+                        },
+                    )
+                    store.append_event(meta.session_id, event)
+
+                # Also check toolUseResult
+                tr_data = raw.get("toolUseResult")
+                if tr_data and isinstance(tr_data, dict):
+                    stdout = tr_data.get("stdout", "") or ""
+                    stderr = tr_data.get("stderr", "") or ""
+                    if stdout or stderr:
+                        result_text = stdout[:500]
+                        if stderr:
+                            result_text += f" [stderr: {stderr[:200]}]"
+                        event = TraceEvent(
+                            event_type=EventType.TOOL_RESULT,
+                            timestamp=ts,
+                            session_id=meta.session_id,
+                            data={
+                                "result": result_text,
+                                "content_types": ["text"],
+                            },
+                        )
+                        store.append_event(meta.session_id, event)
+
+            if text and not text.startswith("{"):
+                event = TraceEvent(
+                    event_type=EventType.USER_PROMPT,
+                    timestamp=ts,
+                    session_id=meta.session_id,
+                    data={"prompt": text[:2000]},
+                )
+                store.append_event(meta.session_id, event)
+
+        # Assistant entry
+        elif entry_type == "assistant":
+            text = _extract_text(content)
+
+            # Extract tool calls
+            if isinstance(content, list):
+                tool_calls = _extract_tool_calls(content)
+                for tc in tool_calls:
+                    tool_data: dict[str, Any] = {
+                        "tool_name": tc["name"],
+                        "arguments": tc["input"],
+                        "request_id": tc["id"],
+                    }
+                    # Tag subagent calls
+                    if is_sidechain:
+                        tool_data["is_sidechain"] = True
+                    caller = tc.get("caller", {})
+                    if caller.get("type"):
+                        tool_data["caller_type"] = caller["type"]
+                    # Extract subagent info from Agent tool
+                    if tc["name"] == "Agent":
+                        inp = tc["input"]
+                        if inp.get("subagent_type"):
+                            tool_data["subagent_type"] = inp["subagent_type"]
+
+                    event = TraceEvent(
+                        event_type=EventType.TOOL_CALL,
+                        timestamp=ts,
+                        session_id=meta.session_id,
+                        data=tool_data,
+                    )
+                    store.append_event(meta.session_id, event)
+                    meta.tool_calls += 1
+
+            # Log assistant text (if any, and no tool calls)
+            if text and not (
+                isinstance(content, list) and _extract_tool_calls(content)
+            ):
+                event = TraceEvent(
+                    event_type=EventType.ASSISTANT_RESPONSE,
+                    timestamp=ts,
+                    session_id=meta.session_id,
+                    data={
+                        "text": text[:2000],
+                        "model": model,
+                    },
+                )
+                store.append_event(meta.session_id, event)
+
+            # Track token usage
+            if usage:
+                input_tokens = usage.get("input_tokens", 0)
+                output_tokens = usage.get("output_tokens", 0)
+                meta.total_tokens += (
+                    input_tokens
+                    + output_tokens
+                    + usage.get("cache_creation_input_tokens", 0)
+                    + usage.get("cache_read_input_tokens", 0)
+                )
+                meta.llm_requests += 1
+
+        # System entry (e.g., turn duration)
+        elif entry_type == "system":
+            subtype = raw.get("subtype", "")
+            if subtype == "turn_duration":
+                duration_ms = raw.get("durationMs", 0)
+                if duration_ms:
+                    meta.total_duration_ms += duration_ms
+
+    # Finalize session
+    meta.ended_at = last_ts if last_ts > 0 else meta.started_at
+    if meta.total_duration_ms == 0 and meta.ended_at > meta.started_at:
+        meta.total_duration_ms = (meta.ended_at - meta.started_at) * 1000
+
+    # Add session end event
+    store.append_event(
+        meta.session_id,
+        TraceEvent(
+            event_type=EventType.SESSION_END,
+            timestamp=meta.ended_at,
+            session_id=meta.session_id,
+            data={
+                "duration_ms": meta.total_duration_ms,
+                "tool_calls": meta.tool_calls,
+                "llm_requests": meta.llm_requests,
+                "total_tokens": meta.total_tokens,
+                "source": str(path),
+            },
+        ),
+    )
+    store.update_meta(meta)
+
+    return meta.session_id
+
+
+def discover_claude_sessions(
+    claude_dir: str | Path = "~/.claude",
+) -> list[dict[str, Any]]:
+    """Discover all Claude Code session JSONL files.
+
+    Parameters
+    ----------
+    claude_dir : str or Path
+        Claude config directory (default: ~/.claude).
+
+    Returns
+    -------
+    list[dict]
+        List of session info dicts with 'path', 'project', 'session_id'.
+    """
+    claude_dir = Path(claude_dir).expanduser().resolve()
+    projects_dir = claude_dir / "projects"
+    if not projects_dir.exists():
+        return []
+
+    sessions = []
+    for project_dir in sorted(projects_dir.iterdir()):
+        if not project_dir.is_dir():
+            continue
+
+        project_name = _decode_project_path(project_dir.name)
+
+        for jsonl_file in sorted(project_dir.glob("*.jsonl")):
+            # Peek at first entry for session ID
+            sid = ""
+            try:
+                with open(jsonl_file, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            raw = json.loads(line)
+                            sid = raw.get("sessionId", "")
+                            if sid:
+                                break
+                        except json.JSONDecodeError:
+                            continue
+            except OSError:
+                continue
+
+            sessions.append(
+                {
+                    "path": jsonl_file,
+                    "project": project_name,
+                    "session_id": sid or jsonl_file.stem,
+                    "size_kb": jsonl_file.stat().st_size // 1024,
+                }
+            )
+
+    return sessions
+
+
+def _decode_project_path(encoded: str) -> str:
+    """Decode Claude Code's encoded project directory name.
+
+    Claude Code encodes paths by replacing '/' with '-'.
+    e.g. '-home-user-proj-myapp' -> '/home/user/proj/myapp'
+    """
+    if not encoded.startswith("-"):
+        return encoded
+
+    parts = encoded.split("-")
+    parts = parts[1:]  # remove leading empty string
+
+    result = ""
+    i = 0
+    while i < len(parts):
+        best_len = 1
+        for j in range(len(parts), i, -1):
+            candidate = result + "/" + "-".join(parts[i:j])
+            if Path(candidate).exists():
+                best_len = j - i
+                break
+        result += "/" + "-".join(parts[i : i + best_len])
+        i += best_len
+
+    return result

--- a/tests/test_jsonl_import.py
+++ b/tests/test_jsonl_import.py
@@ -1,0 +1,173 @@
+"""Tests for Claude Code JSONL import."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.jsonl_import import import_jsonl
+from agent_trace.models import EventType
+from agent_trace.store import TraceStore
+
+
+class TestJSONLImport(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def _write_jsonl(self, entries):
+        """Write entries to a temp JSONL file."""
+        path = os.path.join(self.tmpdir, "session.jsonl")
+        with open(path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+        return path
+
+    def test_import_basic_session(self):
+        path = self._write_jsonl([
+            {
+                "type": "user",
+                "sessionId": "abc123",
+                "gitBranch": "main",
+                "version": "2.1.50",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "message": {"role": "user", "content": "Hello"},
+                "uuid": "u1",
+            },
+            {
+                "type": "assistant",
+                "sessionId": "abc123",
+                "timestamp": "2025-01-01T00:00:01Z",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [{"type": "text", "text": "Hi there!"}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                },
+                "uuid": "a1",
+                "parentUuid": "u1",
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        self.assertTrue(session_id)
+
+        meta = self.store.load_meta(session_id)
+        self.assertEqual(meta.agent_name, "claude-code")
+        self.assertEqual(meta.total_tokens, 150)
+        self.assertEqual(meta.llm_requests, 1)
+
+        events = self.store.load_events(session_id)
+        types = [e.event_type for e in events]
+        self.assertIn(EventType.USER_PROMPT, types)
+        self.assertIn(EventType.ASSISTANT_RESPONSE, types)
+        self.assertIn(EventType.SESSION_END, types)
+
+    def test_import_tool_calls(self):
+        path = self._write_jsonl([
+            {
+                "type": "assistant",
+                "sessionId": "def456",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool1",
+                            "name": "Bash",
+                            "input": {"command": "ls -la"},
+                            "caller": {"type": "direct"},
+                        }
+                    ],
+                    "usage": {"input_tokens": 50, "output_tokens": 20},
+                },
+                "uuid": "a1",
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        meta = self.store.load_meta(session_id)
+        self.assertEqual(meta.tool_calls, 1)
+
+        events = self.store.load_events(session_id)
+        tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].data["tool_name"], "Bash")
+        self.assertEqual(tool_calls[0].data["arguments"]["command"], "ls -la")
+
+    def test_import_subagent(self):
+        path = self._write_jsonl([
+            {
+                "type": "assistant",
+                "sessionId": "ghi789",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "isSidechain": False,
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-opus-4-20250514",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "agent1",
+                            "name": "Agent",
+                            "input": {
+                                "description": "Search code",
+                                "subagent_type": "Explore",
+                                "prompt": "Find all files",
+                            },
+                            "caller": {"type": "direct"},
+                        }
+                    ],
+                    "usage": {"input_tokens": 100, "output_tokens": 50},
+                },
+                "uuid": "a1",
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        events = self.store.load_events(session_id)
+        tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].data["tool_name"], "Agent")
+        self.assertEqual(tool_calls[0].data["subagent_type"], "Explore")
+
+    def test_import_queue_operations_skipped(self):
+        path = self._write_jsonl([
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "sessionId": "q1",
+                "timestamp": "2025-01-01T00:00:00Z",
+            },
+            {
+                "type": "user",
+                "sessionId": "q1",
+                "timestamp": "2025-01-01T00:00:01Z",
+                "message": {"role": "user", "content": "test"},
+                "uuid": "u1",
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        events = self.store.load_events(session_id)
+        # queue-operation should not become an event
+        for e in events:
+            self.assertNotEqual(e.data.get("type"), "queue-operation")
+
+    def test_import_nonexistent_file(self):
+        with self.assertRaises(FileNotFoundError):
+            import_jsonl("/nonexistent/path.jsonl", store=self.store)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Import Claude Code's native JSONL session logs (~/.claude/projects/) into agent-trace format, enabling replay, export, and stats on existing sessions without hooks.

## Changes
- `src/agent_trace/jsonl_import.py` — JSONL parser, importer, CLI handler, session discovery
- `src/agent_trace/cli.py` — added `import` subcommand and `--discover` flag (3 lines)
- `tests/test_jsonl_import.py` — 5 unit tests

Parses: tool_use/tool_result blocks, token usage (input/output/cache), subagent detection (isSidechain, subagent_type, caller.type), session metadata.

## Test Plan
- All 135 tests pass (130 existing + 5 new)
- Tested with real Claude Code session (315-line JSONL, 38 tool calls, 4M tokens)

## Checklist
- [x] Follows existing code style
- [x] Tests pass
- [x] Documentation updated (if applicable)