### PR TITLE
ci: release automation — auto-bump version and create GitHub Release on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip if the commit is itself a version bump (prevents infinite loop)
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version to')"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(grep '^__version__' src/agent_trace/__init__.py | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next patch version
+        id: next
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version in source
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          sed -i "s/__version__ = \".*\"/__version__ = \"${NEXT}\"/" src/agent_trace/__init__.py
+
+      - name: Build changelog from commits since last tag
+        id: changelog
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"- %s" | head -20)
+          else
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s")
+          fi
+          # Write to file to preserve newlines
+          echo "$COMMITS" > /tmp/changelog.txt
+          echo "Changelog entries written."
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/agent_trace/__init__.py
+          git commit -m "chore: bump version to ${{ steps.next.outputs.version }}"
+          git push
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          TAG="v${NEXT}"
+          TITLE="v${NEXT}"
+          BODY=$(cat /tmp/changelog.txt)
+
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes "$BODY" \
+            --target main


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — a workflow that runs on every push to `main` and:

1. Reads the current version from `src/agent_trace/__init__.py`
2. Computes the next patch version (e.g. `0.32.0` → `0.32.1`)
3. Bumps the version in source and commits it back to `main`
4. Builds a changelog from commits since the last tag
5. Creates a GitHub Release tagged `vX.Y.Z` with that changelog as the body

The existing `publish.yml` (PyPI) and `publish-vscode.yml` (VS Code Marketplace) both trigger on `release: published`, so they continue to work without any changes.

## Why

Every subsequent PR in this batch (drift, dashboard --trend, optimize, Langfuse export) needs a release to ship. This workflow means merging a PR to `main` is sufficient — no manual tagging or release creation required.

## Guard against infinite loop

The workflow skips itself when the triggering commit message starts with `chore: bump version to`, which is the exact message the workflow uses for its own commit.

## Checklist

- [x] Workflow file added
- [x] Skips on version bump commits (no infinite loop)
- [x] Compatible with existing PyPI and VS Code publish workflows
- [x] Uses `GITHUB_TOKEN` (no new secrets required)