### PR TITLE
feat: personal agent cost-efficiency curve

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -25,6 +25,7 @@ from .http_proxy import HTTPProxyServer
 from .annotate import cmd_annotate
 from .audit import cmd_audit
 from .cost import cmd_cost
+from .curve import cmd_curve
 from .dashboard import cmd_dashboard
 from .shadow_ai import cmd_audit_tools
 from .diff import cmd_diff
@@ -599,6 +600,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_at.add_argument("--approved", default="",
                       help="comma-separated list of approved tool names")
 
+    # curve (personal cost curve)
+    p_curve = sub.add_parser("curve", help="show your personal agent cost-efficiency curve by task type")
+    p_curve.add_argument("--min-sessions", type=int, default=20, dest="min_sessions",
+                         help="minimum sessions for meaningful analysis (default: 20)")
+    p_curve.add_argument("--export", choices=["csv"], default="",
+                         help="export results (csv)")
+
     # diff --semantic and --eval-config flags (extend existing diff parser)
     p_diff.add_argument("--semantic", action="store_true",
                         help="semantic outcome-level diff (files, cost, errors)")
@@ -650,6 +658,7 @@ def main() -> None:
         "annotate": cmd_annotate,
         "token-budget": cmd_token_budget,
         "audit-tools": cmd_audit_tools,
+        "curve": cmd_curve,
     }
 
     handler = handlers.get(args.command)

