### PR TITLE
feat: v0.19.0 — OTLP span hierarchy and GenAI semantic conventions

### DIFF
--- a/src/agent_trace/otlp.py
+++ b/src/agent_trace/otlp.py
@@ -29,6 +29,21 @@ from .models import EventType, SessionMeta, TraceEvent
 from .store import TraceStore
 
 
+# ---------------------------------------------------------------------------
+# OTel semantic conventions for GenAI (opentelemetry-semantic-conventions 1.27+)
+# https://opentelemetry.io/docs/specs/semconv/gen-ai/
+# ---------------------------------------------------------------------------
+
+_SEMCONV_SYSTEM = "gen_ai.system"
+_SEMCONV_OP = "gen_ai.operation.name"
+_SEMCONV_MODEL = "gen_ai.request.model"
+_SEMCONV_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+_SEMCONV_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+_SEMCONV_TOOL_NAME = "gen_ai.tool.name"
+_SEMCONV_TOOL_CALL_ID = "gen_ai.tool.call.id"
+_SEMCONV_FINISH_REASON = "gen_ai.response.finish_reasons"
+
+
 def _to_trace_id(session_id: str) -> str:
     """Convert session ID to a 32-hex-char trace ID."""
     h = hashlib.sha256(session_id.encode()).hexdigest()
@@ -87,25 +102,50 @@ def session_to_otlp(
     meta: SessionMeta,
     events: list[TraceEvent],
     service_name: str = "agent-trace",
+    parent_span_id: str = "",
+    parent_trace_id: str = "",
 ) -> dict:
     """Convert an agent-trace session to OTLP JSON trace format.
 
     Returns the full ExportTraceServiceRequest body ready to POST.
+
+    Args:
+        parent_span_id: When set, the root span is linked as a child of this
+            span (used for subagent hierarchy).
+        parent_trace_id: When set, the root span shares this trace ID so all
+            subagent spans appear in the same trace in the backend.
     """
-    trace_id = _to_trace_id(meta.session_id)
+    # Use parent trace ID for subagents so they appear in the same trace
+    trace_id = parent_trace_id if parent_trace_id else _to_trace_id(meta.session_id)
 
     # Root span covers the entire session
     root_span_id = _to_span_id(f"root-{meta.session_id}")
     root_start = _ts_to_nanos(meta.started_at)
     root_end = _ts_to_nanos(meta.ended_at or (meta.started_at + (meta.total_duration_ms or 0) / 1000))
 
+    # Detect provider from agent name for semantic conventions
+    agent_lower = (meta.agent_name or "").lower()
+    if "claude" in agent_lower or "anthropic" in agent_lower:
+        gen_ai_system = "anthropic"
+    elif "gpt" in agent_lower or "openai" in agent_lower:
+        gen_ai_system = "openai"
+    elif "gemini" in agent_lower or "google" in agent_lower:
+        gen_ai_system = "google"
+    else:
+        gen_ai_system = "unknown"
+
     root_attrs = _make_attributes({
+        # Standard OTel resource attributes
         "agent.name": meta.agent_name or "unknown",
         "agent.command": meta.command or "",
         "agent.session_id": meta.session_id,
         "agent.tool_calls": meta.tool_calls,
         "agent.llm_requests": meta.llm_requests,
         "agent.errors": meta.errors,
+        "agent.depth": meta.depth,
+        # GenAI semantic conventions
+        _SEMCONV_SYSTEM: gen_ai_system,
+        _SEMCONV_OP: "agent.session",
     })
 
     # Collect span events (user prompts, assistant responses, decisions)
