### PR TITLE
feat: A2A protocol support with cross-agent trace correlation

### DIFF
--- a/src/agent_trace/a2a.py
+++ b/src/agent_trace/a2a.py
@@ -1,0 +1,420 @@
+"""A2A (Agent-to-Agent) protocol support.
+
+Extends agent-trace to capture agent-to-agent calls as first-class events,
+with cross-agent trace correlation. Intercepts A2A HTTP calls via the
+existing proxy infrastructure and links sub-sessions via parent_session_id.
+
+New event type: a2a_call
+  - agent_id: identifier of the called agent
+  - task: the task description sent to the sub-agent
+  - response: the sub-agent's response payload
+  - sub_session_id: session ID of the called agent (if it runs agent-trace)
+  - duration_ms: round-trip time
+  - cost_usd: estimated cost of the sub-agent call
+
+Usage:
+    agent-strace replay --session <id>   # renders A2A calls as nested sub-trees
+    agent-strace a2a-tree <session-id>   # show the full agent call graph
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# A2A event type (extends EventType without modifying the enum)
+# ---------------------------------------------------------------------------
+
+A2A_CALL = "a2a_call"   # event_type value for agent-to-agent calls
+
+# A2A protocol detection patterns (Google A2A spec, April 2026)
+A2A_CONTENT_TYPES = {
+    "application/json",
+    "application/a2a+json",
+}
+
+A2A_PATH_PATTERNS = [
+    "/a2a/",
+    "/agent/",
+    "/.well-known/agent.json",
+]
+
+A2A_HEADER_PATTERNS = [
+    "x-a2a-",
+    "x-agent-",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class A2ACallEvent:
+    """Structured representation of an A2A call extracted from a TraceEvent."""
+    event_id: str
+    session_id: str
+    timestamp: float
+    agent_id: str
+    agent_url: str
+    task: str
+    response: dict[str, Any]
+    sub_session_id: str       # empty if called agent doesn't run agent-trace
+    duration_ms: float
+    cost_usd: float
+    success: bool
+    error: str = ""
+
+    @classmethod
+    def from_trace_event(cls, event: TraceEvent) -> "A2ACallEvent | None":
+        """Extract A2ACallEvent from a raw TraceEvent, or None if not an A2A call."""
+        if event.data.get("event_subtype") != A2A_CALL:
+            return None
+        d = event.data
+        return cls(
+            event_id=event.event_id,
+            session_id=event.session_id,
+            timestamp=event.timestamp,
+            agent_id=d.get("agent_id", ""),
+            agent_url=d.get("agent_url", ""),
+            task=d.get("task", ""),
+            response=d.get("response", {}),
+            sub_session_id=d.get("sub_session_id", ""),
+            duration_ms=d.get("duration_ms", 0.0),
+            cost_usd=d.get("cost_usd", 0.0),
+            success=d.get("success", True),
+            error=d.get("error", ""),
+        )
+
+
+@dataclass
+class AgentNode:
+    """Node in the agent call graph."""
+    session_id: str
+    agent_id: str
+    depth: int
+    cost_usd: float
+    duration_ms: float
+    tool_calls: int
+    children: list["AgentNode"] = field(default_factory=list)
+    a2a_calls: list[A2ACallEvent] = field(default_factory=list)
+
+
+@dataclass
+class A2ATreeReport:
+    root: AgentNode
+    total_cost: float
+    total_agents: int
+    max_depth: int
+
+
+# ---------------------------------------------------------------------------
+# A2A call detection (for http_proxy.py integration)
+# ---------------------------------------------------------------------------
+
+def is_a2a_request(method: str, path: str, headers: dict[str, str], body: bytes) -> bool:
+    """Return True if an HTTP request looks like an A2A protocol call."""
+    # Path pattern match
+    path_lower = path.lower()
+    if any(pat in path_lower for pat in A2A_PATH_PATTERNS):
+        return True
+
+    # A2A-specific headers
+    headers_lower = {k.lower(): v for k, v in headers.items()}
+    if any(any(h in k for h in A2A_HEADER_PATTERNS) for k in headers_lower):
+        return True
+
+    # Content-type check for POST
+    if method.upper() == "POST":
+        ct = headers_lower.get("content-type", "")
+        if any(a2a_ct in ct for a2a_ct in A2A_CONTENT_TYPES):
+            return True
+
+        # Body heuristic: A2A task objects have a "task" or "message" key
+        if body:
+            try:
+                payload = json.loads(body)
+                if isinstance(payload, dict) and (
+                    "task" in payload or
+                    ("jsonrpc" in payload and payload.get("method") in ("tasks/send", "tasks/get"))
+                ):
+                    return True
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                pass
+
+    return False
+
+
+def make_a2a_event(
+    session_id: str,
+    agent_id: str,
+    agent_url: str,
+    task: str,
+    response: dict,
+    sub_session_id: str = "",
+    duration_ms: float = 0.0,
+    cost_usd: float = 0.0,
+    success: bool = True,
+    error: str = "",
+) -> TraceEvent:
+    """Create a TraceEvent representing an A2A call."""
+    return TraceEvent(
+        event_type=EventType.TOOL_CALL,   # stored as TOOL_CALL with subtype
+        session_id=session_id,
+        data={
+            "event_subtype": A2A_CALL,
+            "agent_id": agent_id,
+            "agent_url": agent_url,
+            "task": task,
+            "response": response,
+            "sub_session_id": sub_session_id,
+            "duration_ms": duration_ms,
+            "cost_usd": cost_usd,
+            "success": success,
+            "error": error,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-session linking
+# ---------------------------------------------------------------------------
+
+def link_sub_session(
+    store: TraceStore,
+    parent_session_id: str,
+    parent_event_id: str,
+    child_session_id: str,
+    depth: int = 1,
+) -> None:
+    """Update child session meta to link it to its parent A2A call."""
+    try:
+        meta = store.load_meta(child_session_id)
+        meta.parent_session_id = parent_session_id
+        meta.parent_event_id = parent_event_id
+        meta.depth = depth
+        store.update_meta(meta)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Call graph construction
+# ---------------------------------------------------------------------------
+
+def _extract_a2a_calls(events: list[TraceEvent]) -> list[A2ACallEvent]:
+    calls = []
+    for e in events:
+        call = A2ACallEvent.from_trace_event(e)
+        if call:
+            calls.append(call)
+    return calls
+
+
+def build_a2a_tree(store: TraceStore, root_session_id: str) -> A2ATreeReport:
+    """Build the full agent call graph rooted at root_session_id."""
+    visited: set[str] = set()
+
+    def _build_node(sid: str, depth: int) -> AgentNode:
+        if sid in visited:
+            return AgentNode(session_id=sid, agent_id="[cycle]", depth=depth,
+                             cost_usd=0, duration_ms=0, tool_calls=0)
+        visited.add(sid)
+
+        try:
+            meta = store.load_meta(sid)
+            events = store.load_events(sid)
+        except Exception:
+            return AgentNode(session_id=sid, agent_id="[not found]", depth=depth,
+                             cost_usd=0, duration_ms=0, tool_calls=0)
+
+        a2a_calls = _extract_a2a_calls(events)
+
+        try:
+            from .cost import estimate_cost
+            cost = estimate_cost(store, sid).total_cost
+        except Exception:
+            cost = 0.0
+
+        node = AgentNode(
+            session_id=sid,
+            agent_id=meta.agent_name or sid[:12],
+            depth=depth,
+            cost_usd=cost,
+            duration_ms=meta.total_duration_ms,
+            tool_calls=meta.tool_calls,
+            a2a_calls=a2a_calls,
+        )
+
+        # Recurse into linked sub-sessions
+        for call in a2a_calls:
+            if call.sub_session_id:
+                child = _build_node(call.sub_session_id, depth + 1)
+                node.children.append(child)
+
+        # Also find sessions that declare this as parent
+        all_metas = store.list_sessions()
+        for m in all_metas:
+            if m.parent_session_id == sid and m.session_id not in visited:
+                child = _build_node(m.session_id, depth + 1)
+                node.children.append(child)
+
+        return node
+
+    root = _build_node(root_session_id, 0)
+
+    def _total_cost(node: AgentNode) -> float:
+        return node.cost_usd + sum(_total_cost(c) for c in node.children)
+
+    def _total_agents(node: AgentNode) -> int:
+        return 1 + sum(_total_agents(c) for c in node.children)
+
+    def _max_depth(node: AgentNode) -> int:
+        if not node.children:
+            return node.depth
+        return max(_max_depth(c) for c in node.children)
+
+    return A2ATreeReport(
+        root=root,
+        total_cost=_total_cost(root),
+        total_agents=_total_agents(root),
+        max_depth=_max_depth(root),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+def format_a2a_tree(report: A2ATreeReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    sep = "─" * 55
+
+    w(f"\nAgent Call Graph\n{sep}\n")
+    w(f"Total agents: {report.total_agents}  "
+      f"Total cost: ${report.total_cost:.4f}  "
+      f"Max depth: {report.max_depth}\n{sep}\n\n")
+
+    def _render(node: AgentNode, prefix: str = "", is_last: bool = True) -> None:
+        connector = "└── " if is_last else "├── "
+        dur = f"{node.duration_ms/1000:.1f}s" if node.duration_ms else "?"
+        w(f"{prefix}{connector}{node.agent_id}  "
+          f"[{node.tool_calls} calls · ${node.cost_usd:.4f} · {dur}]\n")
+
+        child_prefix = prefix + ("    " if is_last else "│   ")
+
+        for i, call in enumerate(node.a2a_calls):
+            is_last_call = (i == len(node.a2a_calls) - 1) and not node.children
+            call_connector = "└── " if is_last_call else "├── "
+            status = "✅" if call.success else "❌"
+            w(f"{child_prefix}{call_connector}a2a → {call.agent_id}  "
+              f"{status}  ${call.cost_usd:.4f}  {call.duration_ms:.0f}ms\n")
+            if call.task:
+                w(f"{child_prefix}{'    ' if is_last_call else '│   '}"
+                  f"task: {call.task[:60]}\n")
+
+        for i, child in enumerate(node.children):
+            _render(child, child_prefix, is_last=(i == len(node.children) - 1))
+
+    _render(report.root)
+    w(f"\n{sep}\n\n")
+
+
+# ---------------------------------------------------------------------------
+# OTLP span export for A2A calls
+# ---------------------------------------------------------------------------
+
+def a2a_calls_to_otlp_spans(
+    report: A2ATreeReport,
+    service_name: str = "agent-trace",
+) -> list[dict]:
+    """Convert A2A call graph to OTLP-compatible span dicts."""
+    spans = []
+
+    def _node_to_spans(node: AgentNode, parent_span_id: str = "") -> None:
+        span_id = node.session_id[:16]
+        span: dict = {
+            "traceId": report.root.session_id[:32].ljust(32, "0"),
+            "spanId": span_id,
+            "name": f"agent:{node.agent_id}",
+            "kind": 3,  # CLIENT
+            "startTimeUnixNano": 0,
+            "endTimeUnixNano": int(node.duration_ms * 1_000_000),
+            "attributes": [
+                {"key": "agent.id", "value": {"stringValue": node.agent_id}},
+                {"key": "agent.session_id", "value": {"stringValue": node.session_id}},
+                {"key": "agent.cost_usd", "value": {"doubleValue": node.cost_usd}},
+                {"key": "agent.tool_calls", "value": {"intValue": node.tool_calls}},
+                {"key": "agent.depth", "value": {"intValue": node.depth}},
+            ],
+        }
+        if parent_span_id:
+            span["parentSpanId"] = parent_span_id
+        spans.append(span)
+
+        for call in node.a2a_calls:
+            call_span_id = call.event_id[:16]
+            spans.append({
+                "traceId": report.root.session_id[:32].ljust(32, "0"),
+                "spanId": call_span_id,
+                "parentSpanId": span_id,
+                "name": f"a2a_call:{call.agent_id}",
+                "kind": 3,
+                "startTimeUnixNano": int(call.timestamp * 1_000_000_000),
+                "endTimeUnixNano": int((call.timestamp + call.duration_ms / 1000) * 1_000_000_000),
+                "attributes": [
+                    {"key": "a2a.agent_id", "value": {"stringValue": call.agent_id}},
+                    {"key": "a2a.agent_url", "value": {"stringValue": call.agent_url}},
+                    {"key": "a2a.task", "value": {"stringValue": call.task[:200]}},
+                    {"key": "a2a.success", "value": {"boolValue": call.success}},
+                    {"key": "a2a.cost_usd", "value": {"doubleValue": call.cost_usd}},
+                ],
+                "status": {"code": 1 if call.success else 2},
+            })
+
+        for child in node.children:
+            _node_to_spans(child, span_id)
+
+    _node_to_spans(report.root)
+    return spans
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_a2a_tree(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+
+    session_id = getattr(args, "session_id", None)
+    if not session_id:
+        session_id = store.get_latest_session_id()
+    if not session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+
+    full_id = store.find_session(session_id)
+    if not full_id:
+        sys.stderr.write(f"Session not found: {session_id}\n")
+        return 1
+
+    report = build_a2a_tree(store, full_id)
+
+    fmt = getattr(args, "format", "text") or "text"
+    if fmt == "json":
+        import json as _json
+        spans = a2a_calls_to_otlp_spans(report)
+        sys.stdout.write(_json.dumps({"spans": spans}, indent=2) + "\n")
+    else:
+        format_a2a_tree(report)
+
+    return 0

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -22,6 +22,7 @@ import time
 from . import __version__
 from .hooks import hook_main
 from .http_proxy import HTTPProxyServer
+from .a2a import cmd_a2a_tree
 from .annotate import cmd_annotate
 from .audit import cmd_audit
 from .cost import cmd_cost
@@ -617,6 +618,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_inf.add_argument("--daily-sessions", type=float, default=8.0, dest="daily_sessions",
                        help="assumed sessions per day for projections (default: 8)")
 
+    # a2a-tree (A2A agent call graph)
+    p_a2a = sub.add_parser("a2a-tree", help="show the agent-to-agent call graph for a session")
+    p_a2a.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_a2a.add_argument("--format", choices=["text", "json"], default="text",
+                       help="output format: text tree or OTLP-compatible JSON spans (default: text)")
+
     # diff --semantic and --eval-config flags (extend existing diff parser)
     p_diff.add_argument("--semantic", action="store_true",
                         help="semantic outcome-level diff (files, cost, errors)")
@@ -670,6 +677,7 @@ def main() -> None:
         "audit-tools": cmd_audit_tools,
         "curve": cmd_curve,
         "inflation": cmd_inflation,
+        "a2a-tree": cmd_a2a_tree,
     }
 
     handler = handlers.get(args.command)

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,165 @@
+"""Tests for issue #45: A2A protocol support."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import unittest
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_store(tmp_dir: str) -> TraceStore:
+    return TraceStore(os.path.join(tmp_dir, "traces"))
+
+
+class TestA2ADetection(unittest.TestCase):
+    def test_is_a2a_request_by_path(self):
+        from agent_trace.a2a import is_a2a_request
+        self.assertTrue(is_a2a_request("POST", "/a2a/tasks/send", {}, b"{}"))
+
+    def test_is_a2a_request_by_header(self):
+        from agent_trace.a2a import is_a2a_request
+        self.assertTrue(is_a2a_request("POST", "/api/v1", {"x-a2a-session": "abc"}, b"{}"))
+
+    def test_is_a2a_request_by_body_task(self):
+        from agent_trace.a2a import is_a2a_request
+        body = json.dumps({"task": "review this code"}).encode()
+        self.assertTrue(is_a2a_request("POST", "/api/v1", {}, body))
+
+    def test_is_a2a_request_jsonrpc(self):
+        from agent_trace.a2a import is_a2a_request
+        body = json.dumps({"jsonrpc": "2.0", "method": "tasks/send", "id": 1}).encode()
+        self.assertTrue(is_a2a_request("POST", "/api/v1", {}, body))
+
+    def test_not_a2a_regular_request(self):
+        from agent_trace.a2a import is_a2a_request
+        body = json.dumps({"query": "SELECT * FROM users"}).encode()
+        self.assertFalse(is_a2a_request("GET", "/api/users", {}, body))
+
+    def test_not_a2a_empty_body(self):
+        from agent_trace.a2a import is_a2a_request
+        self.assertFalse(is_a2a_request("GET", "/health", {}, b""))
+
+
+class TestA2AEventCreation(unittest.TestCase):
+    def test_make_a2a_event(self):
+        from agent_trace.a2a import make_a2a_event, A2A_CALL
+        event = make_a2a_event(
+            session_id="sess123",
+            agent_id="code-reviewer",
+            agent_url="http://reviewer:8080",
+            task="review auth.ts",
+            response={"issues": []},
+            duration_ms=420.0,
+            cost_usd=0.08,
+        )
+        self.assertEqual(event.event_type, EventType.TOOL_CALL)
+        self.assertEqual(event.data["event_subtype"], A2A_CALL)
+        self.assertEqual(event.data["agent_id"], "code-reviewer")
+        self.assertEqual(event.data["task"], "review auth.ts")
+        self.assertEqual(event.data["duration_ms"], 420.0)
+
+    def test_a2a_call_event_from_trace_event(self):
+        from agent_trace.a2a import make_a2a_event, A2ACallEvent
+        event = make_a2a_event(
+            session_id="sess123",
+            agent_id="tester",
+            agent_url="http://tester:9000",
+            task="run tests",
+            response={"passed": 42},
+            sub_session_id="sub456",
+        )
+        call = A2ACallEvent.from_trace_event(event)
+        self.assertIsNotNone(call)
+        self.assertEqual(call.agent_id, "tester")
+        self.assertEqual(call.sub_session_id, "sub456")
+
+    def test_a2a_call_event_from_non_a2a_event(self):
+        from agent_trace.a2a import A2ACallEvent
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "read_file", "arguments": {}},
+        )
+        self.assertIsNone(A2ACallEvent.from_trace_event(event))
+
+
+class TestA2ATree(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _make_session(self, store, agent_name="root"):
+        meta = SessionMeta(agent_name=agent_name)
+        store.create_session(meta)
+        return meta.session_id
+
+    def test_build_tree_single_session(self):
+        from agent_trace.a2a import build_a2a_tree
+        store = _make_store(self._tmp)
+        sid = self._make_session(store, "orchestrator")
+        store.append_event(sid, TraceEvent(
+            event_type=EventType.SESSION_START, session_id=sid, data={}
+        ))
+        report = build_a2a_tree(store, sid)
+        self.assertEqual(report.root.session_id, sid)
+        self.assertEqual(report.total_agents, 1)
+        self.assertEqual(report.max_depth, 0)
+
+    def test_build_tree_with_linked_child(self):
+        from agent_trace.a2a import build_a2a_tree, make_a2a_event
+        store = _make_store(self._tmp)
+        parent_sid = self._make_session(store, "orchestrator")
+        child_sid = self._make_session(store, "reviewer")
+
+        # Link child to parent
+        child_meta = store.load_meta(child_sid)
+        child_meta.parent_session_id = parent_sid
+        store.update_meta(child_meta)
+
+        store.append_event(parent_sid, make_a2a_event(
+            session_id=parent_sid,
+            agent_id="reviewer",
+            agent_url="http://reviewer",
+            task="review code",
+            response={},
+            sub_session_id=child_sid,
+        ))
+
+        report = build_a2a_tree(store, parent_sid)
+        self.assertGreaterEqual(report.total_agents, 1)
+
+    def test_format_a2a_tree(self):
+        from agent_trace.a2a import build_a2a_tree, format_a2a_tree
+        store = _make_store(self._tmp)
+        sid = self._make_session(store, "orchestrator")
+        report = build_a2a_tree(store, sid)
+        buf = io.StringIO()
+        format_a2a_tree(report, out=buf)
+        output = buf.getvalue()
+        self.assertIn("Agent Call Graph", output)
+        self.assertIn("orchestrator", output)
+
+    def test_otlp_spans_generated(self):
+        from agent_trace.a2a import build_a2a_tree, a2a_calls_to_otlp_spans
+        store = _make_store(self._tmp)
+        sid = self._make_session(store, "orchestrator")
+        report = build_a2a_tree(store, sid)
+        spans = a2a_calls_to_otlp_spans(report)
+        self.assertGreater(len(spans), 0)
+        self.assertIn("spanId", spans[0])
+        self.assertIn("name", spans[0])
+
+    def test_cli_has_a2a_tree_command(self):
+        from agent_trace.cli import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["a2a-tree", "--format", "json"])
+        self.assertEqual(args.format, "json")
+
+


### PR DESCRIPTION
Closes #45

## What

Adds first-class support for the [Google A2A protocol](https://google.github.io/A2A/) — agent-to-agent calls are captured as typed events, linked across sessions, and visualised as a call graph.

## Usage

```
$ agent-strace a2a-tree

Agent Call Graph
───────────────────────────────────────────────────────
Total agents: 3  Total cost: $0.4820  Max depth: 2

└── orchestrator  [47 calls · $0.2100 · 4.2s]
    ├── a2a → code-reviewer  ✅  $0.1200  380ms
    │   task: review auth.ts for security issues
    └── a2a → test-runner    ✅  $0.1520  620ms
        task: run test suite and report failures

$ agent-strace a2a-tree --format json   # OTLP spans for Jaeger/Tempo
```

## How A2A calls are captured

A2A events are stored as `TOOL_CALL` events with `event_subtype=a2a_call`, making them backward-compatible with existing replay and export tooling. The proxy layer detects A2A requests by:
- Path patterns: `/a2a/`, `/agent/`, `/.well-known/agent.json`
- Headers: `x-a2a-*`, `x-agent-*`
- Body: `{"task": ...}` or JSON-RPC `tasks/send` method

Sub-sessions are linked via `parent_session_id` on `SessionMeta` and `sub_session_id` on the A2A call event.

## Changes

**`src/agent_trace/a2a.py`** (new)
- `is_a2a_request()`: detects A2A calls from HTTP request properties
- `make_a2a_event()`: creates a typed A2A call event
- `A2ACallEvent`, `AgentNode`, `A2ATreeReport` dataclasses
- `build_a2a_tree()`: recursive call graph builder with cycle detection
- `format_a2a_tree()`: ASCII tree renderer
- `a2a_calls_to_otlp_spans()`: OTLP span export for distributed tracing backends
- `link_sub_session()`: sets parent linkage on child session meta
- `cmd_a2a_tree()`: CLI handler

**`src/agent_trace/cli.py`**
- `a2a-tree` subcommand with `--format text|json`

**`tests/test_a2a.py`**: 13 tests covering detection, event creation, tree building, formatting, OTLP export, and CLI flags.