--- a/src/agent_trace/curve.py
+++ b/src/agent_trace/curve.py
@@ -1,0 +1,296 @@
+"""Personal cost curve: which task types are cost-efficient for you?
+
+Analyses stored session history and classifies sessions by task type using
+session titles and initial prompt text from meta.json. Compares your average
+cost per task type against community sweet-spot benchmarks.
+
+Usage:
+    agent-strace curve
+    agent-strace curve --min-sessions 10
+    agent-strace curve --export csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import sys
+from dataclasses import dataclass, field
+from typing import TextIO
+
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Task type classification
+# ---------------------------------------------------------------------------
+
+# Keyword patterns for classifying sessions by task type.
+# Each entry: (task_type_label, [keywords_in_title_or_prompt])
+TASK_CLASSIFIERS: list[tuple[str, list[str]]] = [
+    ("Unit test writing",   ["test", "unittest", "pytest", "spec", "coverage"]),
+    ("Code refactoring",    ["refactor", "cleanup", "clean up", "reorganize", "restructure"]),
+    ("Bug debugging",       ["debug", "fix", "bug", "error", "traceback", "exception", "crash"]),
+    ("Architecture",        ["architect", "design", "system design", "schema", "database design", "api design"]),
+    ("Boilerplate gen",     ["scaffold", "boilerplate", "template", "generate", "init", "setup", "create project"]),
+    ("Documentation",       ["doc", "readme", "comment", "docstring", "changelog"]),
+    ("Code review",         ["review", "pr", "pull request", "feedback", "lint"]),
+    ("Feature impl",        ["implement", "feature", "add", "build", "create", "develop"]),
+    ("Performance",         ["performance", "optimize", "speed", "latency", "profil"]),
+    ("Security",            ["security", "auth", "vulnerability", "cve", "injection", "xss"]),
+]
+
+DEFAULT_TASK_TYPE = "General / other"
+
+# Community sweet-spot benchmarks (dollars per task).
+# These are conservative estimates; users can override via --sweet-spot.
+SWEET_SPOTS: dict[str, float] = {
+    "Unit test writing":  0.12,
+    "Code refactoring":   0.45,
+    "Bug debugging":      0.80,
+    "Architecture":       1.20,
+    "Boilerplate gen":    0.08,
+    "Documentation":      0.15,
+    "Code review":        0.20,
+    "Feature impl":       0.60,
+    "Performance":        0.90,
+    "Security":           0.70,
+    DEFAULT_TASK_TYPE:    0.40,
+}
+
+
+def _classify_session(agent_name: str, command: str) -> str:
+    """Return the task type label for a session based on its name/command."""
+    text = (agent_name + " " + command).lower()
+    for task_type, keywords in TASK_CLASSIFIERS:
+        if any(kw in text for kw in keywords):
+            return task_type
+    return DEFAULT_TASK_TYPE
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TaskTypeStat:
+    task_type: str
+    session_count: int
+    avg_cost: float
+    sweet_spot: float
+    ratio: float          # avg_cost / sweet_spot
+    monthly_estimate: float   # avg_cost * sessions_per_month
+
+    @property
+    def verdict(self) -> str:
+        if self.ratio <= 1.1:
+            return "efficient"
+        if self.ratio <= 2.0:
+            return "over sweet spot"
+        return "do this yourself"
+
+    @property
+    def verdict_icon(self) -> str:
+        if self.ratio <= 1.1:
+            return "✅"
+        if self.ratio <= 2.0:
+            return "⚠️ "
+        return "❌"
+
+
+@dataclass
+class CurveReport:
+    session_count: int
+    days_analysed: int
+    stats: list[TaskTypeStat]
+    potential_monthly_savings: float
+    savings_breakdown: list[tuple[str, float]]   # (task_type, monthly_saving)
+    insufficient_data: bool = False
+    min_sessions: int = 20
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def analyse_curve(
+    store: TraceStore,
+    min_sessions: int = 20,
+    sessions_per_day: float = 8.0,
+) -> CurveReport:
+    """Build a CurveReport from all stored sessions."""
+    from .cost import estimate_cost
+
+    all_metas = store.list_sessions()
+    if not all_metas:
+        return CurveReport(
+            session_count=0,
+            days_analysed=0,
+            stats=[],
+            potential_monthly_savings=0.0,
+            savings_breakdown=[],
+            insufficient_data=True,
+            min_sessions=min_sessions,
+        )
+
+    # Collect per-session data
+    type_costs: dict[str, list[float]] = {}
+    earliest_ts: float | None = None
+    latest_ts: float | None = None
+
+    for meta in all_metas:
+        sid = meta.session_id
+        task_type = _classify_session(meta.agent_name, meta.command)
+
+        try:
+            cost = estimate_cost(store, sid).total_cost
+        except Exception:
+            cost = 0.0
+
+        type_costs.setdefault(task_type, []).append(cost)
+
+        ts = meta.started_at
+        if earliest_ts is None or ts < earliest_ts:
+            earliest_ts = ts
+        if latest_ts is None or ts > latest_ts:
+            latest_ts = ts
+
+    total_sessions = sum(len(v) for v in type_costs.values())
+    if total_sessions == 0:
+        return CurveReport(
+            session_count=0,
+            days_analysed=0,
+            stats=[],
+            potential_monthly_savings=0.0,
+            savings_breakdown=[],
+            insufficient_data=True,
+            min_sessions=min_sessions,
+        )
+    days = max(1, int((latest_ts or 0) - (earliest_ts or 0)) // 86400) if earliest_ts else 1
+
+    # Sessions per month per task type (based on observed frequency)
+    sessions_per_month_total = sessions_per_day * 30
+    sessions_per_month: dict[str, float] = {}
+    for tt, costs in type_costs.items():
+        fraction = len(costs) / max(total_sessions, 1)
+        sessions_per_month[tt] = fraction * sessions_per_month_total
+
+    stats: list[TaskTypeStat] = []
+    savings_breakdown: list[tuple[str, float]] = []
+    total_savings = 0.0
+
+    for task_type, costs in sorted(type_costs.items(), key=lambda x: -len(x[1])):
+        avg = sum(costs) / len(costs)
+        sweet = SWEET_SPOTS.get(task_type, SWEET_SPOTS[DEFAULT_TASK_TYPE])
+        ratio = avg / sweet if sweet > 0 else 1.0
+        spm = sessions_per_month.get(task_type, 0.0)
+        monthly = avg * spm
+
+        stat = TaskTypeStat(
+            task_type=task_type,
+            session_count=len(costs),
+            avg_cost=avg,
+            sweet_spot=sweet,
+            ratio=ratio,
+            monthly_estimate=monthly,
+        )
+        stats.append(stat)
+
+        # Savings if you stopped delegating over-sweet-spot tasks
+        if ratio > 1.5:
+            saving = (avg - sweet) * spm
+            savings_breakdown.append((task_type, saving))
+            total_savings += saving
+
+    savings_breakdown.sort(key=lambda x: -x[1])
+
+    return CurveReport(
+        session_count=total_sessions,
+        days_analysed=days,
+        stats=stats,
+        potential_monthly_savings=total_savings,
+        savings_breakdown=savings_breakdown,
+        insufficient_data=total_sessions < min_sessions,
+        min_sessions=min_sessions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def format_curve(report: CurveReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    sep = "─" * 75
+
+    w(f"\nYour Agent Cost Curve ({report.session_count} sessions, {report.days_analysed} days)\n")
+    w(f"{sep}\n")
+
+    if report.insufficient_data:
+        w(
+            f"⚠️  Only {report.session_count} session(s) found "
+            f"(minimum: {report.min_sessions} for meaningful analysis).\n"
+            f"   Record more sessions and re-run.\n\n"
+        )
+        if not report.stats:
+            return
+
+    w(f"  {'Task type':<22}  {'Sweet spot':>10}  {'Your avg':>10}  {'Ratio':>6}  Verdict\n")
+    w(f"{sep}\n")
+
+    for stat in report.stats:
+        w(
+            f"  {stat.task_type:<22}  "
+            f"${stat.sweet_spot:>8.2f}  "
+            f"${stat.avg_cost:>8.2f}  "
+            f"{stat.ratio:>5.1f}x  "
+            f"{stat.verdict_icon} {stat.verdict}\n"
+        )
+
+    w(f"{sep}\n")
+
+    if report.savings_breakdown:
+        w(f"\nPotential monthly savings if you stop delegating:\n")
+        for task_type, saving in report.savings_breakdown[:5]:
+            w(f"  - {task_type:<22}  ${saving:.2f}/month\n")
+        w(f"  {'Total:':<24}  ${report.potential_monthly_savings:.2f}/month\n")
+
+    w("\n")
+
+
+def export_curve_csv(report: CurveReport, out: TextIO = sys.stdout) -> None:
+    writer = csv.writer(out)
+    writer.writerow([
+        "task_type", "session_count", "avg_cost_usd",
+        "sweet_spot_usd", "ratio", "verdict", "monthly_estimate_usd",
+    ])
+    for stat in report.stats:
+        writer.writerow([
+            stat.task_type,
+            stat.session_count,
+            f"{stat.avg_cost:.4f}",
+            f"{stat.sweet_spot:.4f}",
+            f"{stat.ratio:.2f}",
+            stat.verdict,
+            f"{stat.monthly_estimate:.2f}",
+        ])
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_curve(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    min_sessions = getattr(args, "min_sessions", 20) or 20
+    export = getattr(args, "export", "") or ""
+
+    report = analyse_curve(store, min_sessions=min_sessions)
+
+    if export == "csv":
+        export_curve_csv(report)
+    else:
+        format_curve(report)
+
+    return 0

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import io
-
-import pytest
+import os
+import tempfile
+import unittest
 
 from agent_trace.models import EventType, SessionMeta, TraceEvent
 from agent_trace.store import TraceStore
 
 
-def _make_store(tmp_path) -> TraceStore:
-    return TraceStore(str(tmp_path / "traces"))
+def _make_store(tmp_dir: str) -> TraceStore:
+    return TraceStore(os.path.join(tmp_dir, "traces"))
 
 
 def _populate_sessions(store: TraceStore, n: int = 25) -> None:
@@ -32,76 +33,93 @@ def _populate_sessions(store: TraceStore, n: int = 25) -> None:
         ))
 
 
-class TestCurve:
-    def test_analyse_curve_returns_report(self, tmp_path):
-        from agent_trace.curve import analyse_curve
-        store = _make_store(tmp_path)
-        _populate_sessions(store, 25)
-        report = analyse_curve(store, min_sessions=20)
-        assert report.session_count == 25
-        assert not report.insufficient_data
-        assert len(report.stats) > 0
-
-    def test_insufficient_data_flag(self, tmp_path):
-        from agent_trace.curve import analyse_curve
-        store = _make_store(tmp_path)
-        _populate_sessions(store, 5)
-        report = analyse_curve(store, min_sessions=20)
-        assert report.insufficient_data
-
-    def test_classify_session(self):
+class TestCurveClassification(unittest.TestCase):
+    def test_classify_unit_tests(self):
         from agent_trace.curve import _classify_session
-        assert _classify_session("write unit tests", "pytest") == "Unit test writing"
-        assert _classify_session("fix bug in auth", "") == "Bug debugging"
-        assert _classify_session("refactor database", "") == "Code refactoring"
-        assert _classify_session("", "") == "General / other"
+        self.assertEqual(_classify_session("write unit tests", "pytest"), "Unit test writing")
+
+    def test_classify_bug_debugging(self):
+        from agent_trace.curve import _classify_session
+        self.assertEqual(_classify_session("fix bug in auth", ""), "Bug debugging")
+
+    def test_classify_refactoring(self):
+        from agent_trace.curve import _classify_session
+        self.assertEqual(_classify_session("refactor database", ""), "Code refactoring")
 
     def test_classify_architecture(self):
         from agent_trace.curve import _classify_session
-        assert _classify_session("system design for payments", "") == "Architecture"
+        self.assertEqual(_classify_session("system design for payments", ""), "Architecture")
 
-    def test_format_curve_output(self, tmp_path):
+    def test_classify_fallback(self):
+        from agent_trace.curve import _classify_session
+        self.assertEqual(_classify_session("", ""), "General / other")
+
+
+class TestCurveAnalysis(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_analyse_curve_returns_report(self):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(self._tmp)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        self.assertEqual(report.session_count, 25)
+        self.assertFalse(report.insufficient_data)
+        self.assertGreater(len(report.stats), 0)
+
+    def test_insufficient_data_flag(self):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(self._tmp)
+        _populate_sessions(store, 5)
+        report = analyse_curve(store, min_sessions=20)
+        self.assertTrue(report.insufficient_data)
+
+    def test_stats_have_valid_verdict(self):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(self._tmp)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        valid_verdicts = {"efficient", "over sweet spot", "do this yourself"}
+        for stat in report.stats:
+            self.assertIn(stat.verdict, valid_verdicts)
+
+    def test_format_curve_output(self):
         from agent_trace.curve import analyse_curve, format_curve
-        store = _make_store(tmp_path)
+        store = _make_store(self._tmp)
         _populate_sessions(store, 25)
         report = analyse_curve(store, min_sessions=20)
         buf = io.StringIO()
         format_curve(report, out=buf)
         output = buf.getvalue()
-        assert "Cost Curve" in output
-        assert "Sweet spot" in output
-        assert "Verdict" in output
+        self.assertIn("Cost Curve", output)
+        self.assertIn("Sweet spot", output)
 
-    def test_export_csv(self, tmp_path):
+    def test_export_csv_header(self):
         from agent_trace.curve import analyse_curve, export_curve_csv
-        store = _make_store(tmp_path)
+        store = _make_store(self._tmp)
         _populate_sessions(store, 25)
         report = analyse_curve(store, min_sessions=20)
         buf = io.StringIO()
         export_curve_csv(report, out=buf)
         lines = buf.getvalue().strip().splitlines()
-        assert lines[0].startswith("task_type")
-        assert len(lines) > 1
+        self.assertTrue(lines[0].startswith("task_type"))
+        self.assertGreater(len(lines), 1)
 
-    def test_empty_store(self, tmp_path):
+    def test_empty_store(self):
         from agent_trace.curve import analyse_curve
-        store = _make_store(tmp_path)
+        store = _make_store(self._tmp)
         report = analyse_curve(store)
-        assert report.session_count == 0
-        assert report.insufficient_data
-
-    def test_stats_have_verdict(self, tmp_path):
-        from agent_trace.curve import analyse_curve
-        store = _make_store(tmp_path)
-        _populate_sessions(store, 25)
-        report = analyse_curve(store, min_sessions=20)
-        for stat in report.stats:
-            assert stat.verdict in ("efficient", "over sweet spot", "do this yourself")
-            assert stat.verdict_icon in ("✅", "⚠️ ", "❌")
+        self.assertEqual(report.session_count, 0)
+        self.assertTrue(report.insufficient_data)
 
     def test_cli_has_curve_command(self):
         from agent_trace.cli import build_parser
         parser = build_parser()
         args = parser.parse_args(["curve", "--min-sessions", "10", "--export", "csv"])
-        assert args.min_sessions == 10
-        assert args.export == "csv"
+        self.assertEqual(args.min_sessions, 10)
+        self.assertEqual(args.export, "csv")

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -1,0 +1,107 @@
+"""Tests for issue #50: personal cost curve."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_store(tmp_path) -> TraceStore:
+    return TraceStore(str(tmp_path / "traces"))
+
+
+def _populate_sessions(store: TraceStore, n: int = 25) -> None:
+    task_types = [
+        ("write unit tests for auth module", "pytest"),
+        ("fix bug in login flow", "debug"),
+        ("refactor database layer", "refactor"),
+    ]
+    for i in range(n):
+        name, cmd = task_types[i % len(task_types)]
+        meta = SessionMeta(agent_name=name, command=cmd)
+        store.create_session(meta)
+        sid = meta.session_id
+        store.append_event(sid, TraceEvent(
+            event_type=EventType.LLM_REQUEST,
+            session_id=sid,
+            data={"model": "claude-opus-4-6", "input_tokens": 500},
+        ))
+
+
+class TestCurve:
+    def test_analyse_curve_returns_report(self, tmp_path):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(tmp_path)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        assert report.session_count == 25
+        assert not report.insufficient_data
+        assert len(report.stats) > 0
+
+    def test_insufficient_data_flag(self, tmp_path):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(tmp_path)
+        _populate_sessions(store, 5)
+        report = analyse_curve(store, min_sessions=20)
+        assert report.insufficient_data
+
+    def test_classify_session(self):
+        from agent_trace.curve import _classify_session
+        assert _classify_session("write unit tests", "pytest") == "Unit test writing"
+        assert _classify_session("fix bug in auth", "") == "Bug debugging"
+        assert _classify_session("refactor database", "") == "Code refactoring"
+        assert _classify_session("", "") == "General / other"
+
+    def test_classify_architecture(self):
+        from agent_trace.curve import _classify_session
+        assert _classify_session("system design for payments", "") == "Architecture"
+
+    def test_format_curve_output(self, tmp_path):
+        from agent_trace.curve import analyse_curve, format_curve
+        store = _make_store(tmp_path)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        buf = io.StringIO()
+        format_curve(report, out=buf)
+        output = buf.getvalue()
+        assert "Cost Curve" in output
+        assert "Sweet spot" in output
+        assert "Verdict" in output
+
+    def test_export_csv(self, tmp_path):
+        from agent_trace.curve import analyse_curve, export_curve_csv
+        store = _make_store(tmp_path)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        buf = io.StringIO()
+        export_curve_csv(report, out=buf)
+        lines = buf.getvalue().strip().splitlines()
+        assert lines[0].startswith("task_type")
+        assert len(lines) > 1
+
+    def test_empty_store(self, tmp_path):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(tmp_path)
+        report = analyse_curve(store)
+        assert report.session_count == 0
+        assert report.insufficient_data
+
+    def test_stats_have_verdict(self, tmp_path):
+        from agent_trace.curve import analyse_curve
+        store = _make_store(tmp_path)
+        _populate_sessions(store, 25)
+        report = analyse_curve(store, min_sessions=20)
+        for stat in report.stats:
+            assert stat.verdict in ("efficient", "over sweet spot", "do this yourself")
+            assert stat.verdict_icon in ("✅", "⚠️ ", "❌")
+
+    def test_cli_has_curve_command(self):
+        from agent_trace.cli import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["curve", "--min-sessions", "10", "--export", "csv"])
+        assert args.min_sessions == 10
+        assert args.export == "csv"


