### PR TITLE
feat: export eval scores and behavioral metrics to Langfuse and OTLP backends

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -25,6 +25,7 @@ from .http_proxy import HTTPProxyServer
 from .a2a import cmd_a2a_tree
 from .annotate import cmd_annotate
 from .drift import cmd_drift
+from .langfuse_export import cmd_export_scores
 from .oncall import cmd_oncall
 from .freshness import cmd_freshness
 from .standup import cmd_standup
@@ -223,6 +224,10 @@ def cmd_inspect(args: argparse.Namespace) -> int:
 
 
 def cmd_export(args: argparse.Namespace) -> int:
+    # Route to Langfuse/OTLP export when --scores, --metrics, or --backend is set
+    if getattr(args, "scores", False) or getattr(args, "metrics", False) or getattr(args, "backend", None):
+        return cmd_export_scores(args)
+
     """Export a session to JSON, CSV, or OTLP."""
     store = TraceStore(args.trace_dir)
 
@@ -460,11 +465,30 @@ def build_parser() -> argparse.ArgumentParser:
 
     # export
     p_export = sub.add_parser("export", help="export a session")
-    p_export.add_argument("session_id", help="session ID or prefix")
+    p_export.add_argument("session_id", nargs="?", help="session ID or prefix")
     p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp"], default="json")
     p_export.add_argument("--endpoint", help="OTLP collector URL (e.g. http://localhost:4318)")
     p_export.add_argument("--header", action="append", help="HTTP header for OTLP (e.g. 'x-honeycomb-team: KEY')")
     p_export.add_argument("--service-name", default="agent-trace", help="OTel service name (default: agent-trace)")
+    # Langfuse / OTLP metrics flags
+    p_export.add_argument("--scores", action="store_true",
+                          help="include eval scores in export")
+    p_export.add_argument("--metrics", action="store_true",
+                          help="export behavioral metrics as OTLP gauges")
+    p_export.add_argument("--backend", choices=["langfuse", "otlp"],
+                          help="export backend: langfuse or otlp")
+    p_export.add_argument("--since", metavar="Nd",
+                          help="export sessions from the last N days (e.g. 7d)")
+    p_export.add_argument("--langfuse-public-key", dest="langfuse_public_key", metavar="KEY",
+                          help="Langfuse public key (overrides LANGFUSE_PUBLIC_KEY)")
+    p_export.add_argument("--langfuse-secret-key", dest="langfuse_secret_key", metavar="KEY",
+                          help="Langfuse secret key (overrides LANGFUSE_SECRET_KEY)")
+    p_export.add_argument("--langfuse-host", dest="langfuse_host", metavar="URL",
+                          help="Langfuse host (default: https://cloud.langfuse.com)")
+    p_export.add_argument("--otlp-endpoint", dest="otlp_endpoint", metavar="URL",
+                          help="OTLP metrics endpoint (overrides OTEL_EXPORTER_OTLP_ENDPOINT)")
+    p_export.add_argument("--otlp-headers", dest="otlp_headers", metavar="HEADERS",
+                          help="OTLP headers as key=value,key=value")
 
     # stats
     p_stats = sub.add_parser("stats", help="show session statistics")

