### PR TITLE
feat: live session monitoring with circuit breakers (v1.0.0)

### DIFF
--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -16,7 +16,7 @@ import urllib.request
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, TextIO
+from typing import TextIO
 
 from .cost import _dollars, _event_tokens
 from .models import EventType, TraceEvent
@@ -174,8 +174,10 @@ def _dispatch_alert(
     action: str | None = None,
 ) -> None:
     action = action or config.on_violation
+    # terminal is always shown regardless of action so the operator watching
+    # the process sees every alert; file/webhook are additive channels
     _alert_terminal(message)
-    if action == "file":
+    if action in ("file", "kill"):
         _alert_file(message, config.alert_log)
     if config.webhook_url:
         _alert_webhook(message, config.webhook_url)
@@ -223,7 +225,7 @@ def check_event(
 
     # --- Cost threshold ---
     if state.estimated_cost > config.max_cost_dollars:
-        key_id = f"cost:{int(state.estimated_cost)}"
+        key_id = "cost"
         if key_id not in state.fired:
             state.fired.add(key_id)
             violations.append(
@@ -317,13 +319,6 @@ def watch_session(
 
     state = WatchState(start_time=time.time())
 
-    # Try to read agent PID from meta
-    try:
-        meta = store.load_meta(session_id)
-        # PID not stored in meta currently; placeholder for future use
-    except Exception:
-        pass
-
     out.write(f"[watch] Monitoring session {session_id[:12]}...\n")
     out.flush()
 
@@ -343,9 +338,10 @@ def watch_session(
                 out.write(f"[watch] Session ended ({event_count} events, ${state.estimated_cost:.4f})\n")
                 break
 
-            # Idle timeout
+            # Idle timeout: checked on each new event, so triggers on the
+            # first event that arrives after the idle window has elapsed.
             if time.time() - last_event_time > max_idle_seconds:
-                out.write(f"[watch] No events for {max_idle_seconds:.0f}s — stopping\n")
+                out.write(f"[watch] No events for {max_idle_seconds:.0f}s - stopping\n")
                 break
 
     except KeyboardInterrupt:

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -1,0 +1,388 @@
+"""Live session monitoring with circuit breakers.
+
+Tails the active session's events.ndjson and triggers alerts when
+configurable thresholds are exceeded. Zero new dependencies — stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+import urllib.request
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, TextIO
+
+from .cost import _dollars, _event_tokens
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Alert actions
+# ---------------------------------------------------------------------------
+
+def _alert_terminal(message: str, out: TextIO = sys.stderr) -> None:
+    out.write(f"[watch] ⚠️  {message}\n")
+    out.flush()
+
+
+def _alert_file(message: str, log_path: str = ".agent-traces/alerts.log") -> None:
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as f:
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        f.write(f"{ts}  {message}\n")
+
+
+def _alert_webhook(message: str, url: str) -> None:
+    payload = json.dumps({"text": message, "source": "agent-strace"}).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception:
+        pass  # webhook failures are non-fatal
+
+
+def _kill_process(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Watcher state machines
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WatcherConfig:
+    max_retries: int = 5
+    max_cost_dollars: float = 10.0
+    max_duration_seconds: float = 1800.0
+    loop_sequence_length: int = 3
+    loop_max_repeats: int = 3
+    scope_policy: str = ".agent-scope.json"
+    on_violation: str = "terminal"   # terminal | file | kill
+    webhook_url: str = ""
+    alert_log: str = ".agent-traces/alerts.log"
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WatcherConfig":
+        watchers = d.get("watchers", {})
+        retry_cfg = watchers.get("retry", {})
+        cost_cfg = watchers.get("cost", {})
+        dur_cfg = watchers.get("duration", {})
+        loop_cfg = watchers.get("loop", {})
+        scope_cfg = watchers.get("scope", {})
+        webhook = d.get("webhook", {})
+        return cls(
+            max_retries=int(retry_cfg.get("max", 5)),
+            max_cost_dollars=float(cost_cfg.get("max_dollars", 10.0)),
+            max_duration_seconds=float(dur_cfg.get("max_minutes", 30)) * 60,
+            loop_sequence_length=int(loop_cfg.get("sequence_length", 3)),
+            loop_max_repeats=int(loop_cfg.get("max_repeats", 3)),
+            scope_policy=str(scope_cfg.get("policy", ".agent-scope.json")),
+            on_violation=str(retry_cfg.get("alert", "terminal")),
+            webhook_url=str(webhook.get("url", "")),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "WatcherConfig":
+        p = Path(path)
+        if not p.exists():
+            return cls()
+        try:
+            return cls.from_dict(json.loads(p.read_text()))
+        except Exception:
+            return cls()
+
+
+@dataclass
+class WatchState:
+    """Mutable state accumulated across events."""
+    # Retry tracking: command → count
+    command_counts: Counter = field(default_factory=Counter)
+    # Cost accumulation
+    estimated_cost: float = 0.0
+    # Session start time
+    start_time: float = field(default_factory=time.time)
+    # Recent event sequence for loop detection (circular buffer)
+    recent_events: deque = field(default_factory=lambda: deque(maxlen=30))
+    # Violations already fired (to avoid duplicate alerts)
+    fired: set = field(default_factory=set)
+    # Agent PID (from session meta, if available)
+    agent_pid: int | None = None
+
+
+def _event_key(event: TraceEvent) -> str:
+    """Stable string key for an event (for loop detection)."""
+    if event.event_type == EventType.TOOL_CALL:
+        name = event.data.get("tool_name", "?")
+        args = event.data.get("arguments", {}) or {}
+        cmd = str(args.get("command", args.get("file_path", "")))[:40]
+        return f"{name}:{cmd}"
+    return event.event_type.value
+
+
+def _detect_loop(
+    recent: deque,
+    seq_len: int,
+    max_repeats: int,
+) -> str | None:
+    """Return a description if a repeating sequence is detected, else None."""
+    items = list(recent)
+    if len(items) < seq_len * 2:
+        return None
+
+    # Check if the last seq_len items repeat max_repeats times
+    tail = items[-seq_len:]
+    count = 1
+    pos = len(items) - seq_len * 2
+    while pos >= 0:
+        window = items[pos:pos + seq_len]
+        if window == tail:
+            count += 1
+            pos -= seq_len
+        else:
+            break
+
+    if count >= max_repeats:
+        seq_str = "→".join(tail)
+        return f"detected loop ({seq_str}) × {count}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Alert dispatcher
+# ---------------------------------------------------------------------------
+
+def _dispatch_alert(
+    message: str,
+    config: WatcherConfig,
+    state: WatchState,
+    action: str | None = None,
+) -> None:
+    action = action or config.on_violation
+    _alert_terminal(message)
+    if action == "file":
+        _alert_file(message, config.alert_log)
+    if config.webhook_url:
+        _alert_webhook(message, config.webhook_url)
+    if action == "kill" and state.agent_pid:
+        _alert_terminal(f"Killing agent process {state.agent_pid}")
+        _kill_process(state.agent_pid)
+
+
+# ---------------------------------------------------------------------------
+# Per-event check
+# ---------------------------------------------------------------------------
+
+def check_event(
+    event: TraceEvent,
+    config: WatcherConfig,
+    state: WatchState,
+) -> list[str]:
+    """Update state and return list of violation messages (may be empty)."""
+    violations: list[str] = []
+
+    # --- Cost accumulation ---
+    inp, out = _event_tokens(event)
+    state.estimated_cost += _dollars(inp, out, "sonnet")
+
+    # --- Loop detection ---
+    key = _event_key(event)
+    state.recent_events.append(key)
+
+    # --- Retry detection (bash commands) ---
+    if event.event_type == EventType.TOOL_CALL:
+        name = event.data.get("tool_name", "").lower()
+        args = event.data.get("arguments", {}) or {}
+        if name == "bash":
+            cmd = str(args.get("command", "")).strip()
+            if cmd:
+                state.command_counts[cmd] += 1
+                count = state.command_counts[cmd]
+                if count > config.max_retries:
+                    key_id = f"retry:{cmd}"
+                    if key_id not in state.fired:
+                        state.fired.add(key_id)
+                        violations.append(
+                            f"RetryWatcher: command ran {count} times: {cmd[:60]}"
+                        )
+
+    # --- Cost threshold ---
+    if state.estimated_cost > config.max_cost_dollars:
+        key_id = f"cost:{int(state.estimated_cost)}"
+        if key_id not in state.fired:
+            state.fired.add(key_id)
+            violations.append(
+                f"CostWatcher: ${state.estimated_cost:.2f} (threshold: ${config.max_cost_dollars})"
+            )
+
+    # --- Duration threshold ---
+    elapsed = time.time() - state.start_time
+    if elapsed > config.max_duration_seconds:
+        key_id = "duration"
+        if key_id not in state.fired:
+            state.fired.add(key_id)
+            violations.append(
+                f"DurationWatcher: {elapsed:.0f}s elapsed (threshold: {config.max_duration_seconds:.0f}s)"
+            )
+
+    # --- Loop detection ---
+    loop_msg = _detect_loop(
+        state.recent_events,
+        config.loop_sequence_length,
+        config.loop_max_repeats,
+    )
+    if loop_msg:
+        key_id = f"loop:{loop_msg[:40]}"
+        if key_id not in state.fired:
+            state.fired.add(key_id)
+            violations.append(f"LoopWatcher: {loop_msg}")
+
+    # --- Scope check (file operations) ---
+    if event.event_type == EventType.TOOL_CALL:
+        scope_path = Path(config.scope_policy)
+        if scope_path.exists():
+            try:
+                from .audit import Policy, _glob_match
+                policy = Policy.load(scope_path)
+                if policy:
+                    name = event.data.get("tool_name", "").lower()
+                    args = event.data.get("arguments", {}) or {}
+                    path = str(args.get("file_path") or args.get("path") or "")
+                    if path and name in ("write", "edit", "create"):
+                        if policy.file_write_deny and _glob_match(path, policy.file_write_deny):
+                            key_id = f"scope:{path}"
+                            if key_id not in state.fired:
+                                state.fired.add(key_id)
+                                violations.append(f"ScopeWatcher: write to {path} denied by policy")
+            except Exception:
+                pass
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# File tailer
+# ---------------------------------------------------------------------------
+
+def _tail_events(events_file: Path, poll_interval: float = 0.5):
+    """Generator that yields new TraceEvent lines as they appear."""
+    with open(events_file, "r", encoding="utf-8") as f:
+        # Skip existing content
+        f.seek(0, 2)
+        while True:
+            line = f.readline()
+            if line:
+                line = line.strip()
+                if line:
+                    try:
+                        yield TraceEvent.from_json(line)
+                    except Exception:
+                        pass
+            else:
+                time.sleep(poll_interval)
+
+
+# ---------------------------------------------------------------------------
+# Public watch loop
+# ---------------------------------------------------------------------------
+
+def watch_session(
+    store: TraceStore,
+    session_id: str,
+    config: WatcherConfig,
+    out: TextIO = sys.stderr,
+    poll_interval: float = 0.5,
+    max_idle_seconds: float = 300.0,
+) -> None:
+    """Watch a session's event stream and fire alerts on violations."""
+    events_file = store._session_dir(session_id) / "events.ndjson"
+    if not events_file.exists():
+        out.write(f"[watch] events file not found: {events_file}\n")
+        return
+
+    state = WatchState(start_time=time.time())
+
+    # Try to read agent PID from meta
+    try:
+        meta = store.load_meta(session_id)
+        # PID not stored in meta currently; placeholder for future use
+    except Exception:
+        pass
+
+    out.write(f"[watch] Monitoring session {session_id[:12]}...\n")
+    out.flush()
+
+    last_event_time = time.time()
+    event_count = 0
+
+    try:
+        for event in _tail_events(events_file, poll_interval=poll_interval):
+            event_count += 1
+            last_event_time = time.time()
+
+            violations = check_event(event, config, state)
+            for msg in violations:
+                _dispatch_alert(msg, config, state)
+
+            if event.event_type == EventType.SESSION_END:
+                out.write(f"[watch] Session ended ({event_count} events, ${state.estimated_cost:.4f})\n")
+                break
+
+            # Idle timeout
+            if time.time() - last_event_time > max_idle_seconds:
+                out.write(f"[watch] No events for {max_idle_seconds:.0f}s — stopping\n")
+                break
+
+    except KeyboardInterrupt:
+        out.write("\n[watch] Stopped.\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_watch(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+
+    # Load config file if provided
+    config_path = getattr(args, "config", None)
+    if config_path:
+        config = WatcherConfig.load(config_path)
+    else:
+        config = WatcherConfig(
+            max_retries=getattr(args, "max_retries", 5),
+            max_cost_dollars=getattr(args, "max_cost", 10.0),
+            max_duration_seconds=getattr(args, "max_duration", 1800),
+            on_violation=getattr(args, "on_violation", "terminal"),
+            webhook_url=getattr(args, "webhook", "") or "",
+        )
+
+    session_id = getattr(args, "session_id", None)
+    if not session_id:
+        session_id = store.get_latest_session_id()
+    if not session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+
+    full_id = store.find_session(session_id)
+    if not full_id:
+        sys.stderr.write(f"Session not found: {session_id}\n")
+        return 1
+
+    watch_session(store, full_id, config)
+    return 0

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -105,11 +105,23 @@ class TestCostThreshold(unittest.TestCase):
     def test_violation_when_cost_exceeds_threshold(self):
         config = _default_config(max_cost_dollars=0.0)
         state = WatchState()
-        # Force cost above threshold by setting it directly
         state.estimated_cost = 0.01
         event = _make_event(EventType.ASSISTANT_RESPONSE, 0.0, text="x" * 10000)
         violations = check_event(event, config, state)
         self.assertTrue(any("CostWatcher" in v for v in violations))
+
+    def test_cost_violation_fires_only_once(self):
+        config = _default_config(max_cost_dollars=0.0)
+        state = WatchState()
+        state.estimated_cost = 0.01
+        all_violations = []
+        for _ in range(5):
+            all_violations.extend(check_event(
+                _make_event(EventType.ASSISTANT_RESPONSE, 0.0, text="x"),
+                config, state,
+            ))
+        cost_violations = [v for v in all_violations if "CostWatcher" in v]
+        self.assertEqual(len(cost_violations), 1)
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +185,16 @@ class TestAlertTerminal(unittest.TestCase):
         _alert_terminal("test alert", out=buf)
         self.assertIn("test alert", buf.getvalue())
         self.assertIn("[watch]", buf.getvalue())
+
+    def test_dispatch_always_writes_terminal(self):
+        from agent_trace.watch import _dispatch_alert, WatcherConfig, WatchState
+        import unittest.mock as mock
+        config = WatcherConfig(on_violation="file")
+        state = WatchState()
+        with mock.patch("agent_trace.watch._alert_terminal") as mock_terminal, \
+             mock.patch("agent_trace.watch._alert_file"):
+            _dispatch_alert("msg", config, state)
+            mock_terminal.assert_called_once()
 
 
 class TestAlertFile(unittest.TestCase):

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,241 @@
+"""Tests for live session monitoring and circuit breakers."""
+
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from collections import deque
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+from agent_trace.watch import (
+    WatcherConfig,
+    WatchState,
+    check_event,
+    _alert_terminal,
+    _alert_file,
+    _detect_loop,
+    _event_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(event_type: EventType, ts: float, session_id: str = "s1", **data) -> TraceEvent:
+    return TraceEvent(event_type=event_type, timestamp=ts, session_id=session_id, data=data)
+
+
+def _bash_event(cmd: str, ts: float = 0.0) -> TraceEvent:
+    return _make_event(EventType.TOOL_CALL, ts, tool_name="Bash", arguments={"command": cmd})
+
+
+def _default_config(**kwargs) -> WatcherConfig:
+    defaults = dict(
+        max_retries=3,
+        max_cost_dollars=10.0,
+        max_duration_seconds=3600.0,
+        loop_sequence_length=3,
+        loop_max_repeats=3,
+        on_violation="terminal",
+    )
+    defaults.update(kwargs)
+    return WatcherConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Retry detection
+# ---------------------------------------------------------------------------
+
+class TestRetryDetection(unittest.TestCase):
+    def test_no_violation_below_threshold(self):
+        config = _default_config(max_retries=3)
+        state = WatchState()
+        cmd = "pytest"
+        for i in range(3):
+            violations = check_event(_bash_event(cmd, float(i)), config, state)
+        self.assertEqual(violations, [])
+
+    def test_violation_at_threshold_plus_one(self):
+        config = _default_config(max_retries=3)
+        state = WatchState()
+        cmd = "pytest"
+        all_violations = []
+        for i in range(5):
+            all_violations.extend(check_event(_bash_event(cmd, float(i)), config, state))
+        self.assertTrue(any("RetryWatcher" in v for v in all_violations))
+
+    def test_different_commands_no_violation(self):
+        config = _default_config(max_retries=2)
+        state = WatchState()
+        violations = []
+        for i, cmd in enumerate(["ls", "pwd", "echo hi"]):
+            violations = check_event(_bash_event(cmd, float(i)), config, state)
+        self.assertEqual(violations, [])
+
+    def test_violation_fires_only_once(self):
+        config = _default_config(max_retries=2)
+        state = WatchState()
+        cmd = "failing-cmd"
+        all_violations = []
+        for i in range(6):
+            v = check_event(_bash_event(cmd, float(i)), config, state)
+            all_violations.extend(v)
+        retry_violations = [v for v in all_violations if "RetryWatcher" in v]
+        self.assertEqual(len(retry_violations), 1)
+
+
+# ---------------------------------------------------------------------------
+# Cost threshold
+# ---------------------------------------------------------------------------
+
+class TestCostThreshold(unittest.TestCase):
+    def test_no_violation_below_threshold(self):
+        config = _default_config(max_cost_dollars=100.0)
+        state = WatchState()
+        event = _make_event(EventType.ASSISTANT_RESPONSE, 0.0, text="hello")
+        violations = check_event(event, config, state)
+        self.assertEqual(violations, [])
+
+    def test_violation_when_cost_exceeds_threshold(self):
+        config = _default_config(max_cost_dollars=0.0)
+        state = WatchState()
+        # Force cost above threshold by setting it directly
+        state.estimated_cost = 0.01
+        event = _make_event(EventType.ASSISTANT_RESPONSE, 0.0, text="x" * 10000)
+        violations = check_event(event, config, state)
+        self.assertTrue(any("CostWatcher" in v for v in violations))
+
+
+# ---------------------------------------------------------------------------
+# Duration limit
+# ---------------------------------------------------------------------------
+
+class TestDurationLimit(unittest.TestCase):
+    def test_no_violation_within_limit(self):
+        config = _default_config(max_duration_seconds=3600.0)
+        state = WatchState(start_time=time.time())
+        event = _make_event(EventType.TOOL_CALL, 0.0, tool_name="Bash",
+                            arguments={"command": "ls"})
+        violations = check_event(event, config, state)
+        self.assertEqual(violations, [])
+
+    def test_violation_when_duration_exceeded(self):
+        config = _default_config(max_duration_seconds=0.0)
+        state = WatchState(start_time=time.time() - 10)  # 10s ago
+        event = _make_event(EventType.USER_PROMPT, 0.0, prompt="hi")
+        violations = check_event(event, config, state)
+        self.assertTrue(any("DurationWatcher" in v for v in violations))
+
+
+# ---------------------------------------------------------------------------
+# Loop detection
+# ---------------------------------------------------------------------------
+
+class TestLoopDetection(unittest.TestCase):
+    def test_no_loop_with_varied_events(self):
+        recent = deque(["a", "b", "c", "d", "e", "f"], maxlen=30)
+        result = _detect_loop(recent, seq_len=3, max_repeats=3)
+        self.assertIsNone(result)
+
+    def test_detects_repeating_sequence(self):
+        # Sequence [a, b, c] repeated 3 times
+        seq = ["a", "b", "c"] * 3
+        recent = deque(seq, maxlen=30)
+        result = _detect_loop(recent, seq_len=3, max_repeats=3)
+        self.assertIsNotNone(result)
+        self.assertIn("loop", result)
+
+    def test_no_loop_below_repeat_threshold(self):
+        seq = ["a", "b", "c"] * 2
+        recent = deque(seq, maxlen=30)
+        result = _detect_loop(recent, seq_len=3, max_repeats=3)
+        self.assertIsNone(result)
+
+    def test_insufficient_events_no_loop(self):
+        recent = deque(["a", "b"], maxlen=30)
+        result = _detect_loop(recent, seq_len=3, max_repeats=3)
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# Alert actions
+# ---------------------------------------------------------------------------
+
+class TestAlertTerminal(unittest.TestCase):
+    def test_writes_to_stderr(self):
+        buf = io.StringIO()
+        _alert_terminal("test alert", out=buf)
+        self.assertIn("test alert", buf.getvalue())
+        self.assertIn("[watch]", buf.getvalue())
+
+
+class TestAlertFile(unittest.TestCase):
+    def test_writes_to_log_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = os.path.join(tmp, "alerts.log")
+            _alert_file("file alert message", log_path=log_path)
+            content = Path(log_path).read_text()
+            self.assertIn("file alert message", content)
+
+    def test_creates_parent_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = os.path.join(tmp, "subdir", "alerts.log")
+            _alert_file("msg", log_path=log_path)
+            self.assertTrue(Path(log_path).exists())
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestWatcherConfigLoad(unittest.TestCase):
+    def test_load_missing_file_returns_defaults(self):
+        config = WatcherConfig.load("/nonexistent/path/.agent-watch.json")
+        self.assertIsInstance(config, WatcherConfig)
+        self.assertEqual(config.max_retries, 5)
+
+    def test_load_valid_config(self):
+        data = {
+            "watchers": {
+                "retry": {"max": 2, "alert": "terminal"},
+                "cost": {"max_dollars": 5.0},
+                "duration": {"max_minutes": 10},
+            }
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            config = WatcherConfig.load(path)
+            self.assertEqual(config.max_retries, 2)
+            self.assertAlmostEqual(config.max_cost_dollars, 5.0)
+            self.assertAlmostEqual(config.max_duration_seconds, 600.0)
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Event key
+# ---------------------------------------------------------------------------
+
+class TestEventKey(unittest.TestCase):
+    def test_bash_event_key_includes_command(self):
+        event = _bash_event("pytest tests/")
+        key = _event_key(event)
+        self.assertIn("Bash", key)
+        self.assertIn("pytest", key)
+
+    def test_non_tool_event_key_is_event_type(self):
+        event = _make_event(EventType.USER_PROMPT, 0.0, prompt="hi")
+        key = _event_key(event)
+        self.assertEqual(key, "user_prompt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #8

## What

Adds `agent-strace watch` — real-time session monitoring that tails the active session's `events.ndjson` and fires alerts when configurable thresholds are exceeded.

## Usage

```bash
# Watch with defaults
agent-strace watch

# Custom thresholds
agent-strace watch --max-retries 3 --max-cost 5 --max-duration 600

# Kill the agent on violation
agent-strace watch --max-retries 3 --on-violation kill

# Config file
agent-strace watch --config .agent-watch.json
```

## Watchers

| Watcher | Trigger | Default |
|---------|---------|---------|
| RetryWatcher | Same command runs more than N times | 5 |
| CostWatcher | Estimated cost exceeds threshold | $10 |
| DurationWatcher | Session exceeds time limit | 30 minutes |
| LoopWatcher | Same sequence of events repeats N times | 3× |
| ScopeWatcher | File write denied by `.agent-scope.json` policy | any violation |

## Alert actions

- `terminal` — print warning to stderr (default)
- `file` — append to `.agent-traces/alerts.log`
- `webhook` — POST JSON to a URL (Slack, PagerDuty, etc.) via stdlib `urllib.request`
- `kill` — send SIGTERM to the agent process

## Config file (`.agent-watch.json`)

```json
{
  "watchers": {
    "retry": { "max": 3, "alert": "terminal" },
    "cost": { "max_dollars": 5.0 },
    "duration": { "max_minutes": 15 },
    "loop": { "sequence_length": 3, "max_repeats": 3 }
  },
  "webhook": {
    "url": "https://hooks.slack.com/services/..."
  }
}
```

## Implementation

- `src/agent_trace/watch.py` — watcher state machines, alert dispatcher, file tailer
- Each violation fires exactly once (deduped by key) to avoid alert spam
- Loop detection uses a sliding-window sequence comparison over a bounded deque
- Cost estimation reuses `cost.py` token estimation (`_event_tokens`, `_dollars`)
- Scope checking reuses `audit.py` policy loading

Zero new dependencies. 19 new tests covering retry detection, cost threshold, duration limit, loop detection, alert actions (terminal + file), and config loading.