### PR TITLE
feat: visual eval trend dashboard (agent-strace dashboard --trend)

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -591,6 +591,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_dash.add_argument("--limit", type=int, default=50, help="max sessions to show (default: 50)")
     p_dash.add_argument("--agent", default="", help="filter by agent name")
     p_dash.add_argument("--output", "-o", help="write HTML dashboard to this file")
+    p_dash.add_argument("--trend", action="store_true",
+                        help="show quality and behavioral metrics over time")
+    p_dash.add_argument("--since", metavar="Nd",
+                        help="limit trend to sessions from the last N days (e.g. 30d)")
+    p_dash.add_argument("--html", metavar="FILE",
+                        help="write self-contained HTML trend report to FILE")
+    dash_sub = p_dash.add_subparsers(dest="dash_command")
+    p_dash_ann = dash_sub.add_parser("annotate", help="add a timeline annotation")
+    p_dash_ann.add_argument("--date", required=True, help="date in YYYY-MM-DD format")
+    p_dash_ann.add_argument("--note", required=True, help="annotation text")
 
     # annotate
     p_ann = sub.add_parser("annotate", help="attach notes, labels, and bookmarks to trace events")

--- a/src/agent_trace/dashboard.py
+++ b/src/agent_trace/dashboard.py
@@ -3,6 +3,11 @@
 Produces a terminal table and an optional self-contained HTML dashboard
 showing cost, duration, tool calls, errors, and trend lines across all
 (or a filtered set of) sessions.
+
+The --trend mode extends this with per-session eval scores (read from
+eval.json written by agent-strace eval), error/retry/cost sparklines
+over time, and timeline annotations for config changes or model upgrades.
+All charts are inline SVG — no CDN, no JavaScript libraries.
 """
 
 from __future__ import annotations
@@ -11,11 +16,13 @@ import argparse
 import html
 import json
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TextIO
 
-from .models import SessionMeta
+from .models import EventType, SessionMeta, TraceEvent
 from .store import TraceStore
 
 
@@ -46,6 +53,474 @@ class DashboardReport:
     total_errors: int
     avg_duration_s: float
     success_rate: float   # 0.0–1.0
+
+
+# ---------------------------------------------------------------------------
+# Trend data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvalScorePoint:
+    """A single judge's score for one session."""
+    judge: str
+    score: float
+    passed: bool
+
+
+@dataclass
+class TrendPoint:
+    """All metrics for a single session, used for trend charts."""
+    session_id: str
+    started_at: float
+    error_rate: float        # errors / tool_calls
+    retry_rate: float        # consecutive same-tool calls / tool_calls
+    cost: float
+    duration_s: float
+    eval_scores: list[EvalScorePoint] = field(default_factory=list)
+
+
+@dataclass
+class TrendAnnotation:
+    date: str    # YYYY-MM-DD
+    note: str
+
+
+@dataclass
+class TrendReport:
+    points: list[TrendPoint]
+    annotations: list[TrendAnnotation]
+    judge_names: list[str]   # all judges seen across sessions
+
+
+# ---------------------------------------------------------------------------
+# Annotation storage
+# ---------------------------------------------------------------------------
+
+_ANNOTATIONS_FILE = "annotations.jsonl"
+
+
+def _annotations_path(store: TraceStore) -> Path:
+    return store.base_dir / _ANNOTATIONS_FILE
+
+
+def load_annotations(store: TraceStore) -> list[TrendAnnotation]:
+    p = _annotations_path(store)
+    if not p.exists():
+        return []
+    result = []
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+            result.append(TrendAnnotation(date=d["date"], note=d["note"]))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return result
+
+
+def save_annotation(store: TraceStore, annotation: TrendAnnotation) -> None:
+    p = _annotations_path(store)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a") as f:
+        f.write(json.dumps({"date": annotation.date, "note": annotation.note}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Eval score reading
+# ---------------------------------------------------------------------------
+
+def _load_eval_scores(store: TraceStore, session_id: str) -> list[EvalScorePoint]:
+    eval_path = store.base_dir / session_id / "eval.json"
+    if not eval_path.exists():
+        return []
+    try:
+        data = json.loads(eval_path.read_text())
+        results = data.get("results") or data.get("judges") or []
+        points = []
+        for r in results:
+            name = r.get("scorer") or r.get("name") or "unknown"
+            score = float(r.get("score", 0.0))
+            passed = bool(r.get("passed", score >= r.get("threshold", 1.0)))
+            points.append(EvalScorePoint(judge=name, score=score, passed=passed))
+        return points
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Trend metrics extraction
+# ---------------------------------------------------------------------------
+
+def _extract_trend_point(
+    store: TraceStore,
+    meta: SessionMeta,
+) -> TrendPoint:
+    try:
+        events: list[TraceEvent] = store.load_events(meta.session_id)
+    except Exception:
+        events = []
+
+    tool_calls = 0
+    errors = 0
+    retries = 0
+    prev_tool: str | None = None
+    prev_count = 0
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            tool_calls += 1
+            name = ev.data.get("tool_name", "")
+            if name == prev_tool:
+                prev_count += 1
+                if prev_count >= 2:
+                    retries += 1
+            else:
+                prev_tool = name
+                prev_count = 1
+        elif ev.event_type == EventType.ERROR:
+            errors += 1
+
+    error_rate = errors / max(tool_calls, 1)
+    retry_rate = retries / max(tool_calls, 1)
+    cost = meta.total_tokens / 1_000_000 * 3.0
+    duration_s = meta.total_duration_ms / 1000 if meta.total_duration_ms else 0.0
+
+    eval_scores = _load_eval_scores(store, meta.session_id)
+
+    return TrendPoint(
+        session_id=meta.session_id,
+        started_at=meta.started_at,
+        error_rate=error_rate,
+        retry_rate=retry_rate,
+        cost=cost,
+        duration_s=duration_s,
+        eval_scores=eval_scores,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trend report builder
+# ---------------------------------------------------------------------------
+
+def build_trend_report(
+    store: TraceStore,
+    since_days: float | None = None,
+    limit: int = 200,
+) -> TrendReport:
+    all_meta = store.list_sessions()
+
+    if since_days is not None:
+        cutoff = time.time() - since_days * 86400
+        all_meta = [m for m in all_meta if m.started_at >= cutoff]
+
+    sessions = all_meta[:limit]
+    # Oldest first for charts
+    sessions = list(reversed(sessions))
+
+    points: list[TrendPoint] = []
+    judge_names: set[str] = set()
+
+    for meta in sessions:
+        pt = _extract_trend_point(store, meta)
+        points.append(pt)
+        for es in pt.eval_scores:
+            judge_names.add(es.judge)
+
+    annotations = load_annotations(store)
+
+    return TrendReport(
+        points=points,
+        annotations=annotations,
+        judge_names=sorted(judge_names),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Terminal trend summary
+# ---------------------------------------------------------------------------
+
+def format_trend_terminal(report: TrendReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    n = len(report.points)
+    if n == 0:
+        w("No sessions found.\n")
+        return
+
+    w(f"\nTrend report — {n} session{'s' if n != 1 else ''}\n")
+    w("─" * 60 + "\n\n")
+
+    # Eval score trends
+    if report.judge_names:
+        w("Quality trend (eval pass rate):\n")
+        mid = n // 2
+        for judge in report.judge_names:
+            def _pass_rate(pts: list[TrendPoint]) -> float:
+                scored = [p for p in pts if any(e.judge == judge for e in p.eval_scores)]
+                if not scored:
+                    return float("nan")
+                passed = sum(
+                    1 for p in scored
+                    if any(e.judge == judge and e.passed for e in p.eval_scores)
+                )
+                return passed / len(scored)
+
+            early = _pass_rate(report.points[:mid]) if mid > 0 else float("nan")
+            late = _pass_rate(report.points[mid:]) if mid < n else float("nan")
+
+            if early != early or late != late:  # nan check
+                w(f"  {judge:<30} (no eval scores)\n")
+            else:
+                delta = late - early
+                arrow = "↑" if delta > 0.01 else ("↓" if delta < -0.01 else "→")
+                w(f"  {judge:<30} {early*100:.0f}% → {late*100:.0f}%  {arrow} {delta*100:+.0f}pp\n")
+        w("\n")
+
+    # Behavioral trends
+    def _trend_line(values: list[float], label: str) -> None:
+        if not values:
+            return
+        mid = len(values) // 2
+        early_avg = sum(values[:mid]) / max(mid, 1)
+        late_avg = sum(values[mid:]) / max(len(values) - mid, 1)
+        delta = late_avg - early_avg
+        arrow = "↑" if delta < -0.001 else ("↓" if delta > 0.001 else "→")
+        # For error/retry, lower is better so flip arrow meaning
+        w(f"  {label:<30} {early_avg:.3f} → {late_avg:.3f}  {arrow}\n")
+
+    w("Behavioral trend:\n")
+    _trend_line([p.error_rate for p in report.points], "Error rate")
+    _trend_line([p.retry_rate for p in report.points], "Retry rate")
+    w("\nCost trend:\n")
+    _trend_line([p.cost for p in report.points], "Avg cost/session ($)")
+    _trend_line([p.duration_s for p in report.points], "Avg duration (s)")
+    w("\n")
+
+    if report.annotations:
+        w("Annotations:\n")
+        for ann in report.annotations:
+            w(f"  {ann.date}  {ann.note}\n")
+        w("\n")
+
+
+# ---------------------------------------------------------------------------
+# SVG helpers
+# ---------------------------------------------------------------------------
+
+_CHART_W = 560
+_CHART_H = 80
+_COLORS = ["#58a6ff", "#3fb950", "#f78166", "#d2a8ff", "#ffa657", "#79c0ff"]
+
+
+def _svg_sparkline(
+    values: list[float],
+    width: int = _CHART_W,
+    height: int = _CHART_H,
+    color: str = "#58a6ff",
+    annotations: list[tuple[float, str]] | None = None,  # (x_frac, label)
+) -> str:
+    """Render a list of floats as an inline SVG polyline."""
+    if not values or len(values) < 2:
+        return f'<svg width="{width}" height="{height}"></svg>'
+
+    mn = min(values)
+    mx = max(values)
+    rng = mx - mn or 1.0
+    pad = 6
+
+    def _x(i: int) -> float:
+        return pad + (i / (len(values) - 1)) * (width - 2 * pad)
+
+    def _y(v: float) -> float:
+        return pad + (1 - (v - mn) / rng) * (height - 2 * pad)
+
+    pts = " ".join(f"{_x(i):.1f},{_y(v):.1f}" for i, v in enumerate(values))
+
+    ann_lines = ""
+    if annotations:
+        for x_frac, label in annotations:
+            x = pad + x_frac * (width - 2 * pad)
+            ann_lines += (
+                f'<line x1="{x:.1f}" y1="0" x2="{x:.1f}" y2="{height}" '
+                f'stroke="#e3b341" stroke-width="1" stroke-dasharray="3,2"/>'
+                f'<text x="{x+3:.1f}" y="10" fill="#e3b341" '
+                f'font-size="8" font-family="monospace">{html.escape(label[:20])}</text>'
+            )
+
+    return (
+        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}" '
+        f'style="display:block">'
+        f'{ann_lines}'
+        f'<polyline points="{pts}" fill="none" stroke="{color}" stroke-width="1.5"/>'
+        f'</svg>'
+    )
+
+
+def _annotation_x_fracs(
+    points: list[TrendPoint],
+    annotations: list[TrendAnnotation],
+) -> list[tuple[float, str]]:
+    """Map annotation dates to x-axis fractions based on session timestamps."""
+    if not points or not annotations:
+        return []
+    t_min = points[0].started_at
+    t_max = points[-1].started_at
+    t_rng = t_max - t_min or 1.0
+    result = []
+    for ann in annotations:
+        try:
+            ts = datetime.strptime(ann.date, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp()
+            frac = max(0.0, min(1.0, (ts - t_min) / t_rng))
+            result.append((frac, ann.note))
+        except ValueError:
+            continue
+    return result
+
+
+# ---------------------------------------------------------------------------
+# HTML trend report
+# ---------------------------------------------------------------------------
+
+def render_html_trend(report: TrendReport) -> str:
+    """Produce a self-contained HTML trend report with inline SVG charts."""
+    pts = report.points
+    ann_fracs = _annotation_x_fracs(pts, report.annotations)
+
+    def _spark(values: list[float], color: str = "#58a6ff") -> str:
+        return _svg_sparkline(values, color=color, annotations=ann_fracs)
+
+    # Eval score charts (one per judge)
+    eval_section = ""
+    for i, judge in enumerate(report.judge_names):
+        color = _COLORS[i % len(_COLORS)]
+        scores = []
+        for p in pts:
+            match = next((e.score for e in p.eval_scores if e.judge == judge), None)
+            scores.append(match if match is not None else float("nan"))
+        # Replace nan with previous value for continuity
+        filled: list[float] = []
+        last = 0.5
+        for v in scores:
+            if v == v:  # not nan
+                last = v
+            filled.append(last)
+        pass_rate = (
+            sum(1 for p in pts if any(e.judge == judge and e.passed for e in p.eval_scores))
+            / max(sum(1 for p in pts if any(e.judge == judge for e in p.eval_scores)), 1)
+        )
+        eval_section += f"""
+        <div class="chart-block">
+          <div class="chart-label">{html.escape(judge)} <span class="badge">{pass_rate*100:.0f}% pass</span></div>
+          {_spark(filled, color)}
+        </div>"""
+
+    # Behavioral charts
+    error_spark = _spark([p.error_rate for p in pts], "#f85149")
+    retry_spark = _spark([p.retry_rate for p in pts], "#ffa657")
+    cost_spark = _spark([p.cost for p in pts], "#3fb950")
+    dur_spark = _spark([p.duration_s for p in pts], "#d2a8ff")
+
+    # Annotation list
+    ann_html = ""
+    if report.annotations:
+        ann_html = "<ul>" + "".join(
+            f"<li><span class='ann-date'>{html.escape(a.date)}</span> {html.escape(a.note)}</li>"
+            for a in report.annotations
+        ) + "</ul>"
+
+    # Session table (last 20)
+    table_rows = ""
+    for p in reversed(pts[-20:]):
+        dt = datetime.fromtimestamp(p.started_at, tz=timezone.utc).strftime("%m-%d %H:%M")
+        scores_str = ", ".join(
+            f"{e.judge}={e.score:.2f}" for e in p.eval_scores
+        ) or "—"
+        table_rows += (
+            f"<tr>"
+            f"<td>{html.escape(p.session_id[:12])}</td>"
+            f"<td>{dt}</td>"
+            f"<td>{p.error_rate:.2%}</td>"
+            f"<td>{p.retry_rate:.2%}</td>"
+            f"<td>${p.cost:.4f}</td>"
+            f"<td>{scores_str}</td>"
+            f"</tr>\n"
+        )
+
+    n = len(pts)
+    period = ""
+    if pts:
+        t0 = datetime.fromtimestamp(pts[0].started_at, tz=timezone.utc).strftime("%Y-%m-%d")
+        t1 = datetime.fromtimestamp(pts[-1].started_at, tz=timezone.utc).strftime("%Y-%m-%d")
+        period = f"{t0} to {t1}"
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>agent-strace trend dashboard</title>
+<style>
+*{{box-sizing:border-box}}
+body{{font-family:monospace;background:#0d1117;color:#c9d1d9;margin:0;padding:24px;font-size:13px}}
+h1{{color:#58a6ff;font-size:1.1em;margin:0 0 4px}}
+.subtitle{{color:#8b949e;font-size:.85em;margin-bottom:24px}}
+h2{{color:#8b949e;font-size:.85em;text-transform:uppercase;letter-spacing:.08em;margin:24px 0 8px;border-bottom:1px solid #21262d;padding-bottom:4px}}
+.charts{{display:grid;grid-template-columns:1fr 1fr;gap:16px}}
+.chart-block{{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px}}
+.chart-label{{color:#8b949e;font-size:.8em;margin-bottom:6px}}
+.badge{{background:#1f6feb;color:#e6edf3;border-radius:3px;padding:1px 5px;font-size:.75em;margin-left:6px}}
+table{{width:100%;border-collapse:collapse;font-size:.82em;margin-top:8px}}
+th{{background:#161b22;color:#8b949e;padding:5px 8px;text-align:left;border-bottom:1px solid #30363d}}
+td{{padding:4px 8px;border-bottom:1px solid #21262d}}
+tr:hover{{background:#161b22}}
+.ann-date{{color:#e3b341;margin-right:8px}}
+ul{{margin:0;padding-left:20px;color:#c9d1d9;font-size:.85em;line-height:1.8}}
+polyline{{fill:none}}
+</style>
+</head>
+<body>
+<h1>agent-strace trend dashboard</h1>
+<div class="subtitle">{n} sessions &nbsp;·&nbsp; {html.escape(period)}</div>
+
+<h2>Eval quality</h2>
+<div class="charts">
+{eval_section if eval_section else '<div class="chart-block" style="grid-column:1/-1;color:#8b949e">No eval scores found. Run <code>agent-strace eval</code> to score sessions.</div>'}
+</div>
+
+<h2>Behavioral metrics</h2>
+<div class="charts">
+  <div class="chart-block">
+    <div class="chart-label">Error rate (per session)</div>
+    {error_spark}
+  </div>
+  <div class="chart-block">
+    <div class="chart-label">Retry rate (per session)</div>
+    {retry_spark}
+  </div>
+  <div class="chart-block">
+    <div class="chart-label">Estimated cost ($)</div>
+    {cost_spark}
+  </div>
+  <div class="chart-block">
+    <div class="chart-label">Session duration (s)</div>
+    {dur_spark}
+  </div>
+</div>
+
+{f'<h2>Annotations</h2>{ann_html}' if report.annotations else ''}
+
+<h2>Recent sessions</h2>
+<table>
+<thead><tr>
+  <th>Session</th><th>Started</th><th>Error rate</th>
+  <th>Retry rate</th><th>Cost</th><th>Eval scores</th>
+</tr></thead>
+<tbody>
+{table_rows}
+</tbody>
+</table>
+</body>
+</html>"""
 
 
 # ---------------------------------------------------------------------------
@@ -269,14 +744,45 @@ polyline{{fill:none;stroke:#58a6ff;stroke-width:1.5}}
 
 def cmd_dashboard(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
+
+    # annotate subcommand
+    dash_cmd = getattr(args, "dash_command", None)
+    if dash_cmd == "annotate":
+        date = getattr(args, "date", "")
+        note = getattr(args, "note", "")
+        if not date or not note:
+            sys.stderr.write("--date and --note are required\n")
+            return 1
+        save_annotation(store, TrendAnnotation(date=date, note=note))
+        sys.stdout.write(f"Annotation saved: {date}  {note}\n")
+        return 0
+
+    # --trend mode
+    trend = getattr(args, "trend", False)
+    if trend:
+        since_raw = getattr(args, "since", None)
+        since_days: float | None = None
+        if since_raw:
+            since_days = float(since_raw.rstrip("d"))
+
+        trend_report = build_trend_report(store, since_days=since_days)
+
+        html_path = getattr(args, "html", None)
+        if html_path:
+            Path(html_path).write_text(render_html_trend(trend_report))
+            sys.stdout.write(f"Trend report written to {html_path}\n")
+            return 0
+
+        format_trend_terminal(trend_report)
+        return 0
+
+    # Default aggregate dashboard
     limit = getattr(args, "limit", 50) or 50
     agent_filter = getattr(args, "agent", "") or ""
-
     report = build_dashboard(store, limit=limit, agent_filter=agent_filter)
 
     output_path = getattr(args, "output", None)
     if output_path:
-        from pathlib import Path
         html_content = render_html_dashboard(report)
         Path(output_path).write_text(html_content)
         sys.stdout.write(f"Dashboard written to {output_path}\n")

--- a/tests/test_dashboard_trend.py
+++ b/tests/test_dashboard_trend.py
@@ -1,0 +1,317 @@
+"""Tests for dashboard --trend: TrendReport, SVG rendering, annotation storage."""
+
+import io
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agent_trace.dashboard import (
+    TrendAnnotation,
+    TrendPoint,
+    TrendReport,
+    _annotation_x_fracs,
+    _svg_sparkline,
+    build_trend_report,
+    format_trend_terminal,
+    load_annotations,
+    render_html_trend,
+    save_annotation,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store(tmp: str) -> TraceStore:
+    return TraceStore(tmp)
+
+
+def _add_session(
+    store: TraceStore,
+    session_id: str,
+    events: list[TraceEvent] | None = None,
+    started_at: float | None = None,
+    errors: int = 0,
+    tool_calls: int = 0,
+) -> None:
+    ts = started_at or time.time()
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=ts,
+        ended_at=ts + 60,
+        errors=errors,
+        tool_calls=tool_calls,
+        total_duration_ms=60_000,
+        total_tokens=1000,
+    )
+    store.create_session(meta)
+    for ev in (events or []):
+        store.append_event(session_id, ev)
+
+
+def _write_eval_json(store: TraceStore, session_id: str, results: list[dict]) -> None:
+    path = store.base_dir / session_id / "eval.json"
+    path.write_text(json.dumps({"results": results}))
+
+
+# ---------------------------------------------------------------------------
+# SVG sparkline
+# ---------------------------------------------------------------------------
+
+class TestSvgSparkline(unittest.TestCase):
+    def test_returns_svg_element(self):
+        svg = _svg_sparkline([1.0, 2.0, 3.0])
+        self.assertIn("<svg", svg)
+        self.assertIn("polyline", svg)
+
+    def test_single_value_no_crash(self):
+        svg = _svg_sparkline([1.0])
+        self.assertIn("<svg", svg)
+
+    def test_empty_no_crash(self):
+        svg = _svg_sparkline([])
+        self.assertIn("<svg", svg)
+
+    def test_annotations_rendered(self):
+        svg = _svg_sparkline([1.0, 2.0, 3.0], annotations=[(0.5, "model upgrade")])
+        self.assertIn("model upgrade", svg)
+        self.assertIn("line", svg)
+
+    def test_custom_color(self):
+        svg = _svg_sparkline([1.0, 2.0], color="#ff0000")
+        self.assertIn("#ff0000", svg)
+
+
+# ---------------------------------------------------------------------------
+# Annotation storage
+# ---------------------------------------------------------------------------
+
+class TestAnnotations(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def test_save_and_load(self):
+        save_annotation(self.store, TrendAnnotation(date="2026-05-10", note="Added retry policy"))
+        save_annotation(self.store, TrendAnnotation(date="2026-05-12", note="Model upgrade"))
+        anns = load_annotations(self.store)
+        self.assertEqual(len(anns), 2)
+        self.assertEqual(anns[0].date, "2026-05-10")
+        self.assertEqual(anns[1].note, "Model upgrade")
+
+    def test_load_empty(self):
+        anns = load_annotations(self.store)
+        self.assertEqual(anns, [])
+
+    def test_annotation_x_fracs(self):
+        now = time.time()
+        pts = [
+            TrendPoint("s1", now - 86400 * 10, 0, 0, 0, 0),
+            TrendPoint("s2", now, 0, 0, 0, 0),
+        ]
+        from datetime import datetime, timezone
+        mid_date = datetime.fromtimestamp(now - 86400 * 5, tz=timezone.utc).strftime("%Y-%m-%d")
+        anns = [TrendAnnotation(date=mid_date, note="test")]
+        fracs = _annotation_x_fracs(pts, anns)
+        self.assertEqual(len(fracs), 1)
+        frac, label = fracs[0]
+        self.assertGreater(frac, 0.0)
+        self.assertLess(frac, 1.0)
+        self.assertEqual(label, "test")
+
+
+# ---------------------------------------------------------------------------
+# Trend report builder
+# ---------------------------------------------------------------------------
+
+class TestBuildTrendReport(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def test_empty_store(self):
+        report = build_trend_report(self.store)
+        self.assertEqual(report.points, [])
+        self.assertEqual(report.judge_names, [])
+
+    def test_sessions_included(self):
+        now = time.time()
+        _add_session(self.store, "s1", started_at=now - 100)
+        _add_session(self.store, "s2", started_at=now - 50)
+        report = build_trend_report(self.store)
+        self.assertEqual(len(report.points), 2)
+
+    def test_since_filter(self):
+        now = time.time()
+        _add_session(self.store, "old", started_at=now - 86400 * 10)
+        _add_session(self.store, "new", started_at=now - 100)
+        report = build_trend_report(self.store, since_days=1)
+        ids = [p.session_id for p in report.points]
+        self.assertIn("new", ids)
+        self.assertNotIn("old", ids)
+
+    def test_eval_scores_loaded(self):
+        now = time.time()
+        _add_session(self.store, "s_eval", started_at=now - 100)
+        _write_eval_json(self.store, "s_eval", [
+            {"scorer": "no_errors", "score": 1.0, "threshold": 1.0, "passed": True},
+        ])
+        report = build_trend_report(self.store)
+        pt = next(p for p in report.points if p.session_id == "s_eval")
+        self.assertEqual(len(pt.eval_scores), 1)
+        self.assertEqual(pt.eval_scores[0].judge, "no_errors")
+        self.assertIn("no_errors", report.judge_names)
+
+    def test_error_rate_computed(self):
+        now = time.time()
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, timestamp=now, data={"tool_name": "Bash"}),
+            TraceEvent(event_type=EventType.ERROR, timestamp=now + 1, data={"message": "fail"}),
+        ]
+        _add_session(self.store, "s_err", events=events, started_at=now - 100)
+        report = build_trend_report(self.store)
+        pt = next(p for p in report.points if p.session_id == "s_err")
+        self.assertGreater(pt.error_rate, 0.0)
+
+    def test_retry_rate_computed(self):
+        now = time.time()
+        events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, timestamp=now, data={"tool_name": "Bash"}),
+            TraceEvent(event_type=EventType.TOOL_CALL, timestamp=now + 1, data={"tool_name": "Bash"}),
+            TraceEvent(event_type=EventType.TOOL_CALL, timestamp=now + 2, data={"tool_name": "Bash"}),
+        ]
+        _add_session(self.store, "s_retry", events=events, started_at=now - 100)
+        report = build_trend_report(self.store)
+        pt = next(p for p in report.points if p.session_id == "s_retry")
+        self.assertGreater(pt.retry_rate, 0.0)
+
+    def test_points_ordered_oldest_first(self):
+        now = time.time()
+        _add_session(self.store, "early", started_at=now - 200)
+        _add_session(self.store, "late", started_at=now - 50)
+        report = build_trend_report(self.store)
+        self.assertLess(report.points[0].started_at, report.points[-1].started_at)
+
+
+# ---------------------------------------------------------------------------
+# Terminal formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatTrendTerminal(unittest.TestCase):
+    def _make_report(self, n: int = 6) -> TrendReport:
+        now = time.time()
+        pts = [
+            TrendPoint(
+                session_id=f"s{i}",
+                started_at=now - (n - i) * 100,
+                error_rate=0.1 * i,
+                retry_rate=0.05,
+                cost=0.01 * i,
+                duration_s=60.0,
+            )
+            for i in range(n)
+        ]
+        return TrendReport(points=pts, annotations=[], judge_names=[])
+
+    def test_no_crash_empty(self):
+        buf = io.StringIO()
+        format_trend_terminal(TrendReport(points=[], annotations=[], judge_names=[]), out=buf)
+        self.assertIn("No sessions", buf.getvalue())
+
+    def test_behavioral_section_present(self):
+        buf = io.StringIO()
+        format_trend_terminal(self._make_report(), out=buf)
+        output = buf.getvalue()
+        self.assertIn("Behavioral", output)
+        self.assertIn("Error rate", output)
+
+    def test_annotations_shown(self):
+        report = self._make_report()
+        report.annotations = [TrendAnnotation(date="2026-05-10", note="config change")]
+        buf = io.StringIO()
+        format_trend_terminal(report, out=buf)
+        self.assertIn("config change", buf.getvalue())
+
+    def test_eval_scores_shown(self):
+        from agent_trace.dashboard import EvalScorePoint
+        now = time.time()
+        pts = [
+            TrendPoint(
+                session_id="s1",
+                started_at=now - 100,
+                error_rate=0.0,
+                retry_rate=0.0,
+                cost=0.01,
+                duration_s=60.0,
+                eval_scores=[EvalScorePoint(judge="no_errors", score=1.0, passed=True)],
+            ),
+        ]
+        report = TrendReport(points=pts, annotations=[], judge_names=["no_errors"])
+        buf = io.StringIO()
+        format_trend_terminal(report, out=buf)
+        self.assertIn("no_errors", buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+class TestRenderHtmlTrend(unittest.TestCase):
+    def _make_report(self) -> TrendReport:
+        from agent_trace.dashboard import EvalScorePoint
+        now = time.time()
+        pts = [
+            TrendPoint(
+                session_id=f"s{i}",
+                started_at=now - (5 - i) * 100,
+                error_rate=0.1,
+                retry_rate=0.05,
+                cost=0.02,
+                duration_s=60.0,
+                eval_scores=[EvalScorePoint(judge="no_errors", score=float(i % 2), passed=bool(i % 2))],
+            )
+            for i in range(5)
+        ]
+        return TrendReport(
+            points=pts,
+            annotations=[TrendAnnotation(date="2026-05-10", note="model upgrade")],
+            judge_names=["no_errors"],
+        )
+
+    def test_returns_html(self):
+        html_out = render_html_trend(self._make_report())
+        self.assertIn("<!DOCTYPE html>", html_out)
+        self.assertIn("<svg", html_out)
+
+    def test_judge_section_present(self):
+        html_out = render_html_trend(self._make_report())
+        self.assertIn("no_errors", html_out)
+
+    def test_annotation_in_html(self):
+        html_out = render_html_trend(self._make_report())
+        self.assertIn("model upgrade", html_out)
+
+    def test_no_external_resources(self):
+        html_out = render_html_trend(self._make_report())
+        self.assertNotIn("cdn.", html_out)
+        self.assertNotIn("googleapis", html_out)
+        self.assertNotIn("cloudflare", html_out)
+        self.assertNotIn("<script src", html_out)
+
+    def test_empty_report_no_crash(self):
+        report = TrendReport(points=[], annotations=[], judge_names=[])
+        html_out = render_html_trend(report)
+        self.assertIn("<!DOCTYPE html>", html_out)
+
+    def test_self_contained_no_link_tags(self):
+        html_out = render_html_trend(self._make_report())
+        self.assertNotIn('<link rel="stylesheet"', html_out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Extends `agent-strace dashboard` with `--trend` mode: reads per-session eval scores from `eval.json`, computes error/retry/cost time-series, and renders a self-contained HTML report with inline SVG charts.

Closes #68

## New flags

```
# Terminal trend summary
agent-strace dashboard --trend --since 30d

# Self-contained HTML report
agent-strace dashboard --trend --since 30d --html trend-report.html

# Add a timeline annotation (appears as a vertical marker on all charts)
agent-strace dashboard annotate --date 2026-05-10 --note "Added retry policy to AGENTS.md"
```

## What the HTML report shows

**Eval quality section** (one sparkline per judge, requires `agent-strace eval` scores):
- Pass rate trend per judge with color-coded lines
- Annotation markers showing when config or model changed

**Behavioral metrics section** (four sparklines, no eval required):
- Error rate per session
- Retry rate per session
- Estimated cost per session
- Session duration

**Recent sessions table** with eval scores inline.

## Design constraints met

- Zero CDN dependencies — all CSS inline, all charts inline SVG
- No JavaScript libraries — polylines rendered as SVG paths
- Self-contained: single HTML file, openable in any browser
- Works without eval scores (falls back to behavioral metrics only)

## Files changed

- `src/agent_trace/dashboard.py` — `TrendPoint`, `TrendReport`, `EvalScorePoint`, `build_trend_report()`, `format_trend_terminal()`, `render_html_trend()`, `save_annotation()`, `load_annotations()`, `_svg_sparkline()`
- `src/agent_trace/cli.py` — `--trend`, `--since`, `--html` flags; `dashboard annotate` subcommand
- `tests/test_dashboard_trend.py` — 25 new tests

## Test results

```
Ran 591 tests — OK (25 new)
```