### PR TITLE
feat: behavioral drift detection (agent-strace drift)

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -24,6 +24,7 @@ from .hooks import hook_main
 from .http_proxy import HTTPProxyServer
 from .a2a import cmd_a2a_tree
 from .annotate import cmd_annotate
+from .drift import cmd_drift
 from .oncall import cmd_oncall
 from .freshness import cmd_freshness
 from .standup import cmd_standup
@@ -654,6 +655,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_fresh.add_argument("--scope", default="", help="file glob to limit scope")
     p_fresh.add_argument("--repo", default=".", help="path to git repository (default: .)")
 
+    # drift (behavioral drift detection)
+    p_drift = sub.add_parser("drift", help="detect behavioral drift across sessions")
+    p_drift.add_argument("--since", metavar="Nd", help="analyse sessions from the last N days (e.g. 30d)")
+    p_drift.add_argument("--baseline", metavar="FILE",
+                         help="path to a saved behavioral fingerprint JSON, or a date range YYYY-MM-DD:YYYY-MM-DD")
+    p_drift.add_argument("--current", metavar="RANGE",
+                         help="current window as YYYY-MM-DD:YYYY-MM-DD")
+    p_drift.add_argument("--baseline-range", metavar="RANGE", dest="baseline_range",
+                         help="baseline window as YYYY-MM-DD:YYYY-MM-DD")
+    p_drift.add_argument("--save-baseline", metavar="FILE", dest="save_baseline",
+                         help="save current fingerprint to FILE and exit")
+    p_drift.add_argument("--threshold", type=float, default=0.20,
+                         help="drift score above which to alert (default: 0.20)")
+    p_drift.add_argument("--format", choices=["table", "json"], default="table",
+                         help="output format (default: table)")
+
     # standup (agent standup report)
     p_standup = sub.add_parser("standup", help="plain-English summary of what the agent did")
     p_standup.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
@@ -714,6 +731,7 @@ def main() -> None:
         "curve": cmd_curve,
         "inflation": cmd_inflation,
         "a2a-tree": cmd_a2a_tree,
+        "drift": cmd_drift,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,
         "standup": cmd_standup,