@@ -156,7 +196,11 @@ def session_to_otlp(
             span_start = call_event.timestamp if call_event else event.timestamp
             duration_ns = _duration_to_nanos(event.duration_ms)
 
-            span_attrs = {"tool.name": tool_name}
+            span_attrs = {
+                _SEMCONV_TOOL_NAME: tool_name,
+                _SEMCONV_OP: "tool.call",
+                _SEMCONV_TOOL_CALL_ID: (call_event.event_id if call_event else event.event_id),
+            }
             if call_event:
                 args = call_event.data.get("arguments", {})
                 if args:
@@ -171,8 +215,8 @@ def session_to_otlp(
                 "traceId": trace_id,
                 "spanId": _to_span_id(call_event.event_id if call_event else event.event_id),
                 "parentSpanId": root_span_id,
-                "name": tool_name,
-                "kind": 1,  # SPAN_KIND_INTERNAL
+                "name": f"tool/{tool_name}",
+                "kind": 3,  # SPAN_KIND_CLIENT
                 "startTimeUnixNano": _ts_to_nanos(span_start),
                 "endTimeUnixNano": _ts_to_nanos(span_start + duration_ns / 1_000_000_000),
                 "attributes": _make_attributes(span_attrs),
@@ -214,12 +258,25 @@ def session_to_otlp(
                 })],
             })
 
-        elif event.event_type in (EventType.LLM_REQUEST, EventType.LLM_RESPONSE):
-            root_events.append(_make_event(
-                event.event_type.value,
-                event.timestamp,
-                event.data,
-            ))
+        elif event.event_type == EventType.LLM_REQUEST:
+            llm_attrs: dict = {_SEMCONV_OP: "chat"}
+            model = event.data.get("model", "")
+            if model:
+                llm_attrs[_SEMCONV_MODEL] = model
+            inp_tok = event.data.get("input_tokens", 0)
+            if inp_tok:
+                llm_attrs[_SEMCONV_INPUT_TOKENS] = inp_tok
+            root_events.append(_make_event("gen_ai.system.message", event.timestamp, llm_attrs))
+
+        elif event.event_type == EventType.LLM_RESPONSE:
+            llm_attrs = {_SEMCONV_OP: "chat"}
+            out_tok = event.data.get("output_tokens", 0)
+            if out_tok:
+                llm_attrs[_SEMCONV_OUTPUT_TOKENS] = out_tok
+            finish = event.data.get("stop_reason", event.data.get("finish_reason", ""))
+            if finish:
+                llm_attrs[_SEMCONV_FINISH_REASON] = finish
+            root_events.append(_make_event("gen_ai.assistant.message", event.timestamp, llm_attrs))
 
     # Emit any unmatched tool_calls as spans (no result received)
     for call_event in pending_calls.values():
@@ -240,7 +297,7 @@ def session_to_otlp(
         })
 
     # Build root span
