### PR TITLE
feat: LLM-as-judge scorer, dataset auto-sampling, eval --ci baseline

### DIFF
--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -575,6 +575,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_eval_ci = eval_sub.add_parser("ci", help="run evals and exit 1 if any scorer fails")
     p_eval_ci.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
     p_eval_ci.add_argument("--config", default=".agent-evals.yaml")
+    p_eval_ci.add_argument("--baseline", metavar="FILE",
+                           help="compare scores against a saved baseline JSON")
+    p_eval_ci.add_argument("--save-baseline", dest="save_baseline", metavar="FILE",
+                           help="save current scores as a baseline and exit")
+    p_eval_ci.add_argument("--tolerance", type=float, default=0.0, metavar="N",
+                           help="allow up to N regression vs baseline before failing (default: 0)")
+    p_eval_ci.add_argument("--github-summary", dest="github_summary", action="store_true",
+                           help="write PR-comment Markdown to .agent-traces/eval-summary.md")
 
     p_eval_dataset = eval_sub.add_parser("dataset", help="manage eval datasets")
     dataset_sub = p_eval_dataset.add_subparsers(dest="dataset_command")
@@ -587,6 +595,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_ds_export = dataset_sub.add_parser("export", help="export dataset to JSONL")
     p_ds_export.add_argument("--dataset", default=".agent-traces/datasets/default.jsonl")
+    p_ds_auto = dataset_sub.add_parser("auto", help="auto-populate dataset from sessions by signal filter")
+    p_ds_auto.add_argument("--name", default="default", help="dataset name (default: default)")
+    p_ds_auto.add_argument("--dataset", default="", help="explicit dataset path (overrides --name)")
+    p_ds_auto.add_argument("--filter", default="has-errors",
+                           help="filter: has-errors, high-retry, cost-above:N, wide-blast, "
+                                "long-duration:Ns, low-eval-score:N (default: has-errors)")
+    p_ds_auto.add_argument("--since", default="7d", metavar="Nd",
+                           help="look back N days (default: 7d)")
+    p_ds_auto.add_argument("--label", default="", help="label for added entries")
 
     # watch
     p_watch = sub.add_parser("watch", help="monitor a live session with circuit breakers")

--- a/src/agent_trace/eval/dataset.py
+++ b/src/agent_trace/eval/dataset.py
@@ -13,6 +13,10 @@ import time
 import uuid
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..store import TraceStore
 
 
 