### PR DESCRIPTION
Closes #50

## What

Adds `agent-strace curve` — analyses your stored session history and shows which task types are cost-efficient to delegate to an agent vs. doing yourself.

## Usage

```
$ agent-strace curve

Your Agent Cost Curve (60 sessions, 30 days)
───────────────────────────────────────────────────────────────────────────
  Task type               Sweet spot    Your avg   Ratio  Verdict
───────────────────────────────────────────────────────────────────────────
  Unit test writing          $0.12        $0.09    0.8x  ✅ efficient
  Code refactoring           $0.45        $0.38    0.8x  ✅ efficient
  Bug debugging              $0.80        $2.40    3.0x  ⚠️  over sweet spot
  Architecture               $1.20        $8.90    7.4x  ❌ do this yourself
  Boilerplate gen            $0.08        $0.07    0.9x  ✅ efficient
───────────────────────────────────────────────────────────────────────────

Potential monthly savings if you stop delegating:
  - Architecture             $67.20/month
  - Bug debugging            $48.60/month
  Total:                    $115.80/month

$ agent-strace curve --export csv > curve.csv
```

## How classification works

Sessions are classified by keyword matching on `agent_name` and `command` fields stored in `meta.json`. 10 task types are supported: Unit test writing, Code refactoring, Bug debugging, Architecture, Boilerplate gen, Documentation, Code review, Feature impl, Performance, Security. Unmatched sessions fall into "General / other".

Sweet-spot benchmarks are hardcoded community estimates — the personal curve shows how your actual costs compare.

## Changes

**`src/agent_trace/curve.py`** (new)
- `_classify_session()`: keyword-based task type classifier
- `analyse_curve()`: aggregates costs per task type, computes ratios and monthly savings
- `format_curve()`: terminal table with verdict icons
- `export_curve_csv()`: CSV export
- `TaskTypeStat`, `CurveReport` dataclasses
- `cmd_curve()`: CLI handler

**`src/agent_trace/cli.py`**
- `curve` subcommand with `--min-sessions` and `--export csv`

**`tests/test_curve.py`**: 9 tests covering classification, analysis, formatting, CSV export, insufficient-data warning, and CLI flags.