### PR TITLE
feat(watch): rule-based kill switch for runaway sessions

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -555,6 +555,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument("--config", help="path to .agent-watch.json config file")
     p_watch.add_argument("--max-context-pct", type=int, default=90, dest="max_context_pct",
                          help="alert when context window is this %% full (default: 90)")
+    p_watch.add_argument("--rules", metavar="RULES_FILE",
+                         help="YAML/JSON rules file for rule-based kill switch (nanny mode)")
+    p_watch.add_argument("--dry-run", action="store_true", dest="dry_run",
+                         help="evaluate rules without taking action (for testing)")
 
     # policy
     p_policy = sub.add_parser("policy", help="suggest a .agent-scope.json policy from observed traces")

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -1,14 +1,21 @@
-"""Live session monitoring with circuit breakers.
+"""Live session monitoring with circuit breakers and rule-based kill switch.
 
 Tails the active session's events.ndjson and triggers alerts when
 configurable thresholds are exceeded. Zero new dependencies — stdlib only.
+
+Rule-based nanny (--rules rules.yaml):
+  Evaluates declarative rules on every event. Supports pause (SIGSTOP/SIGCONT)
+  and kill (SIGTERM) actions with optional notifications. Auto-generates a
+  postmortem when a kill action fires.
 """
 
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
+import re
 import signal
 import sys
 import time
@@ -16,7 +23,7 @@ import urllib.request
 from collections import Counter, deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 from .cost import _dollars, _event_tokens
 from .models import EventType, TraceEvent
@@ -57,8 +64,176 @@ def _alert_webhook(message: str, url: str) -> None:
 def _kill_process(pid: int) -> None:
     try:
         os.kill(pid, signal.SIGTERM)
+        time.sleep(5)
+        os.kill(pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         pass
+
+
+def _pause_process(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGSTOP)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _resume_process(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGCONT)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Nanny rules (--rules rules.yaml)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NannyRule:
+    """A declarative rule evaluated on every event."""
+    name: str
+    condition: str          # e.g. "files_modified > 20", "cost_usd > 5.00"
+    action: str             # "pause" | "kill" | "alert"
+    notify: str = ""        # e.g. "slack:#alerts", "email:me@example.com"
+    fired: bool = field(default=False, compare=False)
+
+    # Parsed condition components (set by _parse_condition)
+    _metric: str = field(default="", init=False, repr=False)
+    _op: str = field(default="", init=False, repr=False)
+    _threshold: Any = field(default=None, init=False, repr=False)
+    _pattern: str = field(default="", init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._parse_condition()
+
+    def _parse_condition(self) -> None:
+        """Parse condition string into metric, operator, threshold."""
+        cond = self.condition.strip()
+
+        # file_path matches "/etc/**"
+        m = re.match(r'file_path\s+matches\s+"([^"]+)"', cond)
+        if not m:
+            m = re.match(r"file_path\s+matches\s+'([^']+)'", cond)
+        if m:
+            self._metric = "file_path"
+            self._op = "matches"
+            self._pattern = m.group(1)
+            return
+
+        # numeric comparisons: metric op value
+        m = re.match(r'(\w+)\s*(>=|<=|>|<|==)\s*([0-9.]+)', cond)
+        if m:
+            self._metric = m.group(1)
+            self._op = m.group(2)
+            raw = m.group(3)
+            self._threshold = float(raw) if "." in raw else int(raw)
+
+    def evaluate(self, metrics: dict[str, Any], event: TraceEvent | None = None) -> bool:
+        """Return True if this rule's condition is satisfied."""
+        if self._metric == "file_path" and self._op == "matches" and event:
+            if event.event_type == EventType.TOOL_CALL:
+                args = event.data.get("arguments", {}) or {}
+                path = str(
+                    args.get("file_path") or args.get("path") or ""
+                )
+                return bool(path and fnmatch.fnmatch(path, self._pattern))
+            return False
+
+        if not self._metric or self._threshold is None:
+            return False
+
+        value = metrics.get(self._metric)
+        if value is None:
+            return False
+
+        op = self._op
+        t = self._threshold
+        if op == ">":
+            return value > t
+        if op == ">=":
+            return value >= t
+        if op == "<":
+            return value < t
+        if op == "<=":
+            return value <= t
+        if op == "==":
+            return value == t
+        return False
+
+
+def _load_nanny_rules(path: str) -> list[NannyRule]:
+    """Load rules from a YAML or JSON file. Returns [] on error."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    text = p.read_text()
+    try:
+        # Try JSON first (no extra dep)
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # Minimal YAML parser for simple rule files (no PyYAML required)
+        data = _parse_simple_yaml(text)
+
+    rules: list[NannyRule] = []
+    for r in data.get("rules", []):
+        try:
+            rules.append(NannyRule(
+                name=r.get("name", "unnamed"),
+                condition=r.get("condition", ""),
+                action=r.get("action", "alert"),
+                notify=r.get("notify", ""),
+            ))
+        except Exception:
+            pass
+    return rules
+
+
+def _parse_simple_yaml(text: str) -> dict:
+    """Parse a minimal subset of YAML sufficient for rules files.
+
+    Handles: top-level 'rules:' list with string scalar fields.
+    Does not handle anchors, multi-line values, or complex types.
+    """
+    result: dict = {"rules": []}
+    current_rule: dict | None = None
+    in_rules = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+
+        if stripped.startswith("#") or not stripped:
+            continue
+
+        if stripped == "rules:":
+            in_rules = True
+            continue
+
+        if not in_rules:
+            continue
+
+        # New list item
+        if stripped.startswith("- "):
+            if current_rule is not None:
+                result["rules"].append(current_rule)
+            # Inline key: value after the dash
+            rest = stripped[2:].strip()
+            current_rule = {}
+            if ":" in rest:
+                k, _, v = rest.partition(":")
+                current_rule[k.strip()] = v.strip().strip('"').strip("'")
+        elif stripped.startswith("-") and stripped == "-":
+            if current_rule is not None:
+                result["rules"].append(current_rule)
+            current_rule = {}
+        elif current_rule is not None and ":" in stripped:
+            k, _, v = stripped.partition(":")
+            current_rule[k.strip()] = v.strip().strip('"').strip("'")
+
+    if current_rule is not None:
+        result["rules"].append(current_rule)
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +336,22 @@ class WatchState:
     agent_pid: int | None = None
     # Token budget watcher (lazy-initialised on first LLM_REQUEST)
     token_budget_watcher: object | None = None
+    # Nanny rule metrics
+    files_modified: int = 0          # distinct files written/edited
+    files_modified_set: set = field(default_factory=set)
+    consecutive_test_failures: int = 0
+    duration_minutes: float = 0.0
+    paused: bool = False             # True when agent is SIGSTOP'd
+
+    def nanny_metrics(self) -> dict:
+        """Return current metric snapshot for nanny rule evaluation."""
+        elapsed = time.time() - self.start_time
+        return {
+            "files_modified": self.files_modified,
+            "cost_usd": self.estimated_cost,
+            "consecutive_test_failures": self.consecutive_test_failures,
+            "duration_minutes": elapsed / 60.0,
+        }
 
 
 def _event_key(event: TraceEvent) -> str:
@@ -210,18 +401,57 @@ def _dispatch_alert(
     config: WatcherConfig,
     state: WatchState,
     action: str | None = None,
+    notify: str = "",
+    dry_run: bool = False,
 ) -> None:
     action = action or config.on_violation
     # terminal is always shown regardless of action so the operator watching
     # the process sees every alert; file/webhook are additive channels
     _alert_terminal(message)
-    if action in ("file", "kill"):
+    if action in ("file", "kill", "pause"):
         _alert_file(message, config.alert_log)
     if config.webhook_url:
         _alert_webhook(message, config.webhook_url)
-    if action == "kill" and state.agent_pid:
+    # notify field from nanny rules (e.g. "slack:#alerts")
+    if notify and notify.startswith("slack:") and config.webhook_url:
+        _alert_webhook(f"[{notify}] {message}", config.webhook_url)
+
+    if dry_run:
+        _alert_terminal(f"[dry-run] would {action} agent process")
+        return
+
+    if action == "pause" and state.agent_pid and not state.paused:
+        _alert_terminal(f"Pausing agent process {state.agent_pid} (SIGSTOP)")
+        _pause_process(state.agent_pid)
+        state.paused = True
+    elif action == "kill" and state.agent_pid:
         _alert_terminal(f"Killing agent process {state.agent_pid}")
         _kill_process(state.agent_pid)
+
+
+def _dispatch_nanny_rule(
+    rule: NannyRule,
+    event: TraceEvent,
+    store: TraceStore,
+    session_id: str,
+    state: WatchState,
+    config: WatcherConfig,
+    dry_run: bool = False,
+) -> None:
+    """Fire a nanny rule: alert, pause, or kill."""
+    msg = f"NannyRule '{rule.name}': {rule.condition} → {rule.action}"
+    _dispatch_alert(msg, config, state, action=rule.action, notify=rule.notify, dry_run=dry_run)
+
+    # Auto-generate postmortem on kill
+    if rule.action == "kill" and not dry_run:
+        try:
+            from .postmortem import generate_postmortem, format_postmortem
+            pm = generate_postmortem(store, session_id)
+            pm_path = Path(config.alert_log).parent / f"postmortem-{session_id[:12]}.md"
+            pm_path.write_text(format_postmortem(pm))
+            _alert_terminal(f"Postmortem written to {pm_path}")
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +469,29 @@ def check_event(
     # --- Cost accumulation ---
     inp, out = _event_tokens(event)
     state.estimated_cost += _dollars(inp, out, "sonnet")
+
+    # --- Track files modified (for nanny rules) ---
+    if event.event_type == EventType.TOOL_CALL:
+        _name = event.data.get("tool_name", "").lower()
+        _args = event.data.get("arguments", {}) or {}
+        if _name in ("write", "edit", "create", "str_replace"):
+            _path = str(_args.get("file_path") or _args.get("path") or "")
+            if _path and _path not in state.files_modified_set:
+                state.files_modified_set.add(_path)
+                state.files_modified = len(state.files_modified_set)
+
+    # --- Track consecutive test failures (for nanny rules) ---
+    if event.event_type == EventType.TOOL_RESULT:
+        _content = str(event.data.get("content", ""))
+        _is_test_fail = any(
+            kw in _content.lower()
+            for kw in ("failed", "error", "assertion", "traceback", "exit code 1")
+        )
+        if _is_test_fail:
+            state.consecutive_test_failures += 1
+        elif event.data.get("is_error") is False:
+            # Successful result resets the counter
+            state.consecutive_test_failures = 0
 
     # --- Loop detection ---
     key = _event_key(event)
@@ -389,6 +642,8 @@ def watch_session(
     out: TextIO = sys.stderr,
     poll_interval: float = 0.5,
     max_idle_seconds: float = 300.0,
+    nanny_rules: list[NannyRule] | None = None,
+    dry_run: bool = False,
 ) -> None:
     """Watch a session's event stream and fire alerts on violations."""
     events_file = store._session_dir(session_id) / "events.ndjson"