@@ -69,6 +73,138 @@ def export_entries(dataset_path: str | Path, out=sys.stdout) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Auto-sampling: populate a dataset from stored sessions by signal filter
+# ---------------------------------------------------------------------------
+
+def _session_passes_filter(
+    store: "TraceStore",
+    session_id: str,
+    filter_spec: str,
+    eval_threshold: float = 0.8,
+) -> bool:
+    """Return True if the session matches the given filter spec.
+
+    Supported filters:
+      has-errors          — session has at least one ERROR event
+      high-retry          — retry rate > 30%
+      cost-above:N        — estimated cost > $N
+      wide-blast          — distinct files written > 10
+      long-duration:Ns    — session duration > N seconds
+      low-eval-score:N    — eval.json overall score < N
+    """
+    from ..models import EventType
+
+    try:
+        events = store.load_events(session_id)
+        meta = store.load_meta(session_id)
+    except Exception:
+        return False
+
+    spec = filter_spec.strip().lower()
+
+    if spec == "has-errors":
+        return any(e.event_type == EventType.ERROR for e in events)
+
+    if spec == "high-retry":
+        tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+        if not tool_calls:
+            return False
+        retries = 0
+        prev = None
+        run = 0
+        for ev in tool_calls:
+            name = ev.data.get("tool_name", "")
+            if name == prev:
+                run += 1
+                if run >= 2:
+                    retries += 1
+            else:
+                prev = name
+                run = 0
+        return retries / len(tool_calls) > 0.30
+
+    if spec.startswith("cost-above:"):
+        try:
+            threshold_dollars = float(spec.split(":", 1)[1])
+        except ValueError:
+            return False
+        cost = meta.total_tokens / 1_000_000 * 3.0
+        return cost > threshold_dollars
+
+    if spec == "wide-blast":
+        files: set[str] = set()
+        for ev in events:
+            if ev.event_type == EventType.FILE_WRITE:
+                p = ev.data.get("path") or ev.data.get("file_path") or ""
+                if p:
+                    files.add(p)
+        return len(files) > 10
+
+    if spec.startswith("long-duration:"):
+        try:
+            max_s = float(spec.split(":", 1)[1].rstrip("s"))
+        except ValueError:
+            return False
+        duration = meta.total_duration_ms / 1000 if meta.total_duration_ms else 0.0
+        return duration > max_s
+
+    if spec.startswith("low-eval-score:"):
+        try:
+            score_threshold = float(spec.split(":", 1)[1])
+        except ValueError:
+            score_threshold = eval_threshold
+        eval_path = store.base_dir / session_id / "eval.json"
+        if not eval_path.exists():
+            return False
+        try:
+            data = json.loads(eval_path.read_text())
+            results = data.get("results") or data.get("judges") or []
+            if not results:
+                return False
+            avg = sum(float(r.get("score", 0)) for r in results) / len(results)
+            return avg < score_threshold
+        except Exception:
+            return False
+
+    return False
+
+
+def auto_populate(
+    store: "TraceStore",
+    dataset_path: str | Path,
+    filter_spec: str,
+    since_days: float = 7.0,
+    label: str = "",
+    limit: int = 500,
+) -> int:
+    """Auto-populate a dataset from sessions matching a filter.
+
+    Returns the number of entries added.
+    """
+    cutoff = time.time() - since_days * 86400
+    added = 0
+
+    existing = {e.session_id for e in list_entries(dataset_path)}
+
+    for meta in store.list_sessions():
+        if meta.started_at < cutoff:
+            continue
+        if meta.session_id in existing:
+            continue
+        if added >= limit:
+            break
+        if _session_passes_filter(store, meta.session_id, filter_spec):
+            entry = DatasetEntry(
+                session_id=meta.session_id,
+                label=label or filter_spec,
+            )
+            add_entry(dataset_path, entry)
+            added += 1
+
+    return added
+
+
+# ---------------------------------------------------------------------------
 # CLI handler
 # ---------------------------------------------------------------------------
 
@@ -104,5 +240,17 @@ def cmd_dataset(args: argparse.Namespace) -> int:
         export_entries(dataset_path)
         return 0
 
-    sys.stderr.write("Usage: agent-strace eval dataset <add|list|export>\n")
+    if dataset_command == "auto":
+        from ..store import TraceStore
+        filter_spec = getattr(args, "filter", "has-errors") or "has-errors"
+        since_raw = getattr(args, "since", "7d") or "7d"
+        since_days = float(since_raw.rstrip("d"))
+        label = getattr(args, "label", "") or filter_spec
+        trace_dir = getattr(args, "trace_dir", ".agent-traces")
+        store = TraceStore(trace_dir)
+        added = auto_populate(store, dataset_path, filter_spec, since_days=since_days, label=label)
+        sys.stdout.write(f"Added {added} session(s) to {dataset_path} (filter: {filter_spec})\n")
+        return 0
+
+    sys.stderr.write("Usage: agent-strace eval dataset <add|list|export|auto>\n")
     return 1

--- a/src/agent_trace/eval/runner.py
+++ b/src/agent_trace/eval/runner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 from dataclasses import dataclass, field
 
 from ..store import TraceStore
@@ -211,8 +212,74 @@ def cmd_eval_compare(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_baseline(path: str) -> dict[str, float]:
+    """Load a saved baseline: {scorer_name: score}."""
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def _save_baseline(path: str, report: "EvalReport") -> None:
+    """Save current scores as a baseline file."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data = {r.scorer: r.score for r in report.results}
+    p.write_text(json.dumps(data, indent=2))
+
+
+def _write_github_summary(report: "EvalReport", baseline: dict[str, float], tolerance: float) -> None:
+    """Write a PR-comment-ready Markdown summary to .agent-traces/eval-summary.md."""
+    lines = ["## agent-strace eval\n"]
+    lines.append("| Judge | Pass rate | Baseline | Delta | Status |")
+    lines.append("|---|---|---|---|---|")
+    for r in report.results:
+        base_score = baseline.get(r.scorer)
+        if base_score is not None:
+            delta = r.score - base_score
+            delta_str = f"{delta:+.0%}"
+            regressed = delta < -tolerance
+            status = "❌" if regressed else "✅"
+            base_str = f"{base_score:.0%}"
+        else:
+            delta_str = "—"
+            status = "✅" if r.passed else "❌"
+            base_str = "—"
+        lines.append(f"| `{r.scorer}` | {r.score:.0%} | {base_str} | {delta_str} | {status} |")
+
+    lines.append("")
+    if report.overall_passed:
+        lines.append("**Result: PASS**")
+    else:
+        lines.append(f"**Result: FAIL** — {report.failed} scorer(s) below threshold.")
+
+    failing = [r for r in report.results if not r.passed]
+    if failing:
+        lines.append("")
+        lines.append("<details>")
+        lines.append("<summary>Failing scorers</summary>")
+        lines.append("")
+        for r in failing:
+            lines.append(f"- `{r.scorer}` — score {r.score:.2f} (threshold {r.threshold:.2f}): {r.reason}")
+        lines.append("")
+        lines.append("</details>")
+
+    summary_path = Path(".agent-traces/eval-summary.md")
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text("\n".join(lines) + "\n")
+    sys.stderr.write(f"GitHub summary written to {summary_path}\n")
+
+
 def cmd_eval_ci(args: argparse.Namespace) -> int:
-    """Run evals and exit 1 if any scorer fails (for CI integration)."""
+    """Run evals and exit 1 if any scorer fails (for CI integration).
+
+    Supports baseline comparison (--baseline), saving baselines
+    (--save-baseline), regression tolerance (--tolerance), and
+    GitHub Actions PR comment output (--github-summary).
+    """
     store = TraceStore(args.trace_dir)
     config = load_config(getattr(args, "config", ".agent-evals.yaml"))
 
@@ -222,12 +289,44 @@ def cmd_eval_ci(args: argparse.Namespace) -> int:
         return 1
 
     report = run_eval(store, session_id, config)
-    # Route table to stderr so CI output is pipeable without noise
     format_report_table(report, out=sys.stderr)
 
-    if report.overall_passed:
-        sys.stderr.write("CI: all scorers passed\n")
+    # Save baseline if requested
+    save_baseline_path = getattr(args, "save_baseline", None)
+    if save_baseline_path:
+        _save_baseline(save_baseline_path, report)
+        sys.stderr.write(f"Baseline saved to {save_baseline_path}\n")
         return 0
-    else:
-        sys.stderr.write(f"CI: {report.failed} scorer(s) failed\n")
+
+    # Load baseline for comparison
+    baseline_path = getattr(args, "baseline", None)
+    baseline: dict[str, float] = {}
+    if baseline_path:
+        baseline = _load_baseline(baseline_path)
+
+    tolerance = float(getattr(args, "tolerance", 0.0) or 0.0)
+
+    # GitHub summary
+    if getattr(args, "github_summary", False):
+        _write_github_summary(report, baseline, tolerance)
+
+    # Determine pass/fail with optional baseline regression check
+    failed = False
+    if not report.overall_passed:
+        failed = True
+    elif baseline:
+        for r in report.results:
+            base_score = baseline.get(r.scorer)
+            if base_score is not None and (r.score - base_score) < -tolerance:
+                sys.stderr.write(
+                    f"CI: {r.scorer} regressed {r.score:.2f} vs baseline {base_score:.2f} "
+                    f"(tolerance {tolerance:.2f})\n"
+                )
+                failed = True
+
+    if failed:
+        sys.stderr.write(f"CI: FAIL — {report.failed} scorer(s) failed\n")
         return 1
+
+    sys.stderr.write("CI: PASS — all scorers passed\n")
+    return 0

--- a/src/agent_trace/eval/scorers.py
+++ b/src/agent_trace/eval/scorers.py
@@ -163,6 +163,85 @@ def score_custom(
     return ScoreResult(name, score, threshold, score >= threshold, "custom scorer")
 
 
+def score_llm_judge(
+    events: list[TraceEvent],
+    prompt: str,
+    base_url: str,
+    api_key: str,
+    model: str = "gpt-4o-mini",
+    threshold: float = 1.0,
+) -> ScoreResult:
+    """Call an LLM to judge the session. Returns a score in [0, 1].
+
+    The prompt receives a compact session summary. The LLM must respond
+    with JSON: {"score": <float 0-1>, "reason": "<string>"}.
+    Uses urllib.request — zero new dependencies.
+    """
+    import json as _json
+    import urllib.error
+    import urllib.request
+
+    if not base_url or not api_key:
+        return ScoreResult("llm_judge", 0.0, threshold, False,
+                           "base_url and api_key required for llm_judge scorer")
+
+    # Build a compact session summary for the LLM
+    tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+    errors = [e for e in events if e.event_type == EventType.ERROR]
+    summary_lines = [
+        f"Session: {len(events)} events, {len(tool_calls)} tool calls, {len(errors)} errors.",
+    ]
+    for ev in tool_calls[:15]:
+        name = ev.data.get("tool_name", "unknown")
+        summary_lines.append(f"  TOOL_CALL: {name}")
+    for ev in errors[:5]:
+        msg = str(ev.data.get("message", ""))[:80]
+        summary_lines.append(f"  ERROR: {msg}")
+    session_summary = "\n".join(summary_lines)
+
+    full_prompt = (
+        f"{prompt}\n\n"
+        f"Session summary:\n{session_summary}\n\n"
+        "Respond with JSON only: {\"score\": <float 0.0-1.0>, \"reason\": \"<one sentence>\"}"
+    )
+
+    payload = _json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": full_prompt}],
+        "temperature": 0.1,
+        "max_tokens": 256,
+    }).encode()
+
+    url = base_url.rstrip("/") + "/chat/completions"
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = _json.loads(resp.read())
+            content = data["choices"][0]["message"]["content"].strip()
+            # Strip markdown fences if present
+            if content.startswith("```"):
+                content = "\n".join(content.split("\n")[1:])
+            if content.endswith("```"):
+                content = "\n".join(content.split("\n")[:-1])
+            result = _json.loads(content)
+            score = float(max(0.0, min(1.0, result.get("score", 0.0))))
+            reason = str(result.get("reason", ""))[:200]
+            return ScoreResult("llm_judge", score, threshold, score >= threshold, reason)
+    except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+        return ScoreResult("llm_judge", 0.0, threshold, False, f"LLM request failed: {exc}")
+    except (_json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        return ScoreResult("llm_judge", 0.0, threshold, False, f"LLM response parse error: {exc}")
+
+
 # ---------------------------------------------------------------------------
 # Scorer registry (name → factory)
 # ---------------------------------------------------------------------------
@@ -204,6 +283,17 @@ def run_scorer(
         return score_duration_under(
             events,
             max_seconds=float(config.get("max_seconds", 120.0)),
+            threshold=threshold,
+        )
+
+    if name == "llm_judge":
+        import os
+        return score_llm_judge(
+            events,
+            prompt=config.get("prompt", "Did the agent complete the task correctly?"),
+            base_url=config.get("base_url", "") or os.environ.get("OPENAI_BASE_URL", "") or os.environ.get("AGENT_STRACE_LLM_URL", ""),
+            api_key=config.get("api_key", "") or os.environ.get("OPENAI_API_KEY", "") or os.environ.get("AGENT_STRACE_LLM_KEY", ""),
+            model=config.get("model", "gpt-4o-mini"),
             threshold=threshold,
         )
 

--- a/tests/test_eval_extensions.py
+++ b/tests/test_eval_extensions.py
@@ -1,0 +1,403 @@
+"""Tests for eval extensions: LLM judge scorer, dataset auto-sampling, eval --ci baseline."""
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_trace.eval.config import EvalConfig
+from agent_trace.eval.dataset import DatasetEntry, add_entry, auto_populate, list_entries
+from agent_trace.eval.runner import (
+    EvalReport,
+    _load_baseline,
+    _save_baseline,
+    _write_github_summary,
+)
+from agent_trace.eval.scorers import ScoreResult, run_scorer, score_llm_judge
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store(tmp: str) -> TraceStore:
+    return TraceStore(tmp)
+
+
+def _add_session(
+    store: TraceStore,
+    session_id: str,
+    events: list[TraceEvent] | None = None,
+    started_at: float | None = None,
+    total_tokens: int = 1000,
+    total_duration_ms: float = 60_000,
+) -> SessionMeta:
+    ts = started_at or time.time()
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=ts,
+        ended_at=ts + 60,
+        total_tokens=total_tokens,
+        total_duration_ms=total_duration_ms,
+    )
+    store.create_session(meta)
+    for ev in (events or []):
+        store.append_event(session_id, ev)
+    return meta
+
+
+def _tool(name: str, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.TOOL_CALL, timestamp=ts, data={"tool_name": name})
+
+
+def _error(ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.ERROR, timestamp=ts, data={"message": "fail"})
+
+
+def _write(path: str, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=EventType.FILE_WRITE, timestamp=ts, data={"path": path})
+
+
+def _make_report(scores: list[tuple[str, float, float, bool]]) -> EvalReport:
+    """Build an EvalReport from (scorer, score, threshold, passed) tuples."""
+    results = [
+        ScoreResult(scorer=s, score=sc, threshold=th, passed=p, reason="")
+        for s, sc, th, p in scores
+    ]
+    return EvalReport(
+        session_id="test",
+        results=results,
+        config=EvalConfig.default(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM judge scorer
+# ---------------------------------------------------------------------------
+
+class TestScoreLlmJudge(unittest.TestCase):
+    def _events(self) -> list[TraceEvent]:
+        return [_tool("Bash"), _tool("Read")]
+
+    def _mock_urlopen(self, score: float = 0.9, reason: str = "looks good"):
+        resp_body = json.dumps({
+            "choices": [{"message": {"content": json.dumps({"score": score, "reason": reason})}}]
+        }).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = resp_body
+        mock_resp.status = 200
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_returns_score_from_llm(self):
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen(0.85)):
+            result = score_llm_judge(
+                self._events(),
+                prompt="Did the agent complete the task?",
+                base_url="http://localhost:11434/v1",
+                api_key="test",
+                model="llama3",
+                threshold=0.80,
+            )
+        self.assertAlmostEqual(result.score, 0.85)
+        self.assertTrue(result.passed)
+        self.assertEqual(result.scorer, "llm_judge")
+
+    def test_fails_below_threshold(self):
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen(0.5)):
+            result = score_llm_judge(
+                self._events(),
+                prompt="Did the agent complete the task?",
+                base_url="http://localhost:11434/v1",
+                api_key="test",
+                threshold=0.80,
+            )
+        self.assertFalse(result.passed)
+
+    def test_missing_credentials_returns_failure(self):
+        result = score_llm_judge(
+            self._events(),
+            prompt="test",
+            base_url="",
+            api_key="",
+        )
+        self.assertEqual(result.score, 0.0)
+        self.assertFalse(result.passed)
+        self.assertIn("required", result.reason)
+
+    def test_http_error_returns_failure(self):
+        import urllib.error
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            result = score_llm_judge(
+                self._events(),
+                prompt="test",
+                base_url="http://localhost:11434/v1",
+                api_key="key",
+            )
+        self.assertEqual(result.score, 0.0)
+        self.assertFalse(result.passed)
+
+    def test_malformed_json_response_returns_failure(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"choices": [{"message": {"content": "not json"}}]}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = score_llm_judge(
+                self._events(),
+                prompt="test",
+                base_url="http://localhost:11434/v1",
+                api_key="key",
+            )
+        self.assertEqual(result.score, 0.0)
+
+    def test_score_clamped_to_0_1(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "choices": [{"message": {"content": json.dumps({"score": 1.5, "reason": "great"})}}]
+        }).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = score_llm_judge(
+                self._events(), prompt="test",
+                base_url="http://localhost:11434/v1", api_key="key",
+            )
+        self.assertLessEqual(result.score, 1.0)
+
+    def test_markdown_fences_stripped(self):
+        content = "```json\n" + json.dumps({"score": 0.7, "reason": "ok"}) + "\n```"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "choices": [{"message": {"content": content}}]
+        }).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = score_llm_judge(
+                self._events(), prompt="test",
+                base_url="http://localhost:11434/v1", api_key="key",
+            )
+        self.assertAlmostEqual(result.score, 0.7)
+
+    def test_dispatched_via_run_scorer(self):
+        """llm_judge is reachable through the standard run_scorer dispatch."""
+        import os
+        events = self._events()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({
+            "choices": [{"message": {"content": json.dumps({"score": 0.9, "reason": "ok"})}}]
+        }).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = run_scorer(
+                "llm_judge",
+                {
+                    "prompt": "Did the agent succeed?",
+                    "base_url": "http://localhost:11434/v1",
+                    "api_key": "key",
+                    "model": "llama3",
+                    "threshold": 0.8,
+                },
+                events,
+            )
+        self.assertEqual(result.scorer, "llm_judge")
+        self.assertAlmostEqual(result.score, 0.9)
+
+
+# ---------------------------------------------------------------------------
+# Dataset auto-sampling
+# ---------------------------------------------------------------------------
+
+class TestDatasetAutoPopulate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+        self.ds_path = Path(self.tmp) / "test.jsonl"
+
+    def test_has_errors_filter(self):
+        now = time.time()
+        _add_session(self.store, "s_err", [_error()], started_at=now - 100)
+        _add_session(self.store, "s_ok", [_tool("Bash")], started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "has-errors", since_days=1)
+        self.assertEqual(added, 1)
+        entries = list_entries(self.ds_path)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].session_id, "s_err")
+
+    def test_high_retry_filter(self):
+        now = time.time()
+        # 3 consecutive same-tool calls = 2 retries / 3 calls = 67% > 30%
+        events = [_tool("Bash"), _tool("Bash"), _tool("Bash")]
+        _add_session(self.store, "s_retry", events, started_at=now - 100)
+        _add_session(self.store, "s_ok", [_tool("Bash"), _tool("Read")], started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "high-retry", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_retry")
+
+    def test_cost_above_filter(self):
+        now = time.time()
+        # 1M tokens * $3/M = $3.00 > $1.00
+        _add_session(self.store, "s_expensive", total_tokens=1_000_000, started_at=now - 100)
+        _add_session(self.store, "s_cheap", total_tokens=100, started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "cost-above:1.00", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_expensive")
+
+    def test_wide_blast_filter(self):
+        now = time.time()
+        events = [_write(f"src/file{i}.py") for i in range(11)]
+        _add_session(self.store, "s_wide", events, started_at=now - 100)
+        _add_session(self.store, "s_narrow", [_write("src/a.py")], started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "wide-blast", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_wide")
+
+    def test_long_duration_filter(self):
+        now = time.time()
+        _add_session(self.store, "s_long", total_duration_ms=600_000, started_at=now - 100)
+        _add_session(self.store, "s_short", total_duration_ms=10_000, started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "long-duration:300s", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_long")
+
+    def test_low_eval_score_filter(self):
+        now = time.time()
+        _add_session(self.store, "s_bad", started_at=now - 100)
+        _add_session(self.store, "s_good", started_at=now - 100)
+        # Write eval.json for both
+        (self.store.base_dir / "s_bad" / "eval.json").write_text(
+            json.dumps({"results": [{"scorer": "x", "score": 0.3, "threshold": 1.0, "passed": False}]})
+        )
+        (self.store.base_dir / "s_good" / "eval.json").write_text(
+            json.dumps({"results": [{"scorer": "x", "score": 0.95, "threshold": 1.0, "passed": True}]})
+        )
+        added = auto_populate(self.store, self.ds_path, "low-eval-score:0.5", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_bad")
+
+    def test_since_filter_excludes_old_sessions(self):
+        now = time.time()
+        _add_session(self.store, "s_old", [_error()], started_at=now - 86400 * 10)
+        _add_session(self.store, "s_new", [_error()], started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "has-errors", since_days=1)
+        self.assertEqual(added, 1)
+        self.assertEqual(list_entries(self.ds_path)[0].session_id, "s_new")
+
+    def test_no_duplicates_added(self):
+        now = time.time()
+        _add_session(self.store, "s_err", [_error()], started_at=now - 100)
+        auto_populate(self.store, self.ds_path, "has-errors", since_days=1)
+        added_second = auto_populate(self.store, self.ds_path, "has-errors", since_days=1)
+        self.assertEqual(added_second, 0)
+        self.assertEqual(len(list_entries(self.ds_path)), 1)
+
+    def test_label_applied(self):
+        now = time.time()
+        _add_session(self.store, "s_err", [_error()], started_at=now - 100)
+        auto_populate(self.store, self.ds_path, "has-errors", since_days=1, label="my-label")
+        entries = list_entries(self.ds_path)
+        self.assertEqual(entries[0].label, "my-label")
+
+    def test_unknown_filter_returns_zero(self):
+        now = time.time()
+        _add_session(self.store, "s1", [_error()], started_at=now - 100)
+        added = auto_populate(self.store, self.ds_path, "nonexistent-filter", since_days=1)
+        self.assertEqual(added, 0)
+
+
+# ---------------------------------------------------------------------------
+# eval --ci baseline
+# ---------------------------------------------------------------------------
+
+class TestEvalCiBaseline(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_save_and_load_baseline(self):
+        report = _make_report([
+            ("no_errors", 1.0, 1.0, True),
+            ("cost_under", 0.8, 0.9, False),
+        ])
+        path = str(Path(self.tmp) / "baseline.json")
+        _save_baseline(path, report)
+        loaded = _load_baseline(path)
+        self.assertAlmostEqual(loaded["no_errors"], 1.0)
+        self.assertAlmostEqual(loaded["cost_under"], 0.8)
+
+    def test_load_missing_baseline_returns_empty(self):
+        loaded = _load_baseline("/nonexistent/path/baseline.json")
+        self.assertEqual(loaded, {})
+
+    def test_load_malformed_baseline_returns_empty(self):
+        path = str(Path(self.tmp) / "bad.json")
+        Path(path).write_text("not json")
+        loaded = _load_baseline(path)
+        self.assertEqual(loaded, {})
+
+    def test_github_summary_written(self):
+        report = _make_report([
+            ("no_errors", 0.9, 0.8, True),
+            ("cost_under", 0.6, 0.8, False),
+        ])
+        baseline = {"no_errors": 0.7, "cost_under": 0.8}
+        import os
+        orig = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            _write_github_summary(report, baseline, tolerance=0.0)
+            summary = Path(".agent-traces/eval-summary.md").read_text()
+        finally:
+            os.chdir(orig)
+        self.assertIn("agent-strace eval", summary)
+        self.assertIn("no_errors", summary)
+        self.assertIn("cost_under", summary)
+        self.assertIn("FAIL", summary)
+
+    def test_github_summary_pass(self):
+        report = _make_report([("no_errors", 1.0, 1.0, True)])
+        import os
+        orig = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            _write_github_summary(report, {}, tolerance=0.0)
+            summary = Path(".agent-traces/eval-summary.md").read_text()
+        finally:
+            os.chdir(orig)
+        self.assertIn("PASS", summary)
+
+    def test_github_summary_shows_delta(self):
+        report = _make_report([("no_errors", 0.9, 0.8, True)])
+        baseline = {"no_errors": 0.7}
+        import os
+        orig = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            _write_github_summary(report, baseline, tolerance=0.0)
+            summary = Path(".agent-traces/eval-summary.md").read_text()
+        finally:
+            os.chdir(orig)
+        # Delta should be +20%
+        self.assertIn("+20%", summary)
+
+    def test_github_summary_no_baseline_shows_dashes(self):
+        report = _make_report([("no_errors", 1.0, 1.0, True)])
+        import os
+        orig = os.getcwd()
+        os.chdir(self.tmp)
+        try:
+            _write_github_summary(report, {}, tolerance=0.0)
+            summary = Path(".agent-traces/eval-summary.md").read_text()
+        finally:
+            os.chdir(orig)
+        self.assertIn("—", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #65, #66, #69

## Changes

### LLM-as-judge scorer (`score_llm_judge`)
- Calls any OpenAI-compatible endpoint (`base_url` + `api_key` + `model`)
- Sends a user-supplied prompt with the session event summary
- Parses `{"score": float, "reason": str}` from the response, strips markdown fences, clamps score to `[0, 1]`
- Dispatched via `run_scorer("llm_judge", {...}, events)` alongside existing scorers
- Graceful failure (score=0, passed=False) on missing credentials, HTTP errors, or malformed JSON

### Dataset auto-sampling (`eval dataset auto`)
- `auto_populate(store, path, filter, since_days, label)` scans recent sessions and adds matching ones to a `.jsonl` dataset
- Six built-in filters: `has-errors`, `high-retry`, `cost-above:<usd>`, `wide-blast`, `long-duration:<Ns>`, `low-eval-score:<threshold>`
- Deduplicates against existing dataset entries; returns count of newly added sessions
- CLI: `agent-strace eval dataset auto --filter has-errors --since-days 7`

### eval --ci baseline comparison
- `--save-baseline <path>`: saves current scorer scores as a JSON baseline
- `--baseline <path>`: loads baseline and checks for regressions
- `--tolerance <float>`: allowed score drop before flagging regression (default 0.0)
- `--github-summary`: writes `.agent-traces/eval-summary.md` with a PR-comment-ready Markdown table showing score, baseline, delta, and pass/fail per scorer

## Tests
25 new tests in `tests/test_eval_extensions.py` covering all three features. Full suite: 700 tests, all passing.