-    root_span = {
+    root_span: dict = {
         "traceId": trace_id,
         "spanId": root_span_id,
         "name": f"agent-session ({meta.agent_name or 'agent'})",
@@ -251,6 +308,9 @@ def session_to_otlp(
         "events": root_events,
         "status": {"code": 2 if meta.errors > 0 else 1},
     }
+    # Link to parent span for subagent hierarchy
+    if parent_span_id:
+        root_span["parentSpanId"] = parent_span_id
 
     all_spans = [root_span] + child_spans
 
@@ -267,6 +327,65 @@ def session_to_otlp(
                 "scope": {
                     "name": "agent-trace",
                 },
+                "spans": all_spans,
+            }],
+        }],
+    }
+
+
+def tree_to_otlp(
+    store: TraceStore,
+    root_session_id: str,
+    service_name: str = "agent-trace",
+) -> dict:
+    """Export a full subagent tree as a single OTLP trace.
+
+    All sessions in the tree share the same trace_id. Each subagent session's
+    root span is parented to the tool_call span that spawned it.
+    """
+    from .subagent import build_tree, SessionNode
+
+    tree = build_tree(store, root_session_id)
+    root_trace_id = _to_trace_id(root_session_id)
+    all_spans: list[dict] = []
+
+    def _collect(node: SessionNode, parent_span_id: str = "") -> None:
+        meta = node.meta
+        events = node.events
+        payload = session_to_otlp(
+            meta, events, service_name,
+            parent_span_id=parent_span_id,
+            parent_trace_id=root_trace_id,
+        )
+        spans = payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
+        all_spans.extend(spans)
+
+        # The root span of this session is the first span
+        session_root_span_id = _to_span_id(f"root-{meta.session_id}")
+
+        for child in node.children:
+            # Parent span for child = the tool_call span that spawned it
+            spawning_span_id = (
+                _to_span_id(child.meta.parent_event_id)
+                if child.meta.parent_event_id
+                else session_root_span_id
+            )
+            _collect(child, parent_span_id=spawning_span_id)
+
+    _collect(tree)
+
+    root_meta = store.load_meta(root_session_id)
+    return {
+        "resourceSpans": [{
+            "resource": {
+                "attributes": _make_attributes({
+                    "service.name": service_name,
+                    "service.version": "agent-trace",
+                    "agent.session_id": root_session_id,
+                }),
+            },
+            "scopeSpans": [{
+                "scope": {"name": "agent-trace"},
                 "spans": all_spans,
             }],
         }],

--- a/tests/test_otlp.py
+++ b/tests/test_otlp.py
@@ -158,7 +158,7 @@ class TestSessionToOTLP(unittest.TestCase):
         child_spans = [s for s in spans[1:] if s.get("parentSpanId") == root_id]
         self.assertGreater(len(child_spans), 0)
 
-        bash_span = [s for s in child_spans if s["name"] == "Bash"]
+        bash_span = [s for s in child_spans if "bash" in s["name"].lower()]
         self.assertEqual(len(bash_span), 1)
 
     def test_error_span_has_error_status(self):
@@ -221,7 +221,7 @@ class TestSessionToOTLP(unittest.TestCase):
         payload = session_to_otlp(meta, events)
         spans = payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
 
-        bash_span = [s for s in spans if s["name"] == "Bash"][0]
+        bash_span = [s for s in spans if "bash" in s["name"].lower()][0]
         attr_keys = [a["key"] for a in bash_span["attributes"]]
         self.assertIn("tool.input.command", attr_keys)
 
@@ -230,7 +230,7 @@ class TestSessionToOTLP(unittest.TestCase):
         payload = session_to_otlp(meta, events)
         spans = payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
 
-        bash_span = [s for s in spans if s["name"] == "Bash"][0]
+        bash_span = [s for s in spans if "bash" in s["name"].lower()][0]
         start = int(bash_span["startTimeUnixNano"])
         end = int(bash_span["endTimeUnixNano"])
         self.assertGreater(end, start)

--- a/tests/test_otlp_improvements.py
+++ b/tests/test_otlp_improvements.py
@@ -1,0 +1,125 @@
+"""Tests for OTLP improvements: span hierarchy and semantic conventions (issue #25)."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.otlp import (
+    _SEMCONV_SYSTEM,
+    _SEMCONV_TOOL_NAME,
+    _SEMCONV_OP,
+    session_to_otlp,
+    tree_to_otlp,
+)
+from agent_trace.store import TraceStore
+
+
+def _make_session(store, agent_name="claude-code", events=None):
+    meta = SessionMeta(agent_name=agent_name)
+    store.create_session(meta)
+    for e in (events or []):
+        e.session_id = meta.session_id
+        store.append_event(meta.session_id, e)
+    return meta
+
+
+def _get_spans(payload):
+    return payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
+
+
+def _attr_value(attrs, key):
+    for a in attrs:
+        if a["key"] == key:
+            v = a["value"]
+            return v.get("stringValue") or v.get("intValue") or v.get("boolValue")
+    return None
+
+
+class TestSessionToOtlpSemanticConventions(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_gen_ai_system_anthropic(self):
+        meta = _make_session(self.store, agent_name="claude-code")
+        payload = session_to_otlp(meta, [])
+        spans = _get_spans(payload)
+        root = spans[0]
+        system = _attr_value(root["attributes"], _SEMCONV_SYSTEM)
+        self.assertEqual(system, "anthropic")
+
+    def test_gen_ai_system_openai(self):
+        meta = _make_session(self.store, agent_name="gpt-4o-agent")
+        payload = session_to_otlp(meta, [])
+        spans = _get_spans(payload)
+        system = _attr_value(spans[0]["attributes"], _SEMCONV_SYSTEM)
+        self.assertEqual(system, "openai")
+
+    def test_gen_ai_system_unknown(self):
+        meta = _make_session(self.store, agent_name="my-custom-agent")
+        payload = session_to_otlp(meta, [])
+        spans = _get_spans(payload)
+        system = _attr_value(spans[0]["attributes"], _SEMCONV_SYSTEM)
+        self.assertEqual(system, "unknown")
+
+    def test_tool_span_uses_semconv_tool_name(self):
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "bash", "arguments": {"command": "ls"}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            parent_id=call.event_id,
+            data={"tool_name": "bash", "result": "file.txt"},
+        )
+        meta = _make_session(self.store, events=[call, result])
+        payload = session_to_otlp(meta, [call, result])
+        spans = _get_spans(payload)
+        tool_spans = [s for s in spans if s["name"].startswith("tool/")]
+        self.assertTrue(len(tool_spans) > 0)
+        tool_name = _attr_value(tool_spans[0]["attributes"], _SEMCONV_TOOL_NAME)
+        self.assertEqual(tool_name, "bash")
+
+    def test_tool_span_kind_is_client(self):
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "read", "arguments": {}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            parent_id=call.event_id,
+            data={"tool_name": "read", "result": "content"},
+        )
+        meta = _make_session(self.store, events=[call, result])
+        payload = session_to_otlp(meta, [call, result])
+        spans = _get_spans(payload)
+        tool_spans = [s for s in spans if s["name"].startswith("tool/")]
+        self.assertTrue(len(tool_spans) > 0)
+        self.assertEqual(tool_spans[0]["kind"], 3)  # SPAN_KIND_CLIENT
+
+    def test_parent_span_id_set_for_subagent(self):
+        meta = _make_session(self.store)
+        payload = session_to_otlp(
+            meta, [],
+            parent_span_id="abcdef1234567890",
+            parent_trace_id="a" * 32,
+        )
+        spans = _get_spans(payload)
+        root = spans[0]
+        self.assertEqual(root.get("parentSpanId"), "abcdef1234567890")
+        self.assertEqual(root["traceId"], "a" * 32)
+
+    def test_no_parent_span_id_for_root(self):
+        meta = _make_session(self.store)
+        payload = session_to_otlp(meta, [])
+        spans = _get_spans(payload)
+        root = spans[0]
+        self.assertNotIn("parentSpanId", root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #25

## What

Brings the OTLP exporter in line with the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) and adds full subagent span hierarchy support.

## Semantic conventions

| Attribute | Value |
|---|---|
| `gen_ai.system` | `anthropic` / `openai` / `google` / `unknown` |
| `gen_ai.operation.name` | `agent.session` (root), `tool.call` (tool spans), `chat` (LLM events) |
| `gen_ai.tool.name` | tool name on tool spans |
| `gen_ai.tool.call.id` | event_id of the originating tool_call |
| `gen_ai.usage.input_tokens` | from LLM_REQUEST events |
| `gen_ai.usage.output_tokens` | from LLM_RESPONSE events |
| `gen_ai.response.finish_reasons` | stop_reason / finish_reason |

Tool spans renamed from `"Bash"` → `"tool/bash"` and kind changed to `SPAN_KIND_CLIENT` (3).

## Subagent hierarchy

- `session_to_otlp()` accepts `parent_span_id` and `parent_trace_id` — child sessions share the root trace ID so all spans appear in one trace in the backend
- New `tree_to_otlp()` exports a full subagent tree as a single OTLP trace, linking each child session's root span to the tool_call span that spawned it

## Tests

`tests/test_otlp_improvements.py` — 6 new tests. Existing `test_otlp.py` updated for renamed span names.