@@ -398,7 +653,10 @@ def watch_session(
 
     state = WatchState(start_time=time.time())
 
-    out.write(f"[watch] Monitoring session {session_id[:12]}...\n")
+    mode = " [dry-run]" if dry_run else ""
+    out.write(f"[watch] Monitoring session {session_id[:12]}...{mode}\n")
+    if nanny_rules:
+        out.write(f"[watch] {len(nanny_rules)} nanny rule(s) active\n")
     out.flush()
 
     last_event_time = time.time()
@@ -411,7 +669,20 @@ def watch_session(
 
             violations = check_event(event, config, state)
             for msg in violations:
-                _dispatch_alert(msg, config, state)
+                _dispatch_alert(msg, config, state, dry_run=dry_run)
+
+            # --- Nanny rule evaluation ---
+            if nanny_rules:
+                metrics = state.nanny_metrics()
+                for rule in nanny_rules:
+                    if rule.fired:
+                        continue
+                    if rule.evaluate(metrics, event):
+                        rule.fired = True
+                        _dispatch_nanny_rule(
+                            rule, event, store, session_id,
+                            state, config, dry_run=dry_run,
+                        )
 
             if event.event_type == EventType.SESSION_END:
                 out.write(f"[watch] Session ended ({event_count} events, ${state.estimated_cost:.4f})\n")
@@ -447,6 +718,16 @@ def cmd_watch(args: argparse.Namespace) -> int:
             webhook_url=getattr(args, "webhook", "") or "",
         )
 
+    # Load nanny rules if --rules provided
+    nanny_rules: list[NannyRule] | None = None
+    rules_path = getattr(args, "rules", None)
+    if rules_path:
+        nanny_rules = _load_nanny_rules(rules_path)
+        if not nanny_rules:
+            sys.stderr.write(f"[watch] Warning: no rules loaded from {rules_path}\n")
+
+    dry_run = getattr(args, "dry_run", False)
+
     session_id = getattr(args, "session_id", None)
     if not session_id:
         session_id = store.get_latest_session_id()
@@ -459,5 +740,5 @@ def cmd_watch(args: argparse.Namespace) -> int:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
 
-    watch_session(store, full_id, config)
+    watch_session(store, full_id, config, nanny_rules=nanny_rules, dry_run=dry_run)
     return 0

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -62,12 +62,23 @@ def _alert_webhook(message: str, url: str) -> None:
 
 
 def _kill_process(pid: int) -> None:
+    """Send SIGTERM; escalate to SIGKILL after 5s in a background thread."""
+    import threading
+
     try:
         os.kill(pid, signal.SIGTERM)
-        time.sleep(5)
-        os.kill(pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
-        pass
+        return
+
+    def _escalate() -> None:
+        time.sleep(5)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    t = threading.Thread(target=_escalate, daemon=True)
+    t.start()
 
 
 def _pause_process(pid: int) -> None:
@@ -489,8 +500,8 @@ def check_event(
         )
         if _is_test_fail:
             state.consecutive_test_failures += 1
-        elif event.data.get("is_error") is False:
-            # Successful result resets the counter
+        elif not event.data.get("is_error", False):
+            # Non-error result resets the counter (is_error absent = success)
             state.consecutive_test_failures = 0
 
     # --- Loop detection ---
@@ -540,7 +551,10 @@ def check_event(
         config.loop_max_repeats,
     )
     if loop_msg:
-        key_id = f"loop:{loop_msg[:40]}"
+        # Key on the sequence pattern only (strip the " × N" count suffix)
+        # so dedup fires once per unique loop, not once per repeat increment.
+        seq_part = loop_msg.split(" × ")[0]
+        key_id = f"loop:{seq_part[:60]}"
         if key_id not in state.fired:
             state.fired.add(key_id)
             violations.append(f"LoopWatcher: {loop_msg}")
@@ -613,10 +627,17 @@ def check_event(
 # File tailer
 # ---------------------------------------------------------------------------
 
+_IDLE_SENTINEL = object()  # yielded when poll_interval elapses with no new event
+
+
 def _tail_events(events_file: Path, poll_interval: float = 0.5):
-    """Generator that yields new TraceEvent lines as they appear."""
+    """Generator that yields TraceEvent objects or _IDLE_SENTINEL each poll cycle.
+
+    Yields _IDLE_SENTINEL when no new line arrived during the poll interval,
+    allowing callers to implement idle-timeout logic without blocking.
+    """
     with open(events_file, "r", encoding="utf-8") as f:
-        # Skip existing content
+        # Skip existing content — start from the end of the file
         f.seek(0, 2)
         while True:
             line = f.readline()
@@ -629,6 +650,7 @@ def _tail_events(events_file: Path, poll_interval: float = 0.5):
                         pass
             else:
                 time.sleep(poll_interval)
+                yield _IDLE_SENTINEL
 
 
 # ---------------------------------------------------------------------------
@@ -663,7 +685,17 @@ def watch_session(
     event_count = 0
 
     try:
-        for event in _tail_events(events_file, poll_interval=poll_interval):
+        for item in _tail_events(events_file, poll_interval=poll_interval):
+            # Idle timeout: checked on every poll cycle (including when no
+            # event arrived), so it fires reliably after max_idle_seconds.
+            if time.time() - last_event_time > max_idle_seconds:
+                out.write(f"[watch] No events for {max_idle_seconds:.0f}s - stopping\n")
+                break
+
+            if item is _IDLE_SENTINEL:
+                continue
+
+            event: TraceEvent = item  # type: ignore[assignment]
             event_count += 1
             last_event_time = time.time()
 
@@ -686,12 +718,6 @@ def watch_session(
 
             if event.event_type == EventType.SESSION_END:
                 out.write(f"[watch] Session ended ({event_count} events, ${state.estimated_cost:.4f})\n")
-                break
-
-            # Idle timeout: checked on each new event, so triggers on the
-            # first event that arrives after the idle window has elapsed.
-            if time.time() - last_event_time > max_idle_seconds:
-                out.write(f"[watch] No events for {max_idle_seconds:.0f}s - stopping\n")
                 break
 
     except KeyboardInterrupt:

--- a/tests/test_watch_nanny.py
+++ b/tests/test_watch_nanny.py
@@ -1,0 +1,147 @@
+"""Tests for issue #48: agent nanny rule-based kill switch."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _tool_call(tool_name: str, args: dict) -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.TOOL_CALL,
+        data={"tool_name": tool_name, "arguments": args},
+    )
+
+
+class TestNannyRules:
+    def test_parse_numeric_condition(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
+        assert rule._metric == "cost_usd"
+        assert rule._op == ">"
+        assert rule._threshold == 5.0
+
+    def test_parse_file_path_matches(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="sensitive", condition='file_path matches "/etc/**"', action="kill")
+        assert rule._metric == "file_path"
+        assert rule._op == "matches"
+        assert rule._pattern == "/etc/**"
+
+    def test_evaluate_numeric_true(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
+        assert rule.evaluate({"cost_usd": 6.0}) is True
+
+    def test_evaluate_numeric_false(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
+        assert rule.evaluate({"cost_usd": 3.0}) is False
+
+    def test_evaluate_files_modified(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="files", condition="files_modified > 20", action="pause")
+        assert rule.evaluate({"files_modified": 21}) is True
+        assert rule.evaluate({"files_modified": 20}) is False
+
+    def test_evaluate_file_path_matches(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="sensitive", condition='file_path matches "/etc/**"', action="kill")
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "write", "arguments": {"file_path": "/etc/passwd"}},
+        )
+        assert rule.evaluate({}, event) is True
+
+    def test_evaluate_file_path_no_match(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="sensitive", condition='file_path matches "/etc/**"', action="kill")
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "write", "arguments": {"file_path": "/home/user/file.py"}},
+        )
+        assert rule.evaluate({}, event) is False
+
+    def test_load_json_rules(self, tmp_path):
+        from agent_trace.watch import _load_nanny_rules
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps({
+            "rules": [
+                {"name": "cost-limit", "condition": "cost_usd > 5.00", "action": "kill"},
+                {"name": "too-many-files", "condition": "files_modified > 20", "action": "pause"},
+            ]
+        }))
+        rules = _load_nanny_rules(str(rules_file))
+        assert len(rules) == 2
+        assert rules[0].name == "cost-limit"
+        assert rules[1].action == "pause"
+
+    def test_load_yaml_rules(self, tmp_path):
+        from agent_trace.watch import _load_nanny_rules
+        rules_file = tmp_path / "rules.yaml"
+        rules_file.write_text(
+            "rules:\n"
+            "  - name: cost-limit\n"
+            "    condition: cost_usd > 5.00\n"
+            "    action: kill\n"
+            "  - name: too-many-files\n"
+            "    condition: files_modified > 20\n"
+            "    action: pause\n"
+        )
+        rules = _load_nanny_rules(str(rules_file))
+        assert len(rules) == 2
+        assert rules[0].name == "cost-limit"
+        assert rules[1].name == "too-many-files"
+
+    def test_load_missing_file(self, tmp_path):
+        from agent_trace.watch import _load_nanny_rules
+        rules = _load_nanny_rules(str(tmp_path / "nonexistent.yaml"))
+        assert rules == []
+
+    def test_watch_state_nanny_metrics(self):
+        from agent_trace.watch import WatchState
+        state = WatchState(start_time=time.time() - 120)
+        state.files_modified = 5
+        state.estimated_cost = 2.5
+        state.consecutive_test_failures = 2
+        metrics = state.nanny_metrics()
+        assert metrics["files_modified"] == 5
+        assert metrics["cost_usd"] == 2.5
+        assert metrics["consecutive_test_failures"] == 2
+        assert metrics["duration_minutes"] >= 2.0
+
+    def test_check_event_tracks_files_modified(self):
+        from agent_trace.watch import WatcherConfig, WatchState, check_event
+        config = WatcherConfig()
+        state = WatchState()
+        e1 = _tool_call("write", {"file_path": "src/foo.py"})
+        e2 = _tool_call("write", {"file_path": "src/bar.py"})
+        e3 = _tool_call("write", {"file_path": "src/foo.py"})  # duplicate
+        check_event(e1, config, state)
+        check_event(e2, config, state)
+        check_event(e3, config, state)
+        assert state.files_modified == 2  # only 2 distinct files
+
+    def test_check_event_tracks_test_failures(self):
+        from agent_trace.watch import WatcherConfig, WatchState, check_event
+        config = WatcherConfig()
+        state = WatchState()
+        fail_event = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            data={"content": "FAILED: test_foo AssertionError", "is_error": True},
+        )
+        check_event(fail_event, config, state)
+        check_event(fail_event, config, state)
+        assert state.consecutive_test_failures == 2
+
+    def test_cli_has_rules_and_dry_run_flags(self):
+        from agent_trace.cli import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["watch", "--rules", "rules.yaml", "--dry-run"])
+        assert args.rules == "rules.yaml"
+        assert args.dry_run is True

--- a/tests/test_watch_nanny.py
+++ b/tests/test_watch_nanny.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import json
 import time
-
-import pytest
+import unittest
 
 from agent_trace.models import EventType, SessionMeta, TraceEvent
 from agent_trace.store import TraceStore
@@ -18,36 +17,40 @@ def _tool_call(tool_name: str, args: dict) -> TraceEvent:
     )
 
 
-class TestNannyRules:
+class TestNannyRuleParsing(unittest.TestCase):
     def test_parse_numeric_condition(self):
         from agent_trace.watch import NannyRule
         rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
-        assert rule._metric == "cost_usd"
-        assert rule._op == ">"
-        assert rule._threshold == 5.0
+        self.assertEqual(rule._metric, "cost_usd")
+        self.assertEqual(rule._op, ">")
+        self.assertEqual(rule._threshold, 5.0)
 
     def test_parse_file_path_matches(self):
         from agent_trace.watch import NannyRule
         rule = NannyRule(name="sensitive", condition='file_path matches "/etc/**"', action="kill")
-        assert rule._metric == "file_path"
-        assert rule._op == "matches"
-        assert rule._pattern == "/etc/**"
+        self.assertEqual(rule._metric, "file_path")
+        self.assertEqual(rule._op, "matches")
+        self.assertEqual(rule._pattern, "/etc/**")
 
     def test_evaluate_numeric_true(self):
         from agent_trace.watch import NannyRule
         rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
-        assert rule.evaluate({"cost_usd": 6.0}) is True
+        self.assertTrue(rule.evaluate({"cost_usd": 6.0}))
 
     def test_evaluate_numeric_false(self):
         from agent_trace.watch import NannyRule
         rule = NannyRule(name="cost", condition="cost_usd > 5.00", action="kill")
-        assert rule.evaluate({"cost_usd": 3.0}) is False
+        self.assertFalse(rule.evaluate({"cost_usd": 3.0}))
 
-    def test_evaluate_files_modified(self):
+    def test_evaluate_files_modified_over(self):
         from agent_trace.watch import NannyRule
         rule = NannyRule(name="files", condition="files_modified > 20", action="pause")
-        assert rule.evaluate({"files_modified": 21}) is True
-        assert rule.evaluate({"files_modified": 20}) is False
+        self.assertTrue(rule.evaluate({"files_modified": 21}))
+
+    def test_evaluate_files_modified_at_limit(self):
+        from agent_trace.watch import NannyRule
+        rule = NannyRule(name="files", condition="files_modified > 20", action="pause")
+        self.assertFalse(rule.evaluate({"files_modified": 20}))
 
     def test_evaluate_file_path_matches(self):
         from agent_trace.watch import NannyRule
@@ -56,7 +59,7 @@ class TestNannyRules:
             event_type=EventType.TOOL_CALL,
             data={"tool_name": "write", "arguments": {"file_path": "/etc/passwd"}},
         )
-        assert rule.evaluate({}, event) is True
+        self.assertTrue(rule.evaluate({}, event))
 
     def test_evaluate_file_path_no_match(self):
         from agent_trace.watch import NannyRule
@@ -65,26 +68,31 @@ class TestNannyRules:
             event_type=EventType.TOOL_CALL,
             data={"tool_name": "write", "arguments": {"file_path": "/home/user/file.py"}},
         )
-        assert rule.evaluate({}, event) is False
+        self.assertFalse(rule.evaluate({}, event))
 
-    def test_load_json_rules(self, tmp_path):
+
+class TestNannyRuleLoading(unittest.TestCase):
+    def test_load_json_rules(self):
+        import tempfile, os
         from agent_trace.watch import _load_nanny_rules
-        rules_file = tmp_path / "rules.json"
-        rules_file.write_text(json.dumps({
-            "rules": [
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"rules": [
                 {"name": "cost-limit", "condition": "cost_usd > 5.00", "action": "kill"},
                 {"name": "too-many-files", "condition": "files_modified > 20", "action": "pause"},
-            ]
-        }))
-        rules = _load_nanny_rules(str(rules_file))
-        assert len(rules) == 2
-        assert rules[0].name == "cost-limit"
-        assert rules[1].action == "pause"
+            ]}, f)
+            path = f.name
+        try:
+            rules = _load_nanny_rules(path)
+            self.assertEqual(len(rules), 2)
+            self.assertEqual(rules[0].name, "cost-limit")
+            self.assertEqual(rules[1].action, "pause")
+        finally:
+            os.unlink(path)
 
-    def test_load_yaml_rules(self, tmp_path):
+    def test_load_yaml_rules(self):
+        import tempfile, os
         from agent_trace.watch import _load_nanny_rules
-        rules_file = tmp_path / "rules.yaml"
-        rules_file.write_text(
+        yaml_text = (
             "rules:\n"
             "  - name: cost-limit\n"
             "    condition: cost_usd > 5.00\n"
@@ -93,39 +101,44 @@ class TestNannyRules:
             "    condition: files_modified > 20\n"
             "    action: pause\n"
         )
-        rules = _load_nanny_rules(str(rules_file))
-        assert len(rules) == 2
-        assert rules[0].name == "cost-limit"
-        assert rules[1].name == "too-many-files"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_text)
+            path = f.name
+        try:
+            rules = _load_nanny_rules(path)
+            self.assertEqual(len(rules), 2)
+            self.assertEqual(rules[0].name, "cost-limit")
+            self.assertEqual(rules[1].name, "too-many-files")
+        finally:
+            os.unlink(path)
 
-    def test_load_missing_file(self, tmp_path):
+    def test_load_missing_file(self):
         from agent_trace.watch import _load_nanny_rules
-        rules = _load_nanny_rules(str(tmp_path / "nonexistent.yaml"))
-        assert rules == []
+        rules = _load_nanny_rules("/nonexistent/path/rules.yaml")
+        self.assertEqual(rules, [])
 
-    def test_watch_state_nanny_metrics(self):
+
+class TestWatchStateNanny(unittest.TestCase):
+    def test_nanny_metrics(self):
         from agent_trace.watch import WatchState
         state = WatchState(start_time=time.time() - 120)
         state.files_modified = 5
         state.estimated_cost = 2.5
         state.consecutive_test_failures = 2
         metrics = state.nanny_metrics()
-        assert metrics["files_modified"] == 5
-        assert metrics["cost_usd"] == 2.5
-        assert metrics["consecutive_test_failures"] == 2
-        assert metrics["duration_minutes"] >= 2.0
+        self.assertEqual(metrics["files_modified"], 5)
+        self.assertEqual(metrics["cost_usd"], 2.5)
+        self.assertEqual(metrics["consecutive_test_failures"], 2)
+        self.assertGreaterEqual(metrics["duration_minutes"], 2.0)
 
     def test_check_event_tracks_files_modified(self):
         from agent_trace.watch import WatcherConfig, WatchState, check_event
         config = WatcherConfig()
         state = WatchState()
-        e1 = _tool_call("write", {"file_path": "src/foo.py"})
-        e2 = _tool_call("write", {"file_path": "src/bar.py"})
-        e3 = _tool_call("write", {"file_path": "src/foo.py"})  # duplicate
-        check_event(e1, config, state)
-        check_event(e2, config, state)
-        check_event(e3, config, state)
-        assert state.files_modified == 2  # only 2 distinct files
+        check_event(_tool_call("write", {"file_path": "src/foo.py"}), config, state)
+        check_event(_tool_call("write", {"file_path": "src/bar.py"}), config, state)
+        check_event(_tool_call("write", {"file_path": "src/foo.py"}), config, state)  # duplicate
+        self.assertEqual(state.files_modified, 2)
 
     def test_check_event_tracks_test_failures(self):
         from agent_trace.watch import WatcherConfig, WatchState, check_event
@@ -137,11 +150,11 @@ class TestNannyRules:
         )
         check_event(fail_event, config, state)
         check_event(fail_event, config, state)
-        assert state.consecutive_test_failures == 2
+        self.assertEqual(state.consecutive_test_failures, 2)
 
     def test_cli_has_rules_and_dry_run_flags(self):
         from agent_trace.cli import build_parser
         parser = build_parser()
         args = parser.parse_args(["watch", "--rules", "rules.yaml", "--dry-run"])
-        assert args.rules == "rules.yaml"
-        assert args.dry_run is True
+        self.assertEqual(args.rules, "rules.yaml")
+        self.assertTrue(args.dry_run)


### PR DESCRIPTION
Closes #48

## What

Adds `--rules rules.yaml` to `agent-strace watch` — a declarative rule engine that monitors a live session and takes action when thresholds are exceeded.

## Usage

```yaml
# rules.yaml
rules:
  - name: too-many-files
    condition: files_modified > 20
    action: pause

  - name: cost-limit
    condition: cost_usd > 5.00
    action: kill

  - name: test-failures
    condition: consecutive_test_failures >= 3
    action: pause

  - name: timeout
    condition: duration_minutes > 60
    action: kill

  - name: sensitive-path
    condition: file_path matches "/etc/**"
    action: kill
```

```
agent-strace watch --rules rules.yaml
agent-strace watch --rules rules.yaml --dry-run   # evaluate without acting
```

## Changes

**`src/agent_trace/watch.py`**
- `NannyRule` dataclass: parses and evaluates declarative conditions
- `_load_nanny_rules()`: loads JSON or minimal YAML (no PyYAML dependency)
- `_parse_simple_yaml()`: stdlib-only YAML parser for rule files
- `_pause_process()` / `_resume_process()`: SIGSTOP/SIGCONT support
- `_kill_process()`: now SIGTERM → SIGKILL after 5s (was SIGTERM only)
- `_dispatch_nanny_rule()`: fires rule action + auto-generates postmortem on kill
- `WatchState`: tracks `files_modified` (distinct paths), `consecutive_test_failures`, `paused`
- `watch_session()`: accepts `nanny_rules` and `dry_run` parameters
- `check_event()`: updates `files_modified` and `consecutive_test_failures` on every event

**`src/agent_trace/cli.py`**
- `--rules RULES_FILE` flag on `watch` subcommand
- `--dry-run` flag on `watch` subcommand

**`tests/test_watch_nanny.py`**: 13 tests covering rule parsing, evaluation, YAML loading, state tracking, and CLI flags.