### PR TITLE
feat: v0.13.0 — auto-generate .agent-scope.json from observed traces

### DIFF
--- a/src/agent_trace/policy.py
+++ b/src/agent_trace/policy.py
@@ -287,6 +287,10 @@ def cmd_policy(args: argparse.Namespace) -> int:
             return 1
         session_ids_raw = [s.session_id for s in all_sessions]
 
+    # Default: dry-run when no --output given
+    if not output_path and not dry_run:
+        dry_run = True
+
     # Resolve prefixes
     resolved: list[str] = []
     for sid in session_ids_raw:

--- a/src/agent_trace/policy.py
+++ b/src/agent_trace/policy.py
@@ -1,0 +1,312 @@
+"""Policy suggestion: auto-generate .agent-scope.json from observed traces.
+
+Analyses one or more sessions and produces a minimal allow-list policy that
+covers exactly the files read/written and commands run. The output is a valid
+.agent-scope.json that can be used directly with `agent-strace audit`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PolicySuggestion:
+    session_ids: list[str]
+    files_read: list[str]
+    files_written: list[str]
+    commands: list[str]
+    network_hosts: list[str]
+    # Collapsed glob patterns (e.g. src/**/*.py instead of individual files)
+    file_read_patterns: list[str]
+    file_write_patterns: list[str]
+    cmd_patterns: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Pattern collapsing helpers
+# ---------------------------------------------------------------------------
+
+_COMMON_DIRS = [
+    "src", "tests", "lib", "app", "pkg", "internal",
+    "components", "pages", "utils", "helpers",
+]
+
+
+def _collapse_paths(paths: list[str]) -> list[str]:
+    """Collapse a list of file paths into minimal glob patterns.
+
+    Groups files by directory prefix and emits ``dir/**`` when 3+ files share
+    the same top-level directory. Individual files are kept as-is otherwise.
+    """
+    if not paths:
+        return []
+
+    from collections import Counter
+    dir_counts: Counter = Counter()
+    for p in paths:
+        parts = Path(p).parts
+        if len(parts) > 1:
+            dir_counts[parts[0]] += 1
+
+    collapsed: list[str] = []
+    covered: set[str] = set()
+
+    for top_dir, count in dir_counts.items():
+        if count >= 3:
+            collapsed.append(f"{top_dir}/**")
+            covered.update(p for p in paths if Path(p).parts[0] == top_dir)
+
+    for p in paths:
+        if p not in covered:
+            collapsed.append(p)
+
+    return sorted(set(collapsed))
+
+
+def _collapse_commands(cmds: list[str]) -> list[str]:
+    """Collapse commands to their base executable (first token).
+
+    e.g. ``pytest tests/foo.py -x`` → ``pytest *``
+    Deduplicates by base command and emits ``<cmd> *`` patterns.
+    """
+    if not cmds:
+        return []
+
+    bases: dict[str, list[str]] = {}
+    for cmd in cmds:
+        base = cmd.strip().split()[0] if cmd.strip() else cmd
+        bases.setdefault(base, []).append(cmd)
+
+    patterns: list[str] = []
+    for base, variants in bases.items():
+        if len(variants) == 1 and variants[0] == base:
+            patterns.append(base)
+        else:
+            patterns.append(f"{base} *")
+
+    return sorted(patterns)
+
+
+# ---------------------------------------------------------------------------
+# Observation pass
+# ---------------------------------------------------------------------------
+
+def _extract_url_host(cmd: str) -> list[str]:
+    """Extract hostnames from URLs in a shell command."""
+    import re
+    hosts = []
+    for m in re.finditer(r"https?://([^/\s\"']+)", cmd):
+        host = m.group(1).split(":")[0]
+        hosts.append(host)
+    return hosts
+
+
+def observe_session(store: TraceStore, session_id: str) -> dict:
+    """Return raw observations from a single session."""
+    events = store.load_events(session_id)
+    files_read: list[str] = []
+    files_written: list[str] = []
+    commands: list[str] = []
+    network_hosts: list[str] = []
+
+    for event in events:
+        if event.event_type != EventType.TOOL_CALL:
+            continue
+        name = event.data.get("tool_name", "").lower()
+        args = event.data.get("arguments", {}) or {}
+
+        if name in ("read", "view", "grep", "glob"):
+            path = str(
+                args.get("file_path") or args.get("path") or args.get("pattern") or ""
+            ).strip()
+            if path and not path.startswith("/proc") and not path.startswith("/sys"):
+                files_read.append(path)
+
+        elif name in ("write", "edit", "create"):
+            path = str(args.get("file_path") or args.get("path") or "").strip()
+            if path:
+                files_written.append(path)
+
+        elif name == "bash":
+            cmd = str(args.get("command", "")).strip()
+            if cmd:
+                commands.append(cmd)
+                network_hosts.extend(_extract_url_host(cmd))
+
+    return {
+        "files_read": files_read,
+        "files_written": files_written,
+        "commands": commands,
+        "network_hosts": network_hosts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def suggest_policy(
+    store: TraceStore,
+    session_ids: list[str],
+) -> PolicySuggestion:
+    """Analyse *session_ids* and return a PolicySuggestion."""
+    all_reads: list[str] = []
+    all_writes: list[str] = []
+    all_cmds: list[str] = []
+    all_hosts: list[str] = []
+
+    for sid in session_ids:
+        obs = observe_session(store, sid)
+        all_reads.extend(obs["files_read"])
+        all_writes.extend(obs["files_written"])
+        all_cmds.extend(obs["commands"])
+        all_hosts.extend(obs["network_hosts"])
+
+    # Deduplicate preserving order
+    def _dedup(lst: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for x in lst:
+            if x not in seen:
+                seen.add(x)
+                out.append(x)
+        return out
+
+    reads = _dedup(all_reads)
+    writes = _dedup(all_writes)
+    cmds = _dedup(all_cmds)
+    hosts = _dedup(all_hosts)
+
+    return PolicySuggestion(
+        session_ids=session_ids,
+        files_read=reads,
+        files_written=writes,
+        commands=cmds,
+        network_hosts=hosts,
+        file_read_patterns=_collapse_paths(reads),
+        file_write_patterns=_collapse_paths(writes),
+        cmd_patterns=_collapse_commands(cmds),
+    )
+
+
+def render_policy_json(suggestion: PolicySuggestion) -> dict:
+    """Convert a PolicySuggestion to the .agent-scope.json dict format."""
+    policy: dict = {}
+
+    files: dict = {}
+    if suggestion.file_read_patterns:
+        files["read"] = {"allow": suggestion.file_read_patterns}
+    if suggestion.file_write_patterns:
+        files["write"] = {"allow": suggestion.file_write_patterns}
+    if files:
+        policy["files"] = files
+
+    if suggestion.cmd_patterns:
+        policy["commands"] = {"allow": suggestion.cmd_patterns}
+
+    if suggestion.network_hosts:
+        policy["network"] = {
+            "deny_all": True,
+            "allow": sorted(set(suggestion.network_hosts)),
+        }
+
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def format_suggestion(
+    suggestion: PolicySuggestion,
+    out: TextIO = sys.stdout,
+    dry_run: bool = False,
+) -> None:
+    w = out.write
+    n = len(suggestion.session_ids)
+    w(f"\nPolicy suggestion from {n} session{'s' if n != 1 else ''}:\n\n")
+
+    if suggestion.file_read_patterns:
+        w("  Files read (allow):\n")
+        for p in suggestion.file_read_patterns:
+            w(f"    {p}\n")
+        w("\n")
+
+    if suggestion.file_write_patterns:
+        w("  Files written (allow):\n")
+        for p in suggestion.file_write_patterns:
+            w(f"    {p}\n")
+        w("\n")
+
+    if suggestion.cmd_patterns:
+        w("  Commands (allow):\n")
+        for p in suggestion.cmd_patterns:
+            w(f"    {p}\n")
+        w("\n")
+
+    if suggestion.network_hosts:
+        w("  Network hosts (allow):\n")
+        for h in sorted(set(suggestion.network_hosts)):
+            w(f"    {h}\n")
+        w("\n")
+
+    if dry_run:
+        w("Generated policy (dry run):\n\n")
+        w(json.dumps(render_policy_json(suggestion), indent=2))
+        w("\n\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_policy(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+
+    session_ids_raw: list[str] = getattr(args, "session_ids", []) or []
+
+    # If no sessions specified, use all sessions
+    if not session_ids_raw:
+        all_sessions = store.list_sessions()
+        if not all_sessions:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+        session_ids_raw = [s.session_id for s in all_sessions]
+
+    # Resolve prefixes
+    resolved: list[str] = []
+    for sid in session_ids_raw:
+        full = store.find_session(sid)
+        if not full:
+            sys.stderr.write(f"Session not found: {sid}\n")
+            return 1
+        resolved.append(full)
+
+    suggestion = suggest_policy(store, resolved)
+
+    output_path = getattr(args, "output", None)
+    dry_run = getattr(args, "dry_run", False)
+
+    if dry_run or not output_path:
+        format_suggestion(suggestion, dry_run=True)
+        return 0
+
+    policy_dict = render_policy_json(suggestion)
+    out_path = Path(output_path)
+    out_path.write_text(json.dumps(policy_dict, indent=2) + "\n")
+    sys.stdout.write(f"Policy written to {out_path}\n")
+    return 0

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,151 @@
+"""Tests for policy suggestion (issue #19)."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.policy import (
+    _collapse_commands,
+    _collapse_paths,
+    observe_session,
+    render_policy_json,
+    suggest_policy,
+)
+from agent_trace.store import TraceStore
+
+
+def _make_store_with_session(events):
+    tmpdir = tempfile.mkdtemp()
+    store = TraceStore(tmpdir)
+    meta = SessionMeta(agent_name="test")
+    store.create_session(meta)
+    for e in events:
+        e.session_id = meta.session_id
+        store.append_event(meta.session_id, e)
+    return store, meta.session_id
+
+
+class TestCollapsePaths(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(_collapse_paths([]), [])
+
+    def test_single_file(self):
+        result = _collapse_paths(["src/foo.py"])
+        self.assertIn("src/foo.py", result)
+
+    def test_collapses_three_files_same_dir(self):
+        paths = ["src/a.py", "src/b.py", "src/c.py"]
+        result = _collapse_paths(paths)
+        self.assertIn("src/**", result)
+
+    def test_keeps_individual_files_different_dirs(self):
+        paths = ["src/a.py", "tests/b.py"]
+        result = _collapse_paths(paths)
+        self.assertIn("src/a.py", result)
+        self.assertIn("tests/b.py", result)
+
+
+class TestCollapseCommands(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(_collapse_commands([]), [])
+
+    def test_single_command(self):
+        result = _collapse_commands(["pytest"])
+        self.assertIn("pytest", result)
+
+    def test_collapses_variants(self):
+        cmds = ["pytest tests/foo.py", "pytest tests/bar.py -x"]
+        result = _collapse_commands(cmds)
+        self.assertIn("pytest *", result)
+
+    def test_different_bases_kept_separate(self):
+        cmds = ["git status", "npm install"]
+        result = _collapse_commands(cmds)
+        self.assertTrue(any("git" in r for r in result))
+        self.assertTrue(any("npm" in r for r in result))
+
+
+class TestObserveSession(unittest.TestCase):
+    def test_reads_files(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "read",
+                "arguments": {"file_path": "src/main.py"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        obs = observe_session(store, sid)
+        self.assertIn("src/main.py", obs["files_read"])
+
+    def test_writes_files(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "write",
+                "arguments": {"file_path": "output.txt"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        obs = observe_session(store, sid)
+        self.assertIn("output.txt", obs["files_written"])
+
+    def test_bash_commands(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "bash",
+                "arguments": {"command": "pytest tests/"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        obs = observe_session(store, sid)
+        self.assertIn("pytest tests/", obs["commands"])
+
+    def test_network_hosts_extracted(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "bash",
+                "arguments": {"command": "curl https://api.example.com/data"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        obs = observe_session(store, sid)
+        self.assertIn("api.example.com", obs["network_hosts"])
+
+
+class TestSuggestPolicy(unittest.TestCase):
+    def test_suggest_produces_report(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "read",
+                "arguments": {"file_path": "src/a.py"},
+            }),
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "write",
+                "arguments": {"file_path": "out.txt"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        suggestion = suggest_policy(store, [sid])
+        self.assertIn("src/a.py", suggestion.files_read)
+        self.assertIn("out.txt", suggestion.files_written)
+
+    def test_render_policy_json(self):
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, data={
+                "tool_name": "bash",
+                "arguments": {"command": "pytest"},
+            }),
+        ]
+        store, sid = _make_store_with_session(events)
+        suggestion = suggest_policy(store, [sid])
+        policy = render_policy_json(suggestion)
+        self.assertIn("commands", policy)
+        self.assertIn("allow", policy["commands"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #19

## What

Adds `policy.py` with `suggest_policy()` that analyses one or more sessions and produces a minimal allow-list `.agent-scope.json` covering exactly the files read/written, commands run, and network hosts observed.

## How it works

- Scans `tool_call` events for `read`/`write`/`bash` operations
- Collapses file paths to glob patterns (`src/**`) when 3+ files share a directory
- Collapses commands to base-executable patterns (`pytest *`)
- Extracts hostnames from URLs in bash commands

## CLI

```
agent-strace policy                          # analyse all sessions
agent-strace policy <session-id>...          # specific sessions
agent-strace policy --dry-run                # print without writing
agent-strace policy --output custom.json     # custom output path
```

## Tests

`tests/test_policy.py` — 12 tests covering path collapsing, command collapsing, observation, and policy rendering.