--- a/src/agent_trace/drift.py
+++ b/src/agent_trace/drift.py
@@ -1,0 +1,542 @@
+"""Behavioral drift detection across agent sessions.
+
+Computes a behavioral fingerprint (distribution of tool mix, error rate,
+retry pattern, blast radius, session duration, decision depth) for a window
+of sessions and measures how much that distribution has shifted compared to
+a baseline window.
+
+Distance metric: Jensen-Shannon divergence, normalized to [0, 1].
+No LLM required. All analysis is structural.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TextIO
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DistStats:
+    mean: float = 0.0
+    p50: float = 0.0
+    p95: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {"mean": round(self.mean, 4), "p50": round(self.p50, 4), "p95": round(self.p95, 4)}
+
+
+@dataclass
+class BehavioralFingerprint:
+    fingerprint_id: str = ""
+    sessions: int = 0
+    period_start: str = ""
+    period_end: str = ""
+    # Tool mix: fraction of tool calls per tool name
+    tool_mix: dict[str, float] = field(default_factory=dict)
+    # Per-session distributions
+    error_rate: DistStats = field(default_factory=DistStats)
+    retry_rate: DistStats = field(default_factory=DistStats)
+    blast_radius: DistStats = field(default_factory=DistStats)
+    session_duration_s: DistStats = field(default_factory=DistStats)
+    decision_depth: DistStats = field(default_factory=DistStats)
+
+    def to_dict(self) -> dict:
+        return {
+            "fingerprint_id": self.fingerprint_id,
+            "sessions": self.sessions,
+            "period": {"start": self.period_start, "end": self.period_end},
+            "tool_mix": {k: round(v, 4) for k, v in self.tool_mix.items()},
+            "error_rate": self.error_rate.to_dict(),
+            "retry_rate": self.retry_rate.to_dict(),
+            "blast_radius": self.blast_radius.to_dict(),
+            "session_duration_s": self.session_duration_s.to_dict(),
+            "decision_depth": self.decision_depth.to_dict(),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "BehavioralFingerprint":
+        d = json.loads(text)
+        fp = cls(
+            fingerprint_id=d.get("fingerprint_id", ""),
+            sessions=d.get("sessions", 0),
+            period_start=d.get("period", {}).get("start", ""),
+            period_end=d.get("period", {}).get("end", ""),
+            tool_mix=d.get("tool_mix", {}),
+        )
+        for attr in ("error_rate", "retry_rate", "blast_radius", "session_duration_s", "decision_depth"):
+            raw = d.get(attr, {})
+            setattr(fp, attr, DistStats(
+                mean=raw.get("mean", 0.0),
+                p50=raw.get("p50", 0.0),
+                p95=raw.get("p95", 0.0),
+            ))
+        return fp
+
+
+@dataclass
+class DimensionDrift:
+    name: str
+    score: float          # 0.0 = identical, 1.0 = maximally different
+    label: str            # "stable" / "moderate" / "high"
+    baseline_summary: str = ""
+    current_summary: str = ""
+
+
+@dataclass
+class DriftReport:
+    overall_score: float
+    threshold: float
+    baseline_sessions: int
+    current_sessions: int
+    baseline_period: str
+    current_period: str
+    dimensions: list[DimensionDrift]
+
+    @property
+    def label(self) -> str:
+        if self.overall_score < self.threshold * 0.5:
+            return "stable"
+        if self.overall_score < self.threshold:
+            return "moderate"
+        return "high"
+
+    @property
+    def exceeded(self) -> bool:
+        return self.overall_score >= self.threshold
+
+
+# ---------------------------------------------------------------------------
+# Statistical helpers
+# ---------------------------------------------------------------------------
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    sorted_v = sorted(values)
+    idx = (len(sorted_v) - 1) * p / 100.0
+    lo = int(idx)
+    hi = min(lo + 1, len(sorted_v) - 1)
+    frac = idx - lo
+    return sorted_v[lo] * (1 - frac) + sorted_v[hi] * frac
+
+
+def _dist_stats(values: list[float]) -> DistStats:
+    if not values:
+        return DistStats()
+    return DistStats(
+        mean=sum(values) / len(values),
+        p50=_percentile(values, 50),
+        p95=_percentile(values, 95),
+    )
+
+
+def _js_divergence(p: dict[str, float], q: dict[str, float]) -> float:
+    """Jensen-Shannon divergence between two probability distributions.
+
+    Both dicts map category -> probability. Missing keys treated as 0.
+    Returns a value in [0, 1] (normalized by log(2)).
+    """
+    keys = set(p) | set(q)
+    if not keys:
+        return 0.0
+
+    # Normalize to ensure they sum to 1
+    p_sum = sum(p.values()) or 1.0
+    q_sum = sum(q.values()) or 1.0
+    pn = {k: p.get(k, 0.0) / p_sum for k in keys}
+    qn = {k: q.get(k, 0.0) / q_sum for k in keys}
+
+    m = {k: (pn[k] + qn[k]) / 2.0 for k in keys}
+
+    def kl(a: dict, b: dict) -> float:
+        total = 0.0
+        for k in keys:
+            av = a.get(k, 0.0)
+            bv = b.get(k, 0.0)
+            if av > 0 and bv > 0:
+                total += av * math.log(av / bv)
+        return total
+
+    jsd = (kl(pn, m) + kl(qn, m)) / 2.0
+    # Normalize: max JSD is log(2) for binary distributions
+    return min(1.0, jsd / math.log(2)) if jsd > 0 else 0.0
+
+
+def _stats_divergence(a: DistStats, b: DistStats) -> float:
+    """Approximate divergence between two DistStats using mean/p50/p95."""
+    if a.mean == 0 and b.mean == 0:
+        return 0.0
+    diffs = []
+    for av, bv in [(a.mean, b.mean), (a.p50, b.p50), (a.p95, b.p95)]:
+        denom = max(abs(av), abs(bv), 1e-9)
+        diffs.append(abs(av - bv) / denom)
+    return min(1.0, sum(diffs) / len(diffs))
+
+
+def _drift_label(score: float, threshold: float) -> str:
+    if score < threshold * 0.5:
+        return "stable"
+    if score < threshold:
+        return "moderate"
+    return "high"
+
+
+# ---------------------------------------------------------------------------
+# Per-session metrics extraction
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionMetrics:
+    session_id: str
+    started_at: float
+    duration_s: float
+    tool_mix: dict[str, int]   # tool_name -> count
+    error_count: int
+    total_tool_calls: int
+    retry_count: int
+    blast_radius: int          # distinct files written
+    decision_count: int
+
+
+def _extract_metrics(session_id: str, events: list[TraceEvent], meta_started: float) -> SessionMetrics:
+    tool_mix: dict[str, int] = {}
+    error_count = 0
+    total_tool_calls = 0
+    retry_count = 0
+    files_written: set[str] = set()
+    decision_count = 0
+
+    prev_tool: str | None = None
+    prev_tool_count = 0
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            name = ev.data.get("tool_name", "unknown")
+            tool_mix[name] = tool_mix.get(name, 0) + 1
+            total_tool_calls += 1
+            # Detect retry: same tool called consecutively
+            if name == prev_tool:
+                prev_tool_count += 1
+                if prev_tool_count >= 2:
+                    retry_count += 1
+            else:
+                prev_tool = name
+                prev_tool_count = 1
+
+        elif ev.event_type in (EventType.FILE_WRITE,):
+            path = ev.data.get("path") or ev.data.get("file_path") or ""
+            if path:
+                files_written.add(path)
+
+        elif ev.event_type == EventType.ERROR:
+            error_count += 1
+
+        elif ev.event_type == EventType.DECISION:
+            decision_count += 1
+
+    duration_s = 0.0
+    if events:
+        duration_s = events[-1].timestamp - events[0].timestamp
+
+    return SessionMetrics(
+        session_id=session_id,
+        started_at=meta_started,
+        duration_s=duration_s,
+        tool_mix=tool_mix,
+        error_count=error_count,
+        total_tool_calls=total_tool_calls,
+        retry_count=retry_count,
+        blast_radius=len(files_written),
+        decision_count=decision_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint computation
+# ---------------------------------------------------------------------------
+
+def compute_fingerprint(
+    store: TraceStore,
+    session_ids: list[str],
+    fingerprint_id: str = "",
+) -> BehavioralFingerprint:
+    if not session_ids:
+        return BehavioralFingerprint(fingerprint_id=fingerprint_id)
+
+    all_metrics: list[SessionMetrics] = []
+    timestamps: list[float] = []
+
+    for sid in session_ids:
+        try:
+            meta = store.load_meta(sid)
+            events = store.load_events(sid)
+            m = _extract_metrics(sid, events, meta.started_at)
+            all_metrics.append(m)
+            timestamps.append(meta.started_at)
+        except Exception:
+            continue
+
+    if not all_metrics:
+        return BehavioralFingerprint(fingerprint_id=fingerprint_id)
+
+    # Aggregate tool mix across all sessions
+    combined_tool_mix: dict[str, int] = {}
+    for m in all_metrics:
+        for tool, count in m.tool_mix.items():
+            combined_tool_mix[tool] = combined_tool_mix.get(tool, 0) + count
+    total_calls = sum(combined_tool_mix.values()) or 1
+    tool_mix_frac = {k: v / total_calls for k, v in combined_tool_mix.items()}
+
+    # Per-session rate distributions
+    error_rates = [
+        m.error_count / max(m.total_tool_calls, 1) for m in all_metrics
+    ]
+    retry_rates = [
+        m.retry_count / max(m.total_tool_calls, 1) for m in all_metrics
+    ]
+    blast_radii = [float(m.blast_radius) for m in all_metrics]
+    durations = [m.duration_s for m in all_metrics]
+    decisions = [float(m.decision_count) for m in all_metrics]
+
+    period_start = datetime.fromtimestamp(min(timestamps), tz=timezone.utc).strftime("%Y-%m-%d")
+    period_end = datetime.fromtimestamp(max(timestamps), tz=timezone.utc).strftime("%Y-%m-%d")
+
+    return BehavioralFingerprint(
+        fingerprint_id=fingerprint_id or f"fp_{period_start}",
+        sessions=len(all_metrics),
+        period_start=period_start,
+        period_end=period_end,
+        tool_mix=tool_mix_frac,
+        error_rate=_dist_stats(error_rates),
+        retry_rate=_dist_stats(retry_rates),
+        blast_radius=_dist_stats(blast_radii),
+        session_duration_s=_dist_stats(durations),
+        decision_depth=_dist_stats(decisions),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift computation
+# ---------------------------------------------------------------------------
+
+def compute_drift(
+    baseline: BehavioralFingerprint,
+    current: BehavioralFingerprint,
+    threshold: float = 0.20,
+) -> DriftReport:
+    dimensions: list[DimensionDrift] = []
+
+    # Tool mix (JS divergence on distributions)
+    tool_score = _js_divergence(baseline.tool_mix, current.tool_mix)
+    dimensions.append(DimensionDrift(
+        name="tool_mix",
+        score=round(tool_score, 3),
+        label=_drift_label(tool_score, threshold),
+        baseline_summary=_top_tools(baseline.tool_mix),
+        current_summary=_top_tools(current.tool_mix),
+    ))
+
+    # Scalar distributions (approximate divergence via stats)
+    for attr, label in [
+        ("error_rate", "error_rate"),
+        ("retry_rate", "retry_rate"),
+        ("blast_radius", "blast_radius"),
+        ("session_duration_s", "session_duration"),
+        ("decision_depth", "decision_depth"),
+    ]:
+        b_stat: DistStats = getattr(baseline, attr)
+        c_stat: DistStats = getattr(current, attr)
+        score = _stats_divergence(b_stat, c_stat)
+        dimensions.append(DimensionDrift(
+            name=attr,
+            score=round(score, 3),
+            label=_drift_label(score, threshold),
+            baseline_summary=f"mean={b_stat.mean:.2f} p50={b_stat.p50:.2f} p95={b_stat.p95:.2f}",
+            current_summary=f"mean={c_stat.mean:.2f} p50={c_stat.p50:.2f} p95={c_stat.p95:.2f}",
+        ))
+
+    # Weighted average (tool_mix weighted 2x, others 1x)
+    weights = [2.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    overall = sum(d.score * w for d, w in zip(dimensions, weights)) / sum(weights)
+
+    return DriftReport(
+        overall_score=round(overall, 3),
+        threshold=threshold,
+        baseline_sessions=baseline.sessions,
+        current_sessions=current.sessions,
+        baseline_period=f"{baseline.period_start} to {baseline.period_end}",
+        current_period=f"{current.period_start} to {current.period_end}",
+        dimensions=dimensions,
+    )
+
+
+def _top_tools(tool_mix: dict[str, float], n: int = 3) -> str:
+    top = sorted(tool_mix.items(), key=lambda x: x[1], reverse=True)[:n]
+    return ", ".join(f"{k}={v:.0%}" for k, v in top)
+
+
+# ---------------------------------------------------------------------------
+# Session filtering helpers
+# ---------------------------------------------------------------------------
+
+def _sessions_in_window(store: TraceStore, since_days: float) -> list[str]:
+    import time
+    cutoff = time.time() - since_days * 86400
+    result = []
+    for meta in store.list_sessions():
+        if meta.started_at >= cutoff:
+            result.append(meta.session_id)
+    return result
+
+
+def _sessions_in_range(store: TraceStore, start_ts: float, end_ts: float) -> list[str]:
+    result = []
+    for meta in store.list_sessions():
+        if start_ts <= meta.started_at <= end_ts:
+            result.append(meta.session_id)
+    return result
+
+
+def _parse_date_range(s: str) -> tuple[float, float]:
+    """Parse 'YYYY-MM-DD:YYYY-MM-DD' into (start_ts, end_ts)."""
+    parts = s.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Expected 'YYYY-MM-DD:YYYY-MM-DD', got: {s!r}")
+    start = datetime.strptime(parts[0].strip(), "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp()
+    end = datetime.strptime(parts[1].strip(), "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp() + 86399
+    return start, end
+
+
+# ---------------------------------------------------------------------------
+# Terminal output
+# ---------------------------------------------------------------------------
+
+ICON = {"stable": "✅", "moderate": "⚠️ ", "high": "❌"}
+
+
+def print_report(report: DriftReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    w("\nBehavioral drift report\n")
+    w(f"Baseline: {report.baseline_period} ({report.baseline_sessions} sessions)\n")
+    w(f"Current:  {report.current_period} ({report.current_sessions} sessions)\n")
+    w("─" * 70 + "\n")
+
+    icon = ICON.get(report.label, "")
+    w(f"Overall drift score: {report.overall_score:.2f}  {icon}  {report.label.upper()}"
+      f"  (threshold: {report.threshold:.2f})\n\n")
+
+    w(f"  {'Dimension':<22} {'Score':>6}  Status\n")
+    w("─" * 70 + "\n")
+    for d in report.dimensions:
+        icon_d = ICON.get(d.label, "")
+        w(f"  {d.name:<22} {d.score:>6.3f}  {icon_d}  {d.label}\n")
+
+    w("\n")
+    high = [d for d in report.dimensions if d.label == "high"]
+    if high:
+        w("High-drift dimensions:\n\n")
+        for d in high:
+            w(f"  {d.name} ({d.score:.2f}):\n")
+            w(f"    Baseline: {d.baseline_summary}\n")
+            w(f"    Current:  {d.current_summary}\n\n")
+
+    if report.exceeded:
+        w("Suggested next step:\n")
+        w("  agent-strace dataset auto --name drift-failures --since 14d --filter has-errors\n")
+        w("  agent-strace eval --dataset drift-failures\n")
+    w("\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def cmd_drift(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    threshold = getattr(args, "threshold", 0.20)
+
+    # Resolve baseline fingerprint
+    baseline_fp: BehavioralFingerprint | None = None
+    baseline_path = getattr(args, "baseline", None)
+    if baseline_path and Path(baseline_path).exists():
+        baseline_fp = BehavioralFingerprint.from_json(Path(baseline_path).read_text())
+
+    # Resolve current session window
+    since_days = getattr(args, "since", None)
+    current_range = getattr(args, "current", None)
+    baseline_range = getattr(args, "baseline_range", None)
+
+    if current_range:
+        start, end = _parse_date_range(current_range)
+        current_ids = _sessions_in_range(store, start, end)
+    elif since_days:
+        days = float(since_days.rstrip("d"))
+        all_ids = _sessions_in_window(store, days)
+        # Split in half: first half = baseline (if no explicit baseline), second = current
+        mid = len(all_ids) // 2
+        if baseline_fp is None and not baseline_range:
+            baseline_ids = all_ids[mid:]   # older sessions (list is newest-first)
+            current_ids = all_ids[:mid]
+            baseline_fp = compute_fingerprint(store, baseline_ids, "baseline")
+        else:
+            current_ids = all_ids[:mid]
+    else:
+        sys.stderr.write("Specify --since Nd or --current YYYY-MM-DD:YYYY-MM-DD\n")
+        return 1
+
+    if baseline_range and baseline_fp is None:
+        start, end = _parse_date_range(baseline_range)
+        baseline_ids = _sessions_in_range(store, start, end)
+        baseline_fp = compute_fingerprint(store, baseline_ids, "baseline")
+
+    if baseline_fp is None:
+        sys.stderr.write("No baseline available. Use --baseline <file> or --since Nd.\n")
+        return 1
+
+    current_fp = compute_fingerprint(store, current_ids, "current")
+
+    # Save baseline if requested
+    save_path = getattr(args, "save_baseline", None)
+    if save_path:
+        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(save_path).write_text(current_fp.to_json())
+        sys.stdout.write(f"Behavioral fingerprint saved to {save_path}\n")
+        return 0
+
+    report = compute_drift(baseline_fp, current_fp, threshold=threshold)
+
+    fmt = getattr(args, "format", "table")
+    if fmt == "json":
+        data = {
+            "overall_score": report.overall_score,
+            "threshold": report.threshold,
+            "exceeded": report.exceeded,
+            "label": report.label,
+            "baseline_sessions": report.baseline_sessions,
+            "current_sessions": report.current_sessions,
+            "dimensions": [
+                {"name": d.name, "score": d.score, "label": d.label}
+                for d in report.dimensions
+            ],
+        }
+        sys.stdout.write(json.dumps(data, indent=2) + "\n")
+    else:
+        print_report(report)
+
+    return 1 if report.exceeded else 0

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,310 @@
+"""Tests for behavioral drift detection."""
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agent_trace.drift import (
+    BehavioralFingerprint,
+    DistStats,
+    SessionMetrics,
+    _dist_stats,
+    _js_divergence,
+    _stats_divergence,
+    compute_drift,
+    compute_fingerprint,
+    print_report,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store(tmp: str) -> TraceStore:
+    return TraceStore(tmp)
+
+
+def _add_session(store: TraceStore, session_id: str, events: list[TraceEvent], started_at: float | None = None) -> None:
+    ts = started_at or time.time()
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=ts,
+        ended_at=ts + 60,
+    )
+    store.create_session(meta)
+    for ev in events:
+        store.append_event(session_id, ev)
+
+
+def _tool_call(name: str, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.TOOL_CALL, timestamp=ts, data={"tool_name": name})
+
+
+def _error(ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.ERROR, timestamp=ts, data={"message": "fail"})
+
+
+def _decision(ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.DECISION, timestamp=ts, data={"choice": "A"})
+
+
+def _file_write(path: str, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.FILE_WRITE, timestamp=ts, data={"path": path})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: statistical helpers
+# ---------------------------------------------------------------------------
+
+class TestJsDivergence(unittest.TestCase):
+    def test_identical_distributions_zero(self):
+        p = {"a": 0.5, "b": 0.5}
+        self.assertAlmostEqual(_js_divergence(p, p), 0.0, places=5)
+
+    def test_completely_different_distributions(self):
+        p = {"a": 1.0}
+        q = {"b": 1.0}
+        score = _js_divergence(p, q)
+        self.assertAlmostEqual(score, 1.0, places=5)
+
+    def test_partial_overlap(self):
+        p = {"a": 0.7, "b": 0.3}
+        q = {"a": 0.3, "b": 0.7}
+        score = _js_divergence(p, q)
+        self.assertGreater(score, 0.0)
+        self.assertLess(score, 1.0)
+
+    def test_empty_distributions(self):
+        self.assertEqual(_js_divergence({}, {}), 0.0)
+
+    def test_one_empty(self):
+        p = {"a": 1.0}
+        score = _js_divergence(p, {})
+        self.assertGreater(score, 0.0)
+
+
+class TestStatsDivergence(unittest.TestCase):
+    def test_identical_stats_zero(self):
+        s = DistStats(mean=1.0, p50=1.0, p95=2.0)
+        self.assertAlmostEqual(_stats_divergence(s, s), 0.0, places=5)
+
+    def test_different_stats_nonzero(self):
+        a = DistStats(mean=1.0, p50=1.0, p95=2.0)
+        b = DistStats(mean=5.0, p50=5.0, p95=8.0)
+        score = _stats_divergence(a, b)
+        self.assertGreater(score, 0.0)
+
+    def test_both_zero(self):
+        s = DistStats(mean=0.0, p50=0.0, p95=0.0)
+        self.assertEqual(_stats_divergence(s, s), 0.0)
+
+
+class TestDistStats(unittest.TestCase):
+    def test_empty(self):
+        s = _dist_stats([])
+        self.assertEqual(s.mean, 0.0)
+
+    def test_single_value(self):
+        s = _dist_stats([5.0])
+        self.assertEqual(s.mean, 5.0)
+        self.assertEqual(s.p50, 5.0)
+        self.assertEqual(s.p95, 5.0)
+
+    def test_multiple_values(self):
+        s = _dist_stats([1.0, 2.0, 3.0, 4.0, 5.0])
+        self.assertAlmostEqual(s.mean, 3.0)
+        self.assertAlmostEqual(s.p50, 3.0)
+        self.assertGreaterEqual(s.p95, 4.0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: fingerprint computation
+# ---------------------------------------------------------------------------
+
+class TestComputeFingerprint(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def test_empty_sessions(self):
+        fp = compute_fingerprint(self.store, [])
+        self.assertEqual(fp.sessions, 0)
+
+    def test_single_session_tool_mix(self):
+        events = [
+            _tool_call("Bash", 0.0),
+            _tool_call("Bash", 1.0),
+            _tool_call("Read", 2.0),
+        ]
+        _add_session(self.store, "s1", events, started_at=time.time())
+        fp = compute_fingerprint(self.store, ["s1"])
+        self.assertEqual(fp.sessions, 1)
+        self.assertAlmostEqual(fp.tool_mix.get("Bash", 0), 2 / 3, places=3)
+        self.assertAlmostEqual(fp.tool_mix.get("Read", 0), 1 / 3, places=3)
+
+    def test_error_rate_computed(self):
+        events = [_tool_call("Bash"), _error(), _error()]
+        _add_session(self.store, "s2", events, started_at=time.time())
+        fp = compute_fingerprint(self.store, ["s2"])
+        # 2 errors / 1 tool call = 2.0 (capped at mean)
+        self.assertGreater(fp.error_rate.mean, 0.0)
+
+    def test_blast_radius_from_file_writes(self):
+        events = [
+            _file_write("src/a.py"),
+            _file_write("src/b.py"),
+            _file_write("src/a.py"),  # duplicate — should not count twice
+        ]
+        _add_session(self.store, "s3", events, started_at=time.time())
+        fp = compute_fingerprint(self.store, ["s3"])
+        self.assertEqual(fp.blast_radius.mean, 2.0)
+
+    def test_decision_depth(self):
+        events = [_decision(), _decision(), _decision()]
+        _add_session(self.store, "s4", events, started_at=time.time())
+        fp = compute_fingerprint(self.store, ["s4"])
+        self.assertEqual(fp.decision_depth.mean, 3.0)
+
+    def test_fingerprint_serialization_roundtrip(self):
+        events = [_tool_call("Bash"), _tool_call("Read")]
+        _add_session(self.store, "s5", events, started_at=time.time())
+        fp = compute_fingerprint(self.store, ["s5"], fingerprint_id="test_fp")
+        json_str = fp.to_json()
+        restored = BehavioralFingerprint.from_json(json_str)
+        self.assertEqual(restored.fingerprint_id, "test_fp")
+        self.assertEqual(restored.sessions, 1)
+        self.assertAlmostEqual(
+            restored.tool_mix.get("Bash", 0),
+            fp.tool_mix.get("Bash", 0),
+            places=3,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: drift computation
+# ---------------------------------------------------------------------------
+
+class TestComputeDrift(unittest.TestCase):
+    def _make_fp(self, tool_mix: dict, error_mean: float = 0.0) -> BehavioralFingerprint:
+        fp = BehavioralFingerprint(
+            fingerprint_id="test",
+            sessions=10,
+            period_start="2026-04-01",
+            period_end="2026-04-15",
+            tool_mix=tool_mix,
+            error_rate=DistStats(mean=error_mean, p50=error_mean, p95=error_mean * 2),
+            retry_rate=DistStats(),
+            blast_radius=DistStats(),
+            session_duration_s=DistStats(mean=60.0, p50=60.0, p95=90.0),
+            decision_depth=DistStats(),
+        )
+        return fp
+
+    def test_identical_fingerprints_low_drift(self):
+        fp = self._make_fp({"Bash": 0.5, "Read": 0.5})
+        report = compute_drift(fp, fp, threshold=0.20)
+        self.assertLess(report.overall_score, 0.05)
+        self.assertFalse(report.exceeded)
+
+    def test_completely_different_tool_mix_high_drift(self):
+        baseline = self._make_fp({"Bash": 1.0})
+        current = self._make_fp({"Read": 1.0})
+        report = compute_drift(baseline, current, threshold=0.20)
+        self.assertGreater(report.overall_score, 0.20)
+        self.assertTrue(report.exceeded)
+
+    def test_error_rate_drift_detected(self):
+        baseline = self._make_fp({"Bash": 0.5, "Read": 0.5}, error_mean=0.05)
+        current = self._make_fp({"Bash": 0.5, "Read": 0.5}, error_mean=0.50)
+        report = compute_drift(baseline, current, threshold=0.20)
+        error_dim = next(d for d in report.dimensions if d.name == "error_rate")
+        self.assertGreater(error_dim.score, 0.0)
+
+    def test_report_label_stable(self):
+        fp = self._make_fp({"Bash": 0.5, "Read": 0.5})
+        report = compute_drift(fp, fp, threshold=0.20)
+        self.assertEqual(report.label, "stable")
+
+    def test_report_label_high(self):
+        baseline = self._make_fp({"Bash": 1.0})
+        current = self._make_fp({"Read": 1.0})
+        report = compute_drift(baseline, current, threshold=0.20)
+        self.assertEqual(report.label, "high")
+
+    def test_all_dimensions_present(self):
+        fp = self._make_fp({"Bash": 1.0})
+        report = compute_drift(fp, fp)
+        names = {d.name for d in report.dimensions}
+        expected = {"tool_mix", "error_rate", "retry_rate", "blast_radius", "session_duration_s", "decision_depth"}
+        self.assertEqual(names, expected)
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end with store
+# ---------------------------------------------------------------------------
+
+class TestDriftEndToEnd(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def _populate(self, prefix: str, n: int, tool: str, ts_base: float) -> list[str]:
+        ids = []
+        for i in range(n):
+            sid = f"{prefix}_{i}"
+            events = [_tool_call(tool, ts_base + i * 10)]
+            _add_session(self.store, sid, events, started_at=ts_base + i * 10)
+            ids.append(sid)
+        return ids
+
+    def test_stable_sessions_low_drift(self):
+        now = time.time()
+        baseline_ids = self._populate("base", 5, "Bash", now - 200)
+        current_ids = self._populate("curr", 5, "Bash", now - 100)
+        baseline_fp = compute_fingerprint(self.store, baseline_ids)
+        current_fp = compute_fingerprint(self.store, current_ids)
+        report = compute_drift(baseline_fp, current_fp, threshold=0.20)
+        self.assertLess(report.overall_score, 0.20)
+
+    def test_shifted_tool_mix_high_drift(self):
+        now = time.time()
+        baseline_ids = self._populate("base2", 5, "Bash", now - 200)
+        current_ids = self._populate("curr2", 5, "Write", now - 100)
+        baseline_fp = compute_fingerprint(self.store, baseline_ids)
+        current_fp = compute_fingerprint(self.store, current_ids)
+        report = compute_drift(baseline_fp, current_fp, threshold=0.20)
+        self.assertGreater(report.overall_score, 0.20)
+
+    def test_print_report_no_crash(self):
+        import io
+        now = time.time()
+        baseline_ids = self._populate("base3", 3, "Bash", now - 200)
+        current_ids = self._populate("curr3", 3, "Read", now - 100)
+        baseline_fp = compute_fingerprint(self.store, baseline_ids)
+        current_fp = compute_fingerprint(self.store, current_ids)
+        report = compute_drift(baseline_fp, current_fp)
+        buf = io.StringIO()
+        print_report(report, out=buf)
+        output = buf.getvalue()
+        self.assertIn("drift", output.lower())
+        self.assertIn("overall", output.lower())
+
+    def test_fingerprint_save_and_load(self):
+        now = time.time()
+        ids = self._populate("fp_test", 3, "Bash", now - 100)
+        fp = compute_fingerprint(self.store, ids, fingerprint_id="saved_fp")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(fp.to_json())
+            path = f.name
+        loaded = BehavioralFingerprint.from_json(Path(path).read_text())
+        self.assertEqual(loaded.fingerprint_id, "saved_fp")
+        self.assertEqual(loaded.sessions, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `agent-strace drift` — a command that detects when agent behavior has shifted across sessions, without requiring an LLM.

Closes #70

## How it works

Computes a **behavioral fingerprint** for a window of sessions: a compact JSON summary of six behavioral dimensions. Then measures how much the current window's fingerprint has diverged from a baseline using Jensen-Shannon divergence.

**Six dimensions tracked:**

| Dimension | What it measures |
|---|---|
| `tool_mix` | Fraction of calls per tool type (Bash, Read, Write, etc.) |
| `error_rate` | Errors per session (mean, p50, p95) |
| `retry_rate` | Consecutive same-tool calls per session |
| `blast_radius` | Distinct files written per session |
| `session_duration_s` | Wall-clock time per session |
| `decision_depth` | `log_decision()` events per session |

Overall drift score: weighted average of per-dimension JSD, normalized to [0, 1]. `tool_mix` is weighted 2x (most sensitive signal).

## Usage

```
# Detect drift over the last 30 days (splits window in half automatically)
agent-strace drift --since 30d

# Compare against a saved baseline
agent-strace drift --baseline .agent-traces/baselines/behavior-main.json

# Save current fingerprint as baseline
agent-strace drift --since 30d --save-baseline .agent-traces/baselines/behavior-main.json

# JSON output for CI
agent-strace drift --since 30d --format json
```

Exits non-zero when drift score exceeds `--threshold` (default: 0.20).

## Files changed

- `src/agent_trace/drift.py` — new module: `BehavioralFingerprint`, `DriftReport`, `compute_fingerprint()`, `compute_drift()`, `print_report()`, `cmd_drift()`
- `src/agent_trace/cli.py` — `drift` subcommand wired in
- `tests/test_drift.py` — 27 tests covering statistical helpers, fingerprint computation, drift scoring, serialization, and end-to-end store integration

## Test results

```
Ran 593 tests in 3.4s — OK (27 new)
```