--- a/src/agent_trace/langfuse_export.py
+++ b/src/agent_trace/langfuse_export.py
@@ -1,0 +1,504 @@
+"""Export eval scores and behavioral metrics to Langfuse and OTLP backends.
+
+Langfuse path:
+  - Sessions exported as Langfuse Traces
+  - Tool calls exported as Spans (type=tool)
+  - LLM requests/responses exported as Generations (with token counts)
+  - eval.json judge scores exported as Langfuse Scores attached to the trace
+
+OTLP metrics path:
+  - Behavioral metrics (error_rate, retry_rate, cost, blast_radius, eval scores)
+    exported as OTLP gauge metrics to any compatible backend
+
+No new dependencies. All HTTP calls use urllib.request.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LangfuseConfig:
+    public_key: str = ""
+    secret_key: str = ""
+    host: str = "https://cloud.langfuse.com"
+
+    @property
+    def auth_header(self) -> str:
+        token = base64.b64encode(
+            f"{self.public_key}:{self.secret_key}".encode()
+        ).decode()
+        return f"Basic {token}"
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.public_key and self.secret_key)
+
+
+@dataclass
+class OtlpMetricsConfig:
+    endpoint: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.endpoint)
+
+
+# ---------------------------------------------------------------------------
+# Eval score reading
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvalScore:
+    judge: str
+    score: float
+    passed: bool
+    threshold: float = 1.0
+
+
+def _load_eval_scores(store: TraceStore, session_id: str) -> list[EvalScore]:
+    eval_path = store.base_dir / session_id / "eval.json"
+    if not eval_path.exists():
+        return []
+    try:
+        data = json.loads(eval_path.read_text())
+        results = data.get("results") or data.get("judges") or []
+        scores = []
+        for r in results:
+            name = r.get("scorer") or r.get("name") or "unknown"
+            score = float(r.get("score", 0.0))
+            threshold = float(r.get("threshold", 1.0))
+            passed = bool(r.get("passed", score >= threshold))
+            scores.append(EvalScore(judge=name, score=score, passed=passed, threshold=threshold))
+        return scores
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Langfuse export
+# ---------------------------------------------------------------------------
+
+def _lf_post(config: LangfuseConfig, path: str, body: dict) -> bool:
+    url = config.host.rstrip("/") + path
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": config.auth_header,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status in (200, 201, 202)
+    except (urllib.error.URLError, urllib.error.HTTPError):
+        return False
+
+
+def _session_to_langfuse_trace(
+    meta: SessionMeta,
+    events: list[TraceEvent],
+) -> dict:
+    """Build a Langfuse Trace ingestion body."""
+    duration_s = meta.total_duration_ms / 1000 if meta.total_duration_ms else None
+    return {
+        "id": meta.session_id,
+        "name": f"agent-session ({meta.agent_name or 'agent'})",
+        "timestamp": _iso(meta.started_at),
+        "metadata": {
+            "agent_name": meta.agent_name or "",
+            "command": meta.command or "",
+            "tool_calls": meta.tool_calls,
+            "llm_requests": meta.llm_requests,
+            "errors": meta.errors,
+            "total_tokens": meta.total_tokens,
+        },
+        "tags": ["agent-strace"],
+        **({"duration": duration_s} if duration_s else {}),
+    }
+
+
+def _events_to_langfuse_observations(
+    session_id: str,
+    events: list[TraceEvent],
+) -> list[dict]:
+    """Convert trace events to Langfuse Span/Generation observations."""
+    observations = []
+    pending_calls: dict[str, TraceEvent] = {}
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            pending_calls[ev.event_id] = ev
+
+        elif ev.event_type == EventType.TOOL_RESULT:
+            call = pending_calls.pop(ev.parent_id, None)
+            tool_name = ev.data.get("tool_name") or (
+                call.data.get("tool_name", "tool") if call else "tool"
+            )
+            start_ts = call.timestamp if call else ev.timestamp
+            end_ts = ev.timestamp
+            observations.append({
+                "id": ev.event_id,
+                "traceId": session_id,
+                "type": "SPAN",
+                "name": f"tool/{tool_name}",
+                "startTime": _iso(start_ts),
+                "endTime": _iso(end_ts),
+                "input": call.data.get("arguments") if call else None,
+                "output": ev.data.get("result"),
+                "metadata": {"tool_name": tool_name},
+            })
+
+        elif ev.event_type == EventType.LLM_REQUEST:
+            pending_calls[ev.event_id] = ev
+
+        elif ev.event_type == EventType.LLM_RESPONSE:
+            req_ev = pending_calls.pop(ev.parent_id, None)
+            start_ts = req_ev.timestamp if req_ev else ev.timestamp
+            input_tokens = (req_ev.data.get("input_tokens", 0) if req_ev else 0) or 0
+            output_tokens = ev.data.get("output_tokens", 0) or 0
+            model = (req_ev.data.get("model", "") if req_ev else "") or ""
+            observations.append({
+                "id": ev.event_id,
+                "traceId": session_id,
+                "type": "GENERATION",
+                "name": "llm-call",
+                "startTime": _iso(start_ts),
+                "endTime": _iso(ev.timestamp),
+                "model": model or None,
+                "usage": {
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "total": input_tokens + output_tokens,
+                },
+                "input": req_ev.data.get("prompt") if req_ev else None,
+                "output": ev.data.get("text"),
+            })
+
+    return [o for o in observations if o]  # drop None entries
+
+
+def _scores_to_langfuse(
+    session_id: str,
+    scores: list[EvalScore],
+) -> list[dict]:
+    """Convert eval scores to Langfuse Score objects."""
+    return [
+        {
+            "traceId": session_id,
+            "name": s.judge,
+            "value": s.score,
+            "comment": f"threshold={s.threshold} passed={s.passed}",
+            "source": "API",
+        }
+        for s in scores
+    ]
+
+
+def export_session_to_langfuse(
+    store: TraceStore,
+    session_id: str,
+    config: LangfuseConfig,
+    include_scores: bool = True,
+) -> bool:
+    """Export one session (trace + observations + scores) to Langfuse."""
+    try:
+        meta = store.load_meta(session_id)
+        events = store.load_events(session_id)
+    except Exception as exc:
+        sys.stderr.write(f"Failed to load session {session_id}: {exc}\n")
+        return False
+
+    # Batch ingestion endpoint
+    batch: list[dict] = []
+
+    trace_body = _session_to_langfuse_trace(meta, events)
+    batch.append({"type": "trace-create", "body": trace_body})
+
+    for obs in _events_to_langfuse_observations(session_id, events):
+        batch.append({"type": "observation-create", "body": obs})
+
+    if include_scores:
+        scores = _load_eval_scores(store, session_id)
+        for score_body in _scores_to_langfuse(session_id, scores):
+            batch.append({"type": "score-create", "body": score_body})
+
+    ok = _lf_post(config, "/api/public/ingestion", {"batch": batch})
+    if ok:
+        sys.stderr.write(
+            f"Langfuse: exported session {session_id[:12]} "
+            f"({len(events)} events, {len(batch)} items)\n"
+        )
+    else:
+        sys.stderr.write(f"Langfuse: export failed for session {session_id[:12]}\n")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# OTLP metrics export
+# ---------------------------------------------------------------------------
+
+def _otlp_gauge(
+    name: str,
+    value: float,
+    attributes: dict[str, str],
+    timestamp_ns: int,
+) -> dict:
+    """Build a single OTLP gauge data point."""
+    return {
+        "name": name,
+        "gauge": {
+            "dataPoints": [{
+                "attributes": [
+                    {"key": k, "value": {"stringValue": str(v)}}
+                    for k, v in attributes.items()
+                ],
+                "timeUnixNano": str(timestamp_ns),
+                "asDouble": float(value),
+            }]
+        },
+    }
+
+
+def _session_metrics(
+    store: TraceStore,
+    meta: SessionMeta,
+) -> dict[str, float]:
+    """Extract behavioral metrics for a session."""
+    try:
+        events = store.load_events(meta.session_id)
+    except Exception:
+        events = []
+
+    tool_calls = 0
+    errors = 0
+    retries = 0
+    files_written: set[str] = set()
+    prev_tool: str | None = None
+    run = 0
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            tool_calls += 1
+            name = ev.data.get("tool_name", "")
+            if name == prev_tool:
+                run += 1
+                if run >= 2:
+                    retries += 1
+            else:
+                prev_tool = name
+                run = 0
+        elif ev.event_type == EventType.ERROR:
+            errors += 1
+        elif ev.event_type == EventType.FILE_WRITE:
+            path = ev.data.get("path") or ev.data.get("file_path") or ""
+            if path:
+                files_written.add(path)
+
+    cost = meta.total_tokens / 1_000_000 * 3.0
+    duration_s = meta.total_duration_ms / 1000 if meta.total_duration_ms else 0.0
+
+    return {
+        "agent_strace.session.cost_usd": cost,
+        "agent_strace.session.error_rate": errors / max(tool_calls, 1),
+        "agent_strace.session.retry_rate": retries / max(tool_calls, 1),
+        "agent_strace.session.blast_radius": float(len(files_written)),
+        "agent_strace.session.duration_s": duration_s,
+        "agent_strace.session.tool_calls": float(tool_calls),
+    }
+
+
+def export_metrics_to_otlp(
+    store: TraceStore,
+    session_ids: list[str],
+    config: OtlpMetricsConfig,
+    include_scores: bool = True,
+) -> bool:
+    """Export behavioral metrics and eval scores as OTLP gauge metrics."""
+    metrics: list[dict] = []
+    ts_ns = int(time.time() * 1_000_000_000)
+
+    for sid in session_ids:
+        try:
+            meta = store.load_meta(sid)
+        except Exception:
+            continue
+
+        attrs = {
+            "session_id": sid[:12],
+            "agent_name": meta.agent_name or "unknown",
+        }
+
+        session_m = _session_metrics(store, meta)
+        for metric_name, value in session_m.items():
+            metrics.append(_otlp_gauge(metric_name, value, attrs, ts_ns))
+
+        if include_scores:
+            for score in _load_eval_scores(store, sid):
+                score_attrs = {**attrs, "judge": score.judge}
+                metrics.append(_otlp_gauge(
+                    "agent_strace.eval.score", score.score, score_attrs, ts_ns
+                ))
+
+    if not metrics:
+        sys.stderr.write("No metrics to export.\n")
+        return True
+
+    payload = json.dumps({
+        "resourceMetrics": [{
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": "agent-strace"}}
+                ]
+            },
+            "scopeMetrics": [{
+                "scope": {"name": "agent-strace"},
+                "metrics": metrics,
+            }],
+        }]
+    }).encode()
+
+    url = config.endpoint.rstrip("/") + "/v1/metrics"
+    req_headers = {"Content-Type": "application/json"}
+    req_headers.update(config.headers)
+
+    req = urllib.request.Request(url, data=payload, headers=req_headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            ok = resp.status in (200, 202)
+    except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+        sys.stderr.write(f"OTLP metrics export failed: {exc}\n")
+        return False
+
+    if ok:
+        sys.stderr.write(
+            f"OTLP metrics: exported {len(metrics)} data points "
+            f"for {len(session_ids)} session(s)\n"
+        )
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _iso(ts: float) -> str:
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_export_scores(args) -> int:
+    """Handle: agent-strace export --scores --backend langfuse|otlp"""
+    import os
+    store = TraceStore(args.trace_dir)
+    backend = getattr(args, "backend", "langfuse") or "langfuse"
+    include_scores = getattr(args, "scores", False)
+    include_metrics = getattr(args, "metrics", False)
+    since_raw = getattr(args, "since", None)
+    session_arg = getattr(args, "session_id", None)
+
+    # Resolve sessions
+    if session_arg:
+        found = store.find_session(session_arg)
+        session_ids = [found] if found else []
+    elif since_raw:
+        days = float(since_raw.rstrip("d"))
+        cutoff = time.time() - days * 86400
+        session_ids = [
+            m.session_id for m in store.list_sessions()
+            if m.started_at >= cutoff
+        ]
+    else:
+        latest = store.get_latest_session_id()
+        session_ids = [latest] if latest else []
+
+    if not session_ids:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+
+    if backend == "langfuse":
+        config = LangfuseConfig(
+            public_key=(
+                getattr(args, "langfuse_public_key", None)
+                or os.environ.get("LANGFUSE_PUBLIC_KEY", "")
+            ),
+            secret_key=(
+                getattr(args, "langfuse_secret_key", None)
+                or os.environ.get("LANGFUSE_SECRET_KEY", "")
+            ),
+            host=(
+                getattr(args, "langfuse_host", None)
+                or os.environ.get("LANGFUSE_HOST", "https://cloud.langfuse.com")
+            ),
+        )
+        if not config.configured:
+            sys.stderr.write(
+                "Langfuse credentials not set. "
+                "Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY, "
+                "or use --langfuse-public-key / --langfuse-secret-key.\n"
+            )
+            return 1
+
+        success = 0
+        for sid in session_ids:
+            if export_session_to_langfuse(store, sid, config, include_scores=include_scores):
+                success += 1
+        sys.stdout.write(f"Langfuse: {success}/{len(session_ids)} sessions exported.\n")
+        return 0 if success == len(session_ids) else 1
+
+    elif backend == "otlp":
+        endpoint = (
+            getattr(args, "otlp_endpoint", None)
+            or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+        )
+        if not endpoint:
+            sys.stderr.write(
+                "OTLP endpoint not set. "
+                "Set OTEL_EXPORTER_OTLP_ENDPOINT or use --otlp-endpoint.\n"
+            )
+            return 1
+
+        headers_raw = (
+            getattr(args, "otlp_headers", None)
+            or os.environ.get("OTEL_EXPORTER_OTLP_HEADERS", "")
+        )
+        headers: dict[str, str] = {}
+        if headers_raw:
+            for pair in headers_raw.split(","):
+                if "=" in pair:
+                    k, _, v = pair.partition("=")
+                    headers[k.strip()] = v.strip()
+
+        config_otlp = OtlpMetricsConfig(endpoint=endpoint, headers=headers)
+        ok = export_metrics_to_otlp(
+            store, session_ids, config_otlp, include_scores=include_scores
+        )
+        return 0 if ok else 1
+
+    else:
+        sys.stderr.write(f"Unknown backend: {backend!r}. Use 'langfuse' or 'otlp'.\n")
+        return 1

--- a/tests/test_langfuse_export.py
+++ b/tests/test_langfuse_export.py
@@ -1,0 +1,462 @@
+"""Tests for Langfuse and OTLP metrics export."""
+
+import base64
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_trace.langfuse_export import (
+    EvalScore,
+    LangfuseConfig,
+    OtlpMetricsConfig,
+    _events_to_langfuse_observations,
+    _iso,
+    _load_eval_scores,
+    _otlp_gauge,
+    _scores_to_langfuse,
+    _session_metrics,
+    _session_to_langfuse_trace,
+    export_metrics_to_otlp,
+    export_session_to_langfuse,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store(tmp: str) -> TraceStore:
+    return TraceStore(tmp)
+
+
+def _add_session(
+    store: TraceStore,
+    session_id: str,
+    events: list[TraceEvent] | None = None,
+    started_at: float | None = None,
+    total_tokens: int = 1000,
+    total_duration_ms: float = 60_000,
+) -> SessionMeta:
+    ts = started_at or time.time()
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=ts,
+        ended_at=ts + 60,
+        agent_name="test-agent",
+        total_tokens=total_tokens,
+        total_duration_ms=total_duration_ms,
+    )
+    store.create_session(meta)
+    for ev in (events or []):
+        store.append_event(session_id, ev)
+    return meta
+
+
+def _write_eval_json(store: TraceStore, session_id: str, results: list[dict]) -> None:
+    path = store.base_dir / session_id / "eval.json"
+    path.write_text(json.dumps({"results": results}))
+
+
+def _tool_call(name: str, ts: float = 0.0, event_id: str = "tc1") -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.TOOL_CALL,
+        timestamp=ts,
+        event_id=event_id,
+        data={"tool_name": name, "arguments": {"path": "src/a.py"}},
+    )
+
+
+def _tool_result(name: str, ts: float = 1.0, parent_id: str = "tc1") -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.TOOL_RESULT,
+        timestamp=ts,
+        parent_id=parent_id,
+        data={"tool_name": name, "result": "ok"},
+    )
+
+
+def _llm_req(ts: float = 0.0, event_id: str = "lr1") -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.LLM_REQUEST,
+        timestamp=ts,
+        event_id=event_id,
+        data={"model": "claude-3", "input_tokens": 100},
+    )
+
+
+def _llm_resp(ts: float = 1.0, parent_id: str = "lr1") -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.LLM_RESPONSE,
+        timestamp=ts,
+        parent_id=parent_id,
+        data={"output_tokens": 50, "text": "done"},
+    )
+
+
+def _error_ev(ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.ERROR,
+        timestamp=ts,
+        data={"message": "exit 1"},
+    )
+
+
+def _write_ev(path: str, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.FILE_WRITE,
+        timestamp=ts,
+        data={"path": path},
+    )
+
+
+# ---------------------------------------------------------------------------
+# LangfuseConfig
+# ---------------------------------------------------------------------------
+
+class TestLangfuseConfig(unittest.TestCase):
+    def test_configured_true_when_keys_set(self):
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+        self.assertTrue(cfg.configured)
+
+    def test_configured_false_when_keys_missing(self):
+        cfg = LangfuseConfig()
+        self.assertFalse(cfg.configured)
+
+    def test_auth_header_is_basic(self):
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+        self.assertTrue(cfg.auth_header.startswith("Basic "))
+        decoded = base64.b64decode(cfg.auth_header[6:]).decode()
+        self.assertEqual(decoded, "pk:sk")
+
+
+# ---------------------------------------------------------------------------
+# Eval score loading
+# ---------------------------------------------------------------------------
+
+class TestLoadEvalScores(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def test_no_eval_json_returns_empty(self):
+        _add_session(self.store, "s1")
+        scores = _load_eval_scores(self.store, "s1")
+        self.assertEqual(scores, [])
+
+    def test_eval_json_parsed(self):
+        _add_session(self.store, "s2")
+        _write_eval_json(self.store, "s2", [
+            {"scorer": "no_errors", "score": 1.0, "threshold": 1.0, "passed": True},
+            {"scorer": "cost_under", "score": 0.8, "threshold": 0.9, "passed": False},
+        ])
+        scores = _load_eval_scores(self.store, "s2")
+        self.assertEqual(len(scores), 2)
+        self.assertEqual(scores[0].judge, "no_errors")
+        self.assertEqual(scores[0].score, 1.0)
+        self.assertTrue(scores[0].passed)
+        self.assertFalse(scores[1].passed)
+
+    def test_malformed_eval_json_returns_empty(self):
+        _add_session(self.store, "s3")
+        (self.store.base_dir / "s3" / "eval.json").write_text("not json")
+        scores = _load_eval_scores(self.store, "s3")
+        self.assertEqual(scores, [])
+
+
+# ---------------------------------------------------------------------------
+# Langfuse trace / observation building
+# ---------------------------------------------------------------------------
+
+class TestSessionToLangfuseTrace(unittest.TestCase):
+    def test_trace_has_required_fields(self):
+        meta = SessionMeta(
+            session_id="abc123",
+            started_at=1748000000.0,
+            agent_name="claude",
+            total_tokens=500,
+        )
+        body = _session_to_langfuse_trace(meta, [])
+        self.assertEqual(body["id"], "abc123")
+        self.assertIn("name", body)
+        self.assertIn("timestamp", body)
+        self.assertIn("metadata", body)
+
+    def test_metadata_contains_token_count(self):
+        meta = SessionMeta(session_id="x", started_at=time.time(), total_tokens=1234)
+        body = _session_to_langfuse_trace(meta, [])
+        self.assertEqual(body["metadata"]["total_tokens"], 1234)
+
+
+class TestEventsToLangfuseObservations(unittest.TestCase):
+    def test_tool_call_result_pair_becomes_span(self):
+        events = [_tool_call("Bash", ts=0.0, event_id="tc1"), _tool_result("Bash", ts=1.0, parent_id="tc1")]
+        obs = _events_to_langfuse_observations("sess1", events)
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs[0]["type"], "SPAN")
+        self.assertIn("tool/Bash", obs[0]["name"])
+
+    def test_llm_request_response_pair_becomes_generation(self):
+        events = [_llm_req(ts=0.0, event_id="lr1"), _llm_resp(ts=1.0, parent_id="lr1")]
+        obs = _events_to_langfuse_observations("sess1", events)
+        self.assertEqual(len(obs), 1)
+        self.assertEqual(obs[0]["type"], "GENERATION")
+        self.assertEqual(obs[0]["usage"]["input"], 100)
+        self.assertEqual(obs[0]["usage"]["output"], 50)
+
+    def test_unmatched_tool_call_produces_no_observation(self):
+        events = [_tool_call("Bash", ts=0.0, event_id="tc_orphan")]
+        obs = _events_to_langfuse_observations("sess1", events)
+        self.assertEqual(obs, [])
+
+    def test_empty_events_returns_empty(self):
+        obs = _events_to_langfuse_observations("sess1", [])
+        self.assertEqual(obs, [])
+
+
+class TestScoresToLangfuse(unittest.TestCase):
+    def test_scores_mapped_correctly(self):
+        scores = [
+            EvalScore(judge="no_errors", score=1.0, passed=True, threshold=1.0),
+            EvalScore(judge="cost_under", score=0.7, passed=False, threshold=0.9),
+        ]
+        bodies = _scores_to_langfuse("sess1", scores)
+        self.assertEqual(len(bodies), 2)
+        self.assertEqual(bodies[0]["name"], "no_errors")
+        self.assertEqual(bodies[0]["value"], 1.0)
+        self.assertEqual(bodies[0]["traceId"], "sess1")
+        self.assertEqual(bodies[1]["name"], "cost_under")
+
+    def test_empty_scores_returns_empty(self):
+        self.assertEqual(_scores_to_langfuse("sess1", []), [])
+
+
+# ---------------------------------------------------------------------------
+# OTLP gauge building
+# ---------------------------------------------------------------------------
+
+class TestOtlpGauge(unittest.TestCase):
+    def test_gauge_structure(self):
+        g = _otlp_gauge("agent_strace.session.cost_usd", 0.042, {"session_id": "abc"}, 1748000000000)
+        self.assertEqual(g["name"], "agent_strace.session.cost_usd")
+        self.assertIn("gauge", g)
+        dp = g["gauge"]["dataPoints"][0]
+        self.assertAlmostEqual(dp["asDouble"], 0.042)
+        self.assertEqual(dp["timeUnixNano"], "1748000000000")
+
+    def test_attributes_encoded(self):
+        g = _otlp_gauge("m", 1.0, {"k": "v"}, 0)
+        attrs = g["gauge"]["dataPoints"][0]["attributes"]
+        self.assertEqual(attrs[0]["key"], "k")
+        self.assertEqual(attrs[0]["value"]["stringValue"], "v")
+
+
+# ---------------------------------------------------------------------------
+# Session metrics extraction
+# ---------------------------------------------------------------------------
+
+class TestSessionMetrics(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def test_cost_computed_from_tokens(self):
+        meta = _add_session(self.store, "s1", total_tokens=1_000_000)
+        m = _session_metrics(self.store, meta)
+        self.assertAlmostEqual(m["agent_strace.session.cost_usd"], 3.0)
+
+    def test_error_rate_computed(self):
+        events = [_tool_call("Bash"), _error_ev()]
+        meta = _add_session(self.store, "s2", events=events)
+        m = _session_metrics(self.store, meta)
+        self.assertGreater(m["agent_strace.session.error_rate"], 0.0)
+
+    def test_blast_radius_from_writes(self):
+        events = [_write_ev("a.py"), _write_ev("b.py"), _write_ev("a.py")]
+        meta = _add_session(self.store, "s3", events=events)
+        m = _session_metrics(self.store, meta)
+        self.assertEqual(m["agent_strace.session.blast_radius"], 2.0)
+
+    def test_all_metric_keys_present(self):
+        meta = _add_session(self.store, "s4")
+        m = _session_metrics(self.store, meta)
+        expected_keys = {
+            "agent_strace.session.cost_usd",
+            "agent_strace.session.error_rate",
+            "agent_strace.session.retry_rate",
+            "agent_strace.session.blast_radius",
+            "agent_strace.session.duration_s",
+            "agent_strace.session.tool_calls",
+        }
+        self.assertEqual(set(m.keys()), expected_keys)
+
+
+# ---------------------------------------------------------------------------
+# ISO timestamp helper
+# ---------------------------------------------------------------------------
+
+class TestIso(unittest.TestCase):
+    def test_returns_z_suffix(self):
+        s = _iso(1748000000.0)
+        self.assertTrue(s.endswith("Z"))
+
+    def test_parseable(self):
+        from datetime import datetime
+        s = _iso(1748000000.0)
+        # Should not raise
+        datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+# ---------------------------------------------------------------------------
+# Integration: export_session_to_langfuse (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestExportSessionToLangfuse(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def _mock_urlopen(self, status: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status = status
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_export_calls_langfuse_endpoint(self):
+        events = [_tool_call("Bash", event_id="tc1"), _tool_result("Bash", parent_id="tc1")]
+        _add_session(self.store, "sess_lf", events=events)
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen(200)) as mock_open:
+            result = export_session_to_langfuse(self.store, "sess_lf", cfg, include_scores=False)
+
+        self.assertTrue(result)
+        mock_open.assert_called_once()
+        call_args = mock_open.call_args[0][0]
+        self.assertIn("/api/public/ingestion", call_args.full_url)
+
+    def test_export_includes_scores_when_present(self):
+        _add_session(self.store, "sess_scores")
+        _write_eval_json(self.store, "sess_scores", [
+            {"scorer": "no_errors", "score": 1.0, "threshold": 1.0, "passed": True}
+        ])
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+
+        posted_bodies = []
+
+        def _capture_urlopen(req, timeout=30):
+            posted_bodies.append(json.loads(req.data))
+            return self._mock_urlopen(200)
+
+        with patch("urllib.request.urlopen", side_effect=_capture_urlopen):
+            export_session_to_langfuse(self.store, "sess_scores", cfg, include_scores=True)
+
+        batch = posted_bodies[0]["batch"]
+        score_items = [b for b in batch if b["type"] == "score-create"]
+        self.assertEqual(len(score_items), 1)
+        self.assertEqual(score_items[0]["body"]["name"], "no_errors")
+
+    def test_export_returns_false_on_http_error(self):
+        _add_session(self.store, "sess_fail")
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+
+        import urllib.error
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+            result = export_session_to_langfuse(self.store, "sess_fail", cfg)
+
+        self.assertFalse(result)
+
+    def test_missing_session_returns_false(self):
+        cfg = LangfuseConfig(public_key="pk", secret_key="sk")
+        result = export_session_to_langfuse(self.store, "nonexistent", cfg)
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# Integration: export_metrics_to_otlp (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestExportMetricsToOtlp(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def _mock_urlopen(self, status: int = 200):
+        mock_resp = MagicMock()
+        mock_resp.status = status
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_metrics_posted_to_otlp_endpoint(self):
+        _add_session(self.store, "m1", total_tokens=500)
+        cfg = OtlpMetricsConfig(endpoint="http://localhost:4318")
+
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen(200)) as mock_open:
+            result = export_metrics_to_otlp(self.store, ["m1"], cfg, include_scores=False)
+
+        self.assertTrue(result)
+        mock_open.assert_called_once()
+        call_args = mock_open.call_args[0][0]
+        self.assertIn("/v1/metrics", call_args.full_url)
+
+    def test_payload_contains_cost_metric(self):
+        _add_session(self.store, "m2", total_tokens=1_000_000)
+        cfg = OtlpMetricsConfig(endpoint="http://localhost:4318")
+
+        posted_bodies = []
+
+        def _capture(req, timeout=30):
+            posted_bodies.append(json.loads(req.data))
+            return self._mock_urlopen(200)
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            export_metrics_to_otlp(self.store, ["m2"], cfg, include_scores=False)
+
+        metrics = posted_bodies[0]["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+        names = [m["name"] for m in metrics]
+        self.assertIn("agent_strace.session.cost_usd", names)
+
+    def test_eval_scores_included_as_metrics(self):
+        _add_session(self.store, "m3")
+        _write_eval_json(self.store, "m3", [
+            {"scorer": "no_errors", "score": 1.0, "threshold": 1.0, "passed": True}
+        ])
+        cfg = OtlpMetricsConfig(endpoint="http://localhost:4318")
+
+        posted_bodies = []
+
+        def _capture(req, timeout=30):
+            posted_bodies.append(json.loads(req.data))
+            return self._mock_urlopen(200)
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            export_metrics_to_otlp(self.store, ["m3"], cfg, include_scores=True)
+
+        metrics = posted_bodies[0]["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+        names = [m["name"] for m in metrics]
+        self.assertIn("agent_strace.eval.score", names)
+
+    def test_empty_session_list_returns_true(self):
+        cfg = OtlpMetricsConfig(endpoint="http://localhost:4318")
+        result = export_metrics_to_otlp(self.store, [], cfg)
+        self.assertTrue(result)
+
+    def test_http_error_returns_false(self):
+        _add_session(self.store, "m4")
+        cfg = OtlpMetricsConfig(endpoint="http://localhost:4318")
+
+        import urllib.error
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            result = export_metrics_to_otlp(self.store, ["m4"], cfg)
+
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Extends `agent-strace export` with `--scores` and `--backend` flags to push eval scores and behavioral metrics to Langfuse and any OTLP-compatible backend.

Closes #71

## Langfuse path (`--backend langfuse`)

Sessions, tool calls, LLM calls, and eval scores are exported via Langfuse's `/api/public/ingestion` batch API:

| agent-strace concept | Langfuse concept |
|---|---|
| Session | Trace |
| Tool call + result pair | Span (`type=SPAN`) |
| LLM request + response pair | Generation (with token counts) |
| `eval.json` judge score | Score attached to trace |

```
# Export latest session with eval scores
agent-strace export --scores --backend langfuse

# Export last 7 days
agent-strace export --since 7d --scores --backend langfuse

# Credentials via env or flags
export LANGFUSE_PUBLIC_KEY=pk-lf-...
export LANGFUSE_SECRET_KEY=sk-lf-...
```

## OTLP metrics path (`--backend otlp`)

Behavioral metrics exported as OTLP gauge metrics to `/v1/metrics`:

```
agent_strace.session.cost_usd
agent_strace.session.error_rate
agent_strace.session.retry_rate
agent_strace.session.blast_radius
agent_strace.session.duration_s
agent_strace.session.tool_calls
agent_strace.eval.score          (one per judge, with judge= attribute)
```

```
agent-strace export --metrics --backend otlp --since 30d
export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
```

## Files changed

- `src/agent_trace/langfuse_export.py` — `LangfuseConfig`, `OtlpMetricsConfig`, `EvalScore`, `export_session_to_langfuse()`, `export_metrics_to_otlp()`, `cmd_export_scores()`
- `src/agent_trace/cli.py` — `--scores`, `--metrics`, `--backend`, `--since`, `--langfuse-*`, `--otlp-*` flags on `export`; routes to `cmd_export_scores` when any are set
- `tests/test_langfuse_export.py` — 31 new tests (mocked HTTP, no real network calls)

## Test results

```
Ran 597 tests — OK (31 new)
```