### PR TITLE
feat(vscode): VS Code extension for live session overlay

### DIFF
--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -630,6 +630,27 @@ def check_event(
 _IDLE_SENTINEL = object()  # yielded when poll_interval elapses with no new event
 
 
+def _check_pause_file(store: "TraceStore", state: "WatchState", out: "TextIO") -> None:
+    """Honour a .pause-request file written by the VS Code extension.
+
+    Presence of the file → SIGSTOP the agent (if a PID is known).
+    Absence after a pause → SIGCONT to resume.
+    """
+    pause_file = store.base_dir / ".pause-request"
+    wants_pause = pause_file.exists()
+
+    if wants_pause and not state.paused and state.agent_pid:
+        out.write(f"[watch] Pause requested by editor — SIGSTOP pid {state.agent_pid}\n")
+        out.flush()
+        _pause_process(state.agent_pid)
+        state.paused = True
+    elif not wants_pause and state.paused and state.agent_pid:
+        out.write(f"[watch] Resume requested by editor — SIGCONT pid {state.agent_pid}\n")
+        out.flush()
+        _resume_process(state.agent_pid)
+        state.paused = False
+
+
 def _tail_events(events_file: Path, poll_interval: float = 0.5):
     """Generator that yields TraceEvent objects or _IDLE_SENTINEL each poll cycle.
 
@@ -693,6 +714,8 @@ def watch_session(
                 break
 
             if item is _IDLE_SENTINEL:
+                # Check for pause-request signal file written by the VS Code extension
+                _check_pause_file(store, state, out)
                 continue
 
             event: TraceEvent = item  # type: ignore[assignment]

--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,7 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+tsconfig.json
+**/*.map
+node_modules/**

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,55 @@
+# agent-trace for VS Code
+
+Live session overlay for [agent-trace](https://github.com/Siddhant-K-code/agent-trace). Shows what your agent is doing without leaving the editor.
+
+## Features
+
+**Status bar** — cost, tool call count, and active tool name, updated on every event. Click to open the event stream panel.
+
+```
+$(pulse) agent  $0.0042  47 calls  [Read]
+```
+
+**Gutter annotations** — files the agent has read or modified get a colored left border and inline label:
+
+```
+src/auth/middleware.ts  ← agent read 3×, modified 1× this session
+src/db/schema.ts        ← agent read 1× this session
+```
+
+**Event stream panel** — live feed of every tool call, file op, LLM request, and error in the Explorer sidebar. Same information as `agent-strace watch` but in the editor.
+
+**Pause button** — stop the agent mid-session without killing it. Writes a signal file that `agent-strace watch` picks up and sends SIGSTOP to the agent process. Resume resumes it.
+
+## Requirements
+
+- [agent-trace](https://pypi.org/project/agent-strace/) installed (`pip install agent-strace` or `uv tool install agent-strace`)
+- A session started via `agent-strace setup` (Claude Code hooks) or `agent-strace record` (MCP proxy)
+
+The extension activates automatically when a `.agent-traces/` directory exists in the workspace root.
+
+## Usage
+
+1. Install agent-trace and set up hooks:
+   ```bash
+   agent-strace setup   # adds hooks to .claude/settings.json
+   ```
+2. Open your project in VS Code / Cursor.
+3. Start Claude Code — the status bar item appears as soon as the session starts.
+4. Open the **Agent Trace** panel in the Explorer sidebar for the full event stream.
+
+The **Pause** button in the panel (or `agent-trace: Pause Agent` command) sends SIGSTOP to the agent. This requires `agent-strace watch` to be running in a terminal alongside the session.
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `agentTrace.traceDir` | `.agent-traces` | Path to trace store, relative to workspace root |
+| `agentTrace.showGutterAnnotations` | `true` | Gutter icons on agent-touched files |
+| `agentTrace.showInlineText` | `true` | Inline read/write counts at top of file |
+
+## How it works
+
+The extension watches `.agent-traces/.active-session` for the current session ID, then tails `events.ndjson` for new events using `fs.watch`. No polling when idle. No network calls. No new processes.
+
+Pause works by writing `.agent-traces/.pause-request` — `agent-strace watch` checks for this file on every poll cycle and sends SIGSTOP / SIGCONT to the agent PID.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "agent-trace",
+  "displayName": "agent-trace",
+  "description": "Live session overlay for agent-trace: status bar, gutter annotations, and event stream panel.",
+  "version": "0.1.0",
+  "publisher": "Siddhant-K-code",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Siddhant-K-code/agent-trace"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "keywords": ["ai", "agent", "trace", "observability", "claude", "mcp"],
+  "icon": "icon.png",
+  "activationEvents": [
+    "workspaceContains:.agent-traces"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "agentTrace.pauseAgent",
+        "title": "agent-trace: Pause Agent",
+        "icon": "$(debug-pause)"
+      },
+      {
+        "command": "agentTrace.resumeAgent",
+        "title": "agent-trace: Resume Agent",
+        "icon": "$(debug-continue)"
+      },
+      {
+        "command": "agentTrace.openPanel",
+        "title": "agent-trace: Open Event Stream"
+      },
+      {
+        "command": "agentTrace.clearDecorations",
+        "title": "agent-trace: Clear File Decorations"
+      }
+    ],
+    "views": {
+      "explorer": [
+        {
+          "type": "webview",
+          "id": "agentTrace.eventStream",
+          "name": "Agent Trace",
+          "when": "agentTrace.sessionActive"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "agent-trace",
+      "properties": {
+        "agentTrace.traceDir": {
+          "type": "string",
+          "default": ".agent-traces",
+          "description": "Path to the trace store directory, relative to workspace root."
+        },
+        "agentTrace.showGutterAnnotations": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show gutter icons on files the agent has read or modified."
+        },
+        "agentTrace.showInlineText": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show inline read/write counts at the top of agent-touched files."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src --ext ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/vscode-extension/src/decorations.ts
+++ b/vscode-extension/src/decorations.ts
@@ -1,0 +1,148 @@
+/**
+ * Gutter annotations and inline text for agent-touched files.
+ *
+ * Files the agent read:     subtle left-border highlight + inline "← agent read Nx"
+ * Files the agent modified: stronger highlight + inline "← agent modified Nx"
+ *
+ * Decorations are applied to the first line of the file (non-intrusive).
+ * Cleared when the session ends or the user runs agentTrace.clearDecorations.
+ */
+
+import * as vscode from "vscode";
+import { FileAccess, SessionState } from "./traceStore";
+
+// Decoration type for files the agent has read (but not written)
+const readDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  overviewRulerColor: new vscode.ThemeColor("editorInfo.foreground"),
+  overviewRulerLane: vscode.OverviewRulerLane.Left,
+  borderWidth: "0 0 0 2px",
+  borderStyle: "solid",
+  borderColor: new vscode.ThemeColor("editorInfo.foreground"),
+  light: { borderColor: "#4a9eff55" },
+  dark: { borderColor: "#4a9eff55" },
+});
+
+// Decoration type for files the agent has written
+const writeDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  overviewRulerColor: new vscode.ThemeColor("editorWarning.foreground"),
+  overviewRulerLane: vscode.OverviewRulerLane.Left,
+  borderWidth: "0 0 0 3px",
+  borderStyle: "solid",
+  borderColor: new vscode.ThemeColor("editorWarning.foreground"),
+  light: { borderColor: "#e5a00d88" },
+  dark: { borderColor: "#e5a00d88" },
+});
+
+export class DecorationManager extends vscode.Disposable {
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor() {
+    super(() => this._disposeAll());
+
+    // Re-apply decorations when the active editor changes
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (editor && this.currentState) {
+          this._applyToEditor(editor, this.currentState.fileAccess);
+        }
+      })
+    );
+  }
+
+  private currentState: SessionState | null = null;
+
+  update(state: SessionState | null): void {
+    this.currentState = state;
+
+    if (!state) {
+      this._clearAll();
+      return;
+    }
+
+    for (const editor of vscode.window.visibleTextEditors) {
+      this._applyToEditor(editor, state.fileAccess);
+    }
+  }
+
+  clear(): void {
+    this._clearAll();
+    this.currentState = null;
+  }
+
+  private _applyToEditor(
+    editor: vscode.TextEditor,
+    fileAccess: Map<string, FileAccess>
+  ): void {
+    const filePath = editor.document.uri.fsPath;
+    const access = fileAccess.get(filePath);
+
+    if (!access) {
+      editor.setDecorations(readDecoration, []);
+      editor.setDecorations(writeDecoration, []);
+      return;
+    }
+
+    const firstLine = new vscode.Range(0, 0, 0, 0);
+
+    if (access.writes > 0) {
+      const label = _label(access);
+      editor.setDecorations(readDecoration, []);
+      editor.setDecorations(writeDecoration, [
+        {
+          range: firstLine,
+          renderOptions: {
+            after: {
+              contentText: `  ← ${label}`,
+              color: new vscode.ThemeColor("editorWarning.foreground"),
+              fontStyle: "italic",
+              margin: "0 0 0 2em",
+            },
+          },
+        },
+      ]);
+    } else {
+      const label = _label(access);
+      editor.setDecorations(writeDecoration, []);
+      editor.setDecorations(readDecoration, [
+        {
+          range: firstLine,
+          renderOptions: {
+            after: {
+              contentText: `  ← ${label}`,
+              color: new vscode.ThemeColor("editorInfo.foreground"),
+              fontStyle: "italic",
+              margin: "0 0 0 2em",
+            },
+          },
+        },
+      ]);
+    }
+  }
+
+  private _clearAll(): void {
+    for (const editor of vscode.window.visibleTextEditors) {
+      editor.setDecorations(readDecoration, []);
+      editor.setDecorations(writeDecoration, []);
+    }
+  }
+
+  private _disposeAll(): void {
+    this._clearAll();
+    readDecoration.dispose();
+    writeDecoration.dispose();
+    for (const d of this.disposables) { d.dispose(); }
+  }
+}
+
+function _label(access: FileAccess): string {
+  const parts: string[] = [];
+  if (access.reads > 0) {
+    parts.push(`agent read ${access.reads}×`);
+  }
+  if (access.writes > 0) {
+    parts.push(`agent modified ${access.writes}×`);
+  }
+  return parts.join(", ") + " this session";
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,152 @@
+/**
+ * agent-trace VS Code extension entry point.
+ *
+ * Activates when a workspace contains a .agent-traces directory.
+ * Zero overhead when no session is active — all watchers are fs.watch
+ * based, no polling timers run until a session starts.
+ */
+
+import * as path from "path";
+import * as vscode from "vscode";
+import { DecorationManager } from "./decorations";
+import { EventStreamPanel } from "./panel";
+import { PauseManager } from "./pauseAgent";
+import { StatusBarManager } from "./statusBar";
+import { TraceWatcher } from "./traceStore";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!workspaceRoot) { return; }
+
+  const config = vscode.workspace.getConfiguration("agentTrace");
+  const traceDirSetting = config.get<string>("traceDir", ".agent-traces")!;
+  const traceDir = path.isAbsolute(traceDirSetting)
+    ? traceDirSetting
+    : path.join(workspaceRoot, traceDirSetting);
+
+  // -------------------------------------------------------------------------
+  // Core components
+  // -------------------------------------------------------------------------
+
+  const watcher = new TraceWatcher(workspaceRoot, traceDirSetting);
+  const statusBar = new StatusBarManager();
+  const decorations = new DecorationManager();
+  const pauseManager = new PauseManager(traceDir);
+  const panel = new EventStreamPanel(context.extensionUri);
+
+  // -------------------------------------------------------------------------
+  // Webview panel registration
+  // -------------------------------------------------------------------------
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(EventStreamPanel.viewId, panel, {
+      webviewOptions: { retainContextWhenHidden: true },
+    })
+  );
+
+  // -------------------------------------------------------------------------
+  // Wire watcher → UI components
+  // -------------------------------------------------------------------------
+
+  watcher.onSessionStart((state) => {
+    vscode.commands.executeCommand(
+      "setContext",
+      "agentTrace.sessionActive",
+      true
+    );
+    statusBar.update(state);
+    decorations.update(state);
+    panel.onSessionStart(state);
+  });
+
+  watcher.onSessionEnd((state) => {
+    vscode.commands.executeCommand(
+      "setContext",
+      "agentTrace.sessionActive",
+      false
+    );
+    statusBar.update(null);
+    decorations.update(null);
+    panel.onSessionEnd(state);
+    pauseManager.cleanup();
+  });
+
+  watcher.onStateChange((state) => {
+    statusBar.update(state);
+    if (config.get<boolean>("showGutterAnnotations", true)) {
+      decorations.update(state);
+    }
+  });
+
+  watcher.onEvent(({ state, event }) => {
+    panel.pushEvent(state, event);
+  });
+
+  // -------------------------------------------------------------------------
+  // Commands
+  // -------------------------------------------------------------------------
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentTrace.pauseAgent", () => {
+      const state = watcher.state;
+      if (!state) {
+        vscode.window.showWarningMessage("agent-trace: no active session to pause.");
+        return;
+      }
+      pauseManager.pause(state);
+      statusBar.update(state);
+      vscode.window.setStatusBarMessage("agent-trace: agent paused.", 3000);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentTrace.resumeAgent", () => {
+      const state = watcher.state;
+      if (!state) { return; }
+      pauseManager.resume(state);
+      statusBar.update(state);
+      vscode.window.setStatusBarMessage("agent-trace: agent resumed.", 3000);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentTrace.openPanel", () => {
+      vscode.commands.executeCommand("agentTrace.eventStream.focus");
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentTrace.clearDecorations", () => {
+      decorations.clear();
+    })
+  );
+
+  // -------------------------------------------------------------------------
+  // Config change — re-read traceDir if it changes
+  // -------------------------------------------------------------------------
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("agentTrace")) {
+        vscode.window.showInformationMessage(
+          "agent-trace: configuration changed — reload window to apply."
+        );
+      }
+    })
+  );
+
+  // -------------------------------------------------------------------------
+  // Start watching
+  // -------------------------------------------------------------------------
+
+  watcher.start();
+
+  // Register disposables
+  context.subscriptions.push(watcher, statusBar, decorations);
+}
+
+export function deactivate(): void {
+  // Disposables registered via context.subscriptions are cleaned up
+  // automatically. PauseManager.cleanup() is called in onSessionEnd,
+  // but call it here too in case the window closes mid-session.
+}

--- a/vscode-extension/src/panel.ts
+++ b/vscode-extension/src/panel.ts
@@ -1,0 +1,399 @@
+/**
+ * Side panel webview showing the live event stream.
+ *
+ * Renders as a VS Code WebviewView in the Explorer sidebar.
+ * Receives events via postMessage from the extension host.
+ * Includes a Pause / Resume button that posts a command back.
+ */
+
+import * as vscode from "vscode";
+import { SessionState, TraceEvent } from "./traceStore";
+
+// ---------------------------------------------------------------------------
+// Icons / labels per event type
+// ---------------------------------------------------------------------------
+
+const EVENT_ICON: Record<string, string> = {
+  session_start: "▶",
+  session_end: "■",
+  user_prompt: "👤",
+  assistant_response: "🤖",
+  tool_call: "→",
+  tool_result: "←",
+  llm_request: "⇢",
+  llm_response: "⇠",
+  file_read: "📖",
+  file_write: "✏️",
+  decision: "🔀",
+  error: "✗",
+};
+
+function eventSummary(event: TraceEvent): string {
+  const d = event.data;
+  switch (event.event_type) {
+    case "tool_call":
+      return `${d.tool_name ?? ""}  ${_truncate(JSON.stringify(d.arguments ?? ""), 60)}`;
+    case "tool_result":
+      return _truncate(String(d.output ?? d.result ?? ""), 80);
+    case "user_prompt":
+      return _truncate(String(d.prompt ?? d.text ?? ""), 80);
+    case "assistant_response":
+      return _truncate(String(d.text ?? d.response ?? ""), 80);
+    case "file_read":
+    case "file_write":
+      return String(d.path ?? "");
+    case "error":
+      return _truncate(String(d.message ?? d.error ?? ""), 80);
+    default:
+      return "";
+  }
+}
+
+function _truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+function _relTime(ts: number): string {
+  const s = Math.floor(Date.now() / 1000 - ts);
+  if (s < 60) { return `${s}s ago`; }
+  const m = Math.floor(s / 60);
+  return `${m}m ago`;
+}
+
+// ---------------------------------------------------------------------------
+// EventStreamPanel — WebviewViewProvider
+// ---------------------------------------------------------------------------
+
+export class EventStreamPanel implements vscode.WebviewViewProvider {
+  public static readonly viewId = "agentTrace.eventStream";
+
+  private view?: vscode.WebviewView;
+  private pendingEvents: TraceEvent[] = [];
+  private currentState: SessionState | null = null;
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken
+  ): void {
+    this.view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+    };
+
+    webviewView.webview.html = this._buildHtml(webviewView.webview);
+
+    // Handle messages from the webview (pause/resume button)
+    webviewView.webview.onDidReceiveMessage((msg) => {
+      if (msg.command === "pause") {
+        vscode.commands.executeCommand("agentTrace.pauseAgent");
+      } else if (msg.command === "resume") {
+        vscode.commands.executeCommand("agentTrace.resumeAgent");
+      }
+    });
+
+    // Flush any events that arrived before the view was ready
+    if (this.currentState) {
+      this._postState(this.currentState);
+    }
+    for (const e of this.pendingEvents) {
+      this._postEvent(e);
+    }
+    this.pendingEvents = [];
+  }
+
+  /** Called when a new session starts — resets the panel. */
+  onSessionStart(state: SessionState): void {
+    this.currentState = state;
+    this.pendingEvents = [];
+    this.view?.webview.postMessage({ type: "reset" });
+    this._postState(state);
+  }
+
+  /** Called when the session ends. */
+  onSessionEnd(state: SessionState): void {
+    this.currentState = null;
+    this._postState({ ...state, activeTool: null });
+    this.view?.webview.postMessage({ type: "sessionEnd" });
+  }
+
+  /** Called on every new event. */
+  pushEvent(state: SessionState, event: TraceEvent): void {
+    this.currentState = state;
+    if (!this.view) {
+      this.pendingEvents.push(event);
+      return;
+    }
+    this._postState(state);
+    this._postEvent(event);
+  }
+
+  private _postState(state: SessionState): void {
+    this.view?.webview.postMessage({
+      type: "state",
+      cost: state.estimatedCostUsd.toFixed(4),
+      toolCalls: state.toolCallCount,
+      errors: state.errorCount,
+      activeTool: state.activeTool,
+      paused: state.paused,
+      sessionId: state.sessionId.slice(0, 8),
+    });
+  }
+
+  private _postEvent(event: TraceEvent): void {
+    this.view?.webview.postMessage({
+      type: "event",
+      icon: EVENT_ICON[event.event_type] ?? "·",
+      eventType: event.event_type,
+      summary: eventSummary(event),
+      time: _relTime(event.timestamp),
+      isError: event.event_type === "error",
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // HTML
+  // -------------------------------------------------------------------------
+
+  private _buildHtml(_webview: vscode.Webview): string {
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-foreground);
+    background: var(--vscode-sideBar-background);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  /* Header */
+  #header {
+    padding: 8px 10px 6px;
+    border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, #333);
+    flex-shrink: 0;
+  }
+  #stats {
+    display: flex;
+    gap: 12px;
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    margin-bottom: 6px;
+  }
+  #stats span { white-space: nowrap; }
+  #stats .cost { color: var(--vscode-charts-green, #4ec9b0); font-weight: 600; }
+  #stats .errors { color: var(--vscode-errorForeground, #f48771); }
+  #active-tool {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    min-height: 14px;
+    font-style: italic;
+  }
+
+  /* Controls */
+  #controls {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+  }
+  button {
+    font-size: 11px;
+    padding: 2px 8px;
+    border: 1px solid var(--vscode-button-border, transparent);
+    border-radius: 2px;
+    cursor: pointer;
+    background: var(--vscode-button-secondaryBackground);
+    color: var(--vscode-button-secondaryForeground);
+  }
+  button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+  button.primary {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+  }
+  button.primary:hover { background: var(--vscode-button-hoverBackground); }
+  button:disabled { opacity: 0.4; cursor: default; }
+
+  /* Event list */
+  #events {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 0;
+  }
+  .event {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    gap: 4px;
+    padding: 3px 10px;
+    font-size: 11px;
+    line-height: 1.4;
+    border-bottom: 1px solid var(--vscode-sideBar-background);
+  }
+  .event:hover { background: var(--vscode-list-hoverBackground); }
+  .event.error { color: var(--vscode-errorForeground, #f48771); }
+  .event .icon { text-align: center; flex-shrink: 0; }
+  .event .summary {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--vscode-foreground);
+  }
+  .event.error .summary { color: var(--vscode-errorForeground, #f48771); }
+  .event .time {
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+    font-size: 10px;
+    align-self: center;
+  }
+
+  /* Empty state */
+  #empty {
+    padding: 20px 10px;
+    text-align: center;
+    color: var(--vscode-descriptionForeground);
+    font-size: 11px;
+    line-height: 1.6;
+  }
+
+  /* Session ended banner */
+  #ended-banner {
+    display: none;
+    padding: 4px 10px;
+    font-size: 11px;
+    background: var(--vscode-diffEditor-removedLineBackground, #3a1a1a);
+    color: var(--vscode-descriptionForeground);
+    text-align: center;
+    flex-shrink: 0;
+  }
+</style>
+</head>
+<body>
+
+<div id="header">
+  <div id="stats">
+    <span class="cost" id="stat-cost">$0.0000</span>
+    <span id="stat-calls">0 calls</span>
+    <span class="errors" id="stat-errors" style="display:none">0 errors</span>
+    <span id="stat-session" style="color:var(--vscode-descriptionForeground)"></span>
+  </div>
+  <div id="active-tool"></div>
+  <div id="controls">
+    <button class="primary" id="btn-pause" onclick="sendPause()" disabled>Pause</button>
+    <button id="btn-resume" onclick="sendResume()" style="display:none">Resume</button>
+    <button id="btn-clear" onclick="clearEvents()">Clear</button>
+  </div>
+</div>
+
+<div id="ended-banner">Session ended</div>
+
+<div id="events">
+  <div id="empty">No active session.<br>Start an agent with <code>agent-strace setup</code>.</div>
+</div>
+
+<script>
+  const vscode = acquireVsCodeApi();
+  const eventsEl = document.getElementById('events');
+  const emptyEl = document.getElementById('empty');
+  const endedBanner = document.getElementById('ended-banner');
+  let eventCount = 0;
+  let paused = false;
+
+  function sendPause() { vscode.postMessage({ command: 'pause' }); }
+  function sendResume() { vscode.postMessage({ command: 'resume' }); }
+  function clearEvents() {
+    eventsEl.innerHTML = '';
+    eventCount = 0;
+    emptyEl.style.display = 'block';
+    eventsEl.appendChild(emptyEl);
+  }
+
+  window.addEventListener('message', (e) => {
+    const msg = e.data;
+
+    if (msg.type === 'reset') {
+      clearEvents();
+      endedBanner.style.display = 'none';
+      document.getElementById('btn-pause').disabled = false;
+      return;
+    }
+
+    if (msg.type === 'sessionEnd') {
+      endedBanner.style.display = 'block';
+      document.getElementById('btn-pause').disabled = true;
+      document.getElementById('btn-resume').style.display = 'none';
+      document.getElementById('btn-pause').style.display = 'inline-block';
+      return;
+    }
+
+    if (msg.type === 'state') {
+      document.getElementById('stat-cost').textContent = '$' + msg.cost;
+      document.getElementById('stat-calls').textContent = msg.toolCalls + ' calls';
+      const errEl = document.getElementById('stat-errors');
+      if (msg.errors > 0) {
+        errEl.textContent = msg.errors + ' error' + (msg.errors > 1 ? 's' : '');
+        errEl.style.display = 'inline';
+      } else {
+        errEl.style.display = 'none';
+      }
+      if (msg.sessionId) {
+        document.getElementById('stat-session').textContent = msg.sessionId + '…';
+      }
+      const toolEl = document.getElementById('active-tool');
+      toolEl.textContent = msg.activeTool ? '⟳ ' + msg.activeTool : '';
+
+      paused = msg.paused;
+      const pauseBtn = document.getElementById('btn-pause');
+      const resumeBtn = document.getElementById('btn-resume');
+      if (paused) {
+        pauseBtn.style.display = 'none';
+        resumeBtn.style.display = 'inline-block';
+      } else {
+        pauseBtn.style.display = 'inline-block';
+        resumeBtn.style.display = 'none';
+      }
+      return;
+    }
+
+    if (msg.type === 'event') {
+      emptyEl.style.display = 'none';
+      eventCount++;
+
+      const row = document.createElement('div');
+      row.className = 'event' + (msg.isError ? ' error' : '');
+
+      const icon = document.createElement('span');
+      icon.className = 'icon';
+      icon.textContent = msg.icon;
+
+      const summary = document.createElement('span');
+      summary.className = 'summary';
+      summary.textContent = msg.summary || msg.eventType;
+      summary.title = msg.summary || msg.eventType;
+
+      const time = document.createElement('span');
+      time.className = 'time';
+      time.textContent = msg.time;
+
+      row.appendChild(icon);
+      row.appendChild(summary);
+      row.appendChild(time);
+      eventsEl.appendChild(row);
+
+      // Auto-scroll to bottom
+      eventsEl.scrollTop = eventsEl.scrollHeight;
+    }
+  });
+</script>
+</body>
+</html>`;
+  }
+}

--- a/vscode-extension/src/pauseAgent.ts
+++ b/vscode-extension/src/pauseAgent.ts
@@ -1,0 +1,60 @@
+/**
+ * Pause / resume the active agent session.
+ *
+ * Uses a signal file (.agent-traces/.pause-request) that watch.py polls.
+ * Writing the file requests a pause; deleting it requests a resume.
+ * This avoids needing a daemon or direct process access from the extension.
+ *
+ * watch.py checks for this file on every event loop iteration and calls
+ * SIGSTOP / SIGCONT on the agent PID accordingly.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { SessionState } from "./traceStore";
+
+export class PauseManager {
+  private traceDir: string;
+
+  constructor(traceDir: string) {
+    this.traceDir = traceDir;
+  }
+
+  private get pauseFile(): string {
+    return path.join(this.traceDir, ".pause-request");
+  }
+
+  pause(state: SessionState): void {
+    if (state.paused) { return; }
+    try {
+      fs.mkdirSync(this.traceDir, { recursive: true });
+      fs.writeFileSync(this.pauseFile, state.sessionId, "utf8");
+      state.paused = true;
+    } catch {
+      // Non-fatal — watch.py may not be running
+    }
+  }
+
+  resume(state: SessionState): void {
+    if (!state.paused) { return; }
+    try {
+      if (fs.existsSync(this.pauseFile)) {
+        fs.unlinkSync(this.pauseFile);
+      }
+      state.paused = false;
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  /** Clean up signal file on extension deactivation. */
+  cleanup(): void {
+    try {
+      if (fs.existsSync(this.pauseFile)) {
+        fs.unlinkSync(this.pauseFile);
+      }
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/vscode-extension/src/statusBar.ts
+++ b/vscode-extension/src/statusBar.ts
@@ -1,0 +1,55 @@
+/**
+ * Status bar item showing live session cost, tool call count, and active tool.
+ *
+ * Idle (no session): hidden.
+ * Active session:    "$(pulse) agent  $0.0042  47 calls  [Read]"
+ * Paused session:    "$(debug-pause) agent  PAUSED"
+ */
+
+import * as vscode from "vscode";
+import { SessionState } from "./traceStore";
+
+export class StatusBarManager extends vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+
+  constructor() {
+    super(() => this.dispose());
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      100
+    );
+    this.item.command = "agentTrace.openPanel";
+    this.item.tooltip = "agent-trace — click to open event stream";
+  }
+
+  update(state: SessionState | null): void {
+    if (!state) {
+      this.item.hide();
+      return;
+    }
+
+    const cost = `$${state.estimatedCostUsd.toFixed(4)}`;
+    const calls = `${state.toolCallCount} calls`;
+
+    if (state.paused) {
+      this.item.text = `$(debug-pause) agent  PAUSED`;
+      this.item.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.warningBackground"
+      );
+    } else {
+      const tool = state.activeTool ? `  [${state.activeTool}]` : "";
+      this.item.text = `$(pulse) agent  ${cost}  ${calls}${tool}`;
+      this.item.backgroundColor = undefined;
+    }
+
+    this.item.show();
+  }
+
+  hide(): void {
+    this.item.hide();
+  }
+
+  override dispose(): void {
+    this.item.dispose();
+  }
+}

--- a/vscode-extension/src/traceStore.ts
+++ b/vscode-extension/src/traceStore.ts
@@ -1,0 +1,393 @@
+/**
+ * Watches the agent-trace store for live session activity.
+ *
+ * Reads .agent-traces/.active-session to find the current session,
+ * then tails events.ndjson for new events. Emits typed events that
+ * the rest of the extension subscribes to.
+ *
+ * Zero polling when no session is active — uses fs.watch on the
+ * .active-session file and the events.ndjson file.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+// ---------------------------------------------------------------------------
+// Types mirroring agent-trace's Python models
+// ---------------------------------------------------------------------------
+
+export type EventType =
+  | "session_start"
+  | "session_end"
+  | "tool_call"
+  | "tool_result"
+  | "llm_request"
+  | "llm_response"
+  | "file_read"
+  | "file_write"
+  | "decision"
+  | "error"
+  | "user_prompt"
+  | "assistant_response";
+
+export interface TraceEvent {
+  event_type: EventType;
+  timestamp: number;
+  event_id: string;
+  session_id: string;
+  parent_id?: string;
+  duration_ms?: number;
+  data: Record<string, unknown>;
+}
+
+export interface SessionMeta {
+  session_id: string;
+  started_at: number;
+  ended_at?: number;
+  agent_name?: string;
+  command?: string;
+  tool_calls: number;
+  errors: number;
+  total_tokens: number;
+}
+
+/** Aggregated per-file access counts for the current session. */
+export interface FileAccess {
+  reads: number;
+  writes: number;
+}
+
+/** Live state derived from the current session's events. */
+export interface SessionState {
+  sessionId: string;
+  meta: SessionMeta;
+  /** Absolute path -> access counts */
+  fileAccess: Map<string, FileAccess>;
+  toolCallCount: number;
+  errorCount: number;
+  estimatedCostUsd: number;
+  activeTool: string | null;
+  paused: boolean;
+  events: TraceEvent[];
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimation (mirrors cost.py heuristic: len/4 tokens, sonnet pricing)
+// ---------------------------------------------------------------------------
+
+const INPUT_PRICE_PER_TOKEN = 3.0 / 1_000_000;   // $3 / 1M input tokens
+const OUTPUT_PRICE_PER_TOKEN = 15.0 / 1_000_000;  // $15 / 1M output tokens
+
+function estimateEventCost(event: TraceEvent): number {
+  const payload = JSON.stringify(event.data);
+  const tokens = Math.floor(payload.length / 4);
+  if (event.event_type === "llm_request") {
+    return tokens * INPUT_PRICE_PER_TOKEN;
+  }
+  if (event.event_type === "llm_response" || event.event_type === "assistant_response") {
+    return tokens * OUTPUT_PRICE_PER_TOKEN;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// TraceWatcher
+// ---------------------------------------------------------------------------
+
+export class TraceWatcher extends vscode.Disposable {
+  private readonly _onSessionStart = new vscode.EventEmitter<SessionState>();
+  private readonly _onSessionEnd = new vscode.EventEmitter<SessionState>();
+  private readonly _onEvent = new vscode.EventEmitter<{ state: SessionState; event: TraceEvent }>();
+  private readonly _onStateChange = new vscode.EventEmitter<SessionState>();
+
+  readonly onSessionStart = this._onSessionStart.event;
+  readonly onSessionEnd = this._onSessionEnd.event;
+  readonly onEvent = this._onEvent.event;
+  readonly onStateChange = this._onStateChange.event;
+
+  private traceDir: string;
+  private activeSessionFile: string;
+  private currentSessionId: string | null = null;
+  private currentState: SessionState | null = null;
+  private eventsFileOffset = 0;
+
+  private activeSessionWatcher: fs.FSWatcher | null = null;
+  private eventsWatcher: fs.FSWatcher | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+
+  constructor(workspaceRoot: string, traceDir: string) {
+    super(() => this.dispose());
+    this.traceDir = path.isAbsolute(traceDir)
+      ? traceDir
+      : path.join(workspaceRoot, traceDir);
+    this.activeSessionFile = path.join(this.traceDir, ".active-session");
+  }
+
+  /** Start watching. Call once after construction. */
+  start(): void {
+    this._watchActiveSessionFile();
+    // Check immediately in case a session is already running
+    this._checkActiveSession();
+  }
+
+  get state(): SessionState | null {
+    return this.currentState;
+  }
+
+  // -------------------------------------------------------------------------
+  // Active session file watcher
+  // -------------------------------------------------------------------------
+
+  private _watchActiveSessionFile(): void {
+    // Watch the parent directory so we catch creation of .active-session
+    const dir = this.traceDir;
+    if (!fs.existsSync(dir)) {
+      // Retry when the directory appears
+      this.pollTimer = setTimeout(() => this._watchActiveSessionFile(), 2000);
+      return;
+    }
+
+    try {
+      this.activeSessionWatcher = fs.watch(dir, (_event, filename) => {
+        if (filename === ".active-session") {
+          this._checkActiveSession();
+        }
+      });
+    } catch {
+      // Fall back to polling if fs.watch fails (e.g. network FS)
+      this.pollTimer = setInterval(() => this._checkActiveSession(), 1000);
+    }
+  }
+
+  private _checkActiveSession(): void {
+    const sessionId = this._readActiveSession();
+
+    if (sessionId && sessionId !== this.currentSessionId) {
+      this._startSession(sessionId);
+    } else if (!sessionId && this.currentSessionId) {
+      this._endSession();
+    }
+  }
+
+  private _readActiveSession(): string | null {
+    try {
+      if (!fs.existsSync(this.activeSessionFile)) { return null; }
+      const id = fs.readFileSync(this.activeSessionFile, "utf8").trim();
+      return id || null;
+    } catch {
+      return null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Session lifecycle
+  // -------------------------------------------------------------------------
+
+  private _startSession(sessionId: string): void {
+    this.currentSessionId = sessionId;
+    this.eventsFileOffset = 0;
+
+    const meta = this._loadMeta(sessionId);
+    this.currentState = {
+      sessionId,
+      meta,
+      fileAccess: new Map(),
+      toolCallCount: 0,
+      errorCount: 0,
+      estimatedCostUsd: 0,
+      activeTool: null,
+      paused: false,
+      events: [],
+    };
+
+    // Replay any events already written before we started watching
+    this._readNewEvents();
+
+    // Watch events.ndjson for appends
+    this._watchEventsFile(sessionId);
+
+    this._onSessionStart.fire(this.currentState);
+    this._onStateChange.fire(this.currentState);
+  }
+
+  private _endSession(): void {
+    if (!this.currentState) { return; }
+    this.eventsWatcher?.close();
+    this.eventsWatcher = null;
+    this.currentSessionId = null;
+    this._onSessionEnd.fire(this.currentState);
+    this.currentState = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Events file watcher
+  // -------------------------------------------------------------------------
+
+  private _watchEventsFile(sessionId: string): void {
+    const eventsFile = path.join(this.traceDir, sessionId, "events.ndjson");
+    if (!fs.existsSync(eventsFile)) { return; }
+
+    try {
+      this.eventsWatcher = fs.watch(eventsFile, () => {
+        this._readNewEvents();
+      });
+    } catch {
+      // Polling fallback
+      const timer = setInterval(() => {
+        if (this.currentSessionId !== sessionId) {
+          clearInterval(timer);
+          return;
+        }
+        this._readNewEvents();
+      }, 500);
+    }
+  }
+
+  private _readNewEvents(): void {
+    if (!this.currentSessionId || !this.currentState) { return; }
+
+    const eventsFile = path.join(
+      this.traceDir,
+      this.currentSessionId,
+      "events.ndjson"
+    );
+
+    let content: string;
+    try {
+      const buf = fs.readFileSync(eventsFile, "utf8");
+      content = buf.slice(this.eventsFileOffset);
+      this.eventsFileOffset = buf.length;
+    } catch {
+      return;
+    }
+
+    const lines = content.split("\n").filter((l) => l.trim());
+    for (const line of lines) {
+      try {
+        const event: TraceEvent = JSON.parse(line);
+        this._applyEvent(event);
+      } catch {
+        // malformed line — skip
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // State accumulation
+  // -------------------------------------------------------------------------
+
+  private _applyEvent(event: TraceEvent): void {
+    if (!this.currentState) { return; }
+    const s = this.currentState;
+
+    s.events.push(event);
+    s.estimatedCostUsd += estimateEventCost(event);
+
+    switch (event.event_type) {
+      case "tool_call": {
+        s.toolCallCount++;
+        const toolName = (event.data.tool_name as string) ?? "";
+        s.activeTool = toolName;
+        // Extract file paths from Claude Code hook tool calls (Read/Write/Edit/etc.)
+        this._extractToolFilePaths(event);
+        break;
+      }
+      case "tool_result": {
+        s.activeTool = null;
+        break;
+      }
+      case "file_read": {
+        const p = this._resolveFilePath(event.data.path as string);
+        if (p) {
+          const acc = s.fileAccess.get(p) ?? { reads: 0, writes: 0 };
+          acc.reads++;
+          s.fileAccess.set(p, acc);
+        }
+        break;
+      }
+      case "file_write": {
+        const p = this._resolveFilePath(event.data.path as string);
+        if (p) {
+          const acc = s.fileAccess.get(p) ?? { reads: 0, writes: 0 };
+          acc.writes++;
+          s.fileAccess.set(p, acc);
+        }
+        break;
+      }
+      case "error": {
+        s.errorCount++;
+        break;
+      }
+      case "session_end": {
+        s.activeTool = null;
+        break;
+      }
+    }
+
+    this._onEvent.fire({ state: s, event });
+    this._onStateChange.fire(s);
+  }
+
+  /**
+   * Claude Code hooks record file ops as tool_call events with tool_name
+   * Read/Write/Edit/Glob. Extract the file path from those.
+   */
+  private _extractToolFilePaths(event: TraceEvent): void {
+    if (!this.currentState) { return; }
+    const s = this.currentState;
+    const toolName = (event.data.tool_name as string ?? "").toLowerCase();
+    const args = (event.data.arguments as Record<string, unknown>) ?? {};
+
+    const filePath = (args.path ?? args.file_path ?? args.filename) as string | undefined;
+    if (!filePath) { return; }
+
+    const resolved = this._resolveFilePath(filePath);
+    if (!resolved) { return; }
+
+    const acc = s.fileAccess.get(resolved) ?? { reads: 0, writes: 0 };
+    if (["read", "view", "grep", "glob"].includes(toolName)) {
+      acc.reads++;
+    } else if (["write", "edit", "multiedit", "create"].includes(toolName)) {
+      acc.writes++;
+    }
+    s.fileAccess.set(resolved, acc);
+  }
+
+  private _resolveFilePath(p: string | undefined): string | null {
+    if (!p) { return null; }
+    if (path.isAbsolute(p)) { return p; }
+    // Relative paths — resolve against workspace root (parent of traceDir)
+    const workspaceRoot = path.dirname(this.traceDir);
+    return path.resolve(workspaceRoot, p);
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private _loadMeta(sessionId: string): SessionMeta {
+    const metaFile = path.join(this.traceDir, sessionId, "meta.json");
+    try {
+      return JSON.parse(fs.readFileSync(metaFile, "utf8")) as SessionMeta;
+    } catch {
+      return {
+        session_id: sessionId,
+        started_at: Date.now() / 1000,
+        tool_calls: 0,
+        errors: 0,
+        total_tokens: 0,
+      };
+    }
+  }
+
+  override dispose(): void {
+    this.activeSessionWatcher?.close();
+    this.eventsWatcher?.close();
+    if (this.pollTimer) { clearTimeout(this.pollTimer); }
+    this._onSessionStart.dispose();
+    this._onSessionEnd.dispose();
+    this._onEvent.dispose();
+    this._onStateChange.dispose();
+  }
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "./out",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary

Closes #49.

Adds a VS Code / Cursor extension (`vscode-extension/`) that shows agent-trace session activity directly in the editor — no alt-tabbing to a terminal.

## Features

**Status bar** — live cost, tool call count, and active tool name on every event. Click to open the event stream panel.

```
$(pulse) agent  $0.0042  47 calls  [Read]
```

**Gutter annotations** — files the agent has read or modified get a colored left border and inline label at the top of the file.

```
src/auth/middleware.ts  ← agent read 3×, modified 1× this session
src/db/schema.ts        ← agent read 1× this session
```

Read-only files: blue border. Modified files: amber border.

**Event stream panel** — live feed in the Explorer sidebar showing every tool call, file op, LLM request, and error. Same information as `agent-strace watch` but in the editor. Includes a Pause / Resume button.

**Pause agent** — writes `.agent-traces/.pause-request`; `watch.py` picks it up on its next poll cycle and sends SIGSTOP / SIGCONT to the agent process. Requires `agent-strace watch` to be running alongside the session.

## How it works

- Watches `.agent-traces/.active-session` via `fs.watch` — zero overhead when no session is active
- Tails `events.ndjson` for new lines as they are appended
- Falls back to polling if `fs.watch` is unavailable (network FS)
- Activates automatically on `workspaceContains:.agent-traces`

## Changes

- `vscode-extension/` — new extension (TypeScript, VS Code API)
- `src/agent_trace/watch.py` — adds `_check_pause_file()` called on every idle poll cycle to honour pause/resume requests from the extension

## Before packaging

```bash
cd vscode-extension
npm install
npm run compile   # outputs to out/
npx vsce package  # produces agent-trace-*.vsix
```