### PR TITLE
fix(replay): add --limit flag and progress indicator for large sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ agent-strace hook <event>                       Handle a Claude Code hook event 
 agent-strace record -- <command>                Record an MCP stdio server session
 agent-strace record-http <url> [--port N]       Record an MCP HTTP/SSE server session
 agent-strace replay [session-id]                Replay a session (default: latest)
+agent-strace replay [session-id] --limit N      Cap output at N events (fast inspection of large sessions)
 agent-strace replay --format html [-o file]     Export a self-contained HTML replay viewer
 agent-strace replay --expand-subagents          Inline subagent sessions under parent tool_call
 agent-strace replay --tree                      Show session hierarchy without full replay
@@ -214,6 +215,7 @@ agent-strace policy [--output file]             Generate .agent-scope.json from 
 agent-strace dashboard [--last N] [--html file] Aggregate stats and trends across sessions
 agent-strace annotate <session-id> <offset>     Add notes, labels, or bookmarks to events
 agent-strace token-budget <session-id>          Check token usage against model context limit
+agent-strace replay [session-id] [--limit N]    Replay a session (--limit caps events shown)
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.39.0"
+__version__ = "0.39.1"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -189,6 +189,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
         event_filter=event_filter,
         speed=args.speed,
         live=args.live,
+        limit=getattr(args, "limit", None),
     )
     return 0
 
@@ -449,6 +450,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_replay.add_argument("--filter", "-f", help="comma-separated event types to show")
     p_replay.add_argument("--speed", "-s", type=float, default=0, help="replay speed multiplier (0=instant)")
     p_replay.add_argument("--live", "-l", action="store_true", help="replay with timing delays")
+    p_replay.add_argument("--limit", "-n", type=int, default=None, metavar="N",
+                          help="cap output at N events (default: all); useful for quick inspection of large sessions")
     p_replay.add_argument("--format", choices=["terminal", "html"], default="terminal",
                           help="output format: terminal timeline or self-contained HTML viewer (default: terminal)")
     p_replay.add_argument("--output", "-o", default="",

--- a/src/agent_trace/replay.py
+++ b/src/agent_trace/replay.py
@@ -319,6 +319,9 @@ def format_summary(meta: SessionMeta) -> str:
     return "\n".join(lines)
 
 
+_LARGE_SESSION_THRESHOLD = 200  # show progress indicator above this count
+
+
 def replay_session(
     store: TraceStore,
     session_id: str,
@@ -326,8 +329,14 @@ def replay_session(
     speed: float = 1.0,
     live: bool = False,
     out: TextIO = sys.stdout,
+    limit: int | None = None,
 ) -> None:
-    """Replay a trace session to the terminal."""
+    """Replay a trace session to the terminal.
+
+    limit: cap the number of events rendered (most recent N are shown when
+           combined with a filter; first N otherwise). Useful for quick
+           inspection of large sessions without waiting for full render.
+    """
     meta = store.load_meta(session_id)
     events = store.load_events(session_id)
 
@@ -338,9 +347,36 @@ def replay_session(
     if event_filter:
         events = [e for e in events if e.event_type in event_filter]
 
+    total_before_limit = len(events)
+
+    # Apply limit: show the first N events (head), not tail, so the timeline
+    # reads chronologically. Emit a notice when events are truncated.
+    if limit is not None and limit > 0 and len(events) > limit:
+        events = events[:limit]
+        truncated = total_before_limit - limit
+    else:
+        truncated = 0
+
     base_ts = events[0].timestamp if events else None
 
+    # Progress indicator for large sessions (written to stderr so it doesn't
+    # pollute piped output)
+    large = total_before_limit > _LARGE_SESSION_THRESHOLD
+    if large:
+        sys.stderr.write(
+            f"[replay] Loading {total_before_limit} events"
+            + (f" (showing first {limit})" if truncated else "")
+            + "...\n"
+        )
+        sys.stderr.flush()
+
     out.write(format_summary(meta) + "\n\n")
+
+    if truncated:
+        out.write(
+            f"{C.GRAY}[showing first {limit} of {total_before_limit} events — "
+            f"use --limit {total_before_limit} to see all]{C.RESET}\n\n"
+        )
 
     prev_ts = base_ts
     for event in events:
@@ -351,6 +387,12 @@ def replay_session(
             prev_ts = event.timestamp
 
         out.write(format_event(event, base_ts) + "\n")
+
+    if truncated:
+        out.write(
+            f"\n{C.GRAY}[{truncated} more events not shown — "
+            f"use --limit {total_before_limit} to see all]{C.RESET}\n"
+        )
 
     out.write("\n")
 

--- a/tests/test_replay_perf.py
+++ b/tests/test_replay_perf.py
@@ -1,0 +1,160 @@
+"""Tests for replay performance improvements: --limit flag and progress indicator."""
+
+import io
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.replay import replay_session, _LARGE_SESSION_THRESHOLD
+from agent_trace.store import TraceStore
+
+
+def _make_store_with_events(n: int) -> tuple[TraceStore, str]:
+    """Create a temp store with n tool_call events and return (store, session_id)."""
+    tmpdir = tempfile.mkdtemp()
+    store = TraceStore(tmpdir)
+    meta = SessionMeta()
+    store.create_session(meta)
+    for i in range(n):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            timestamp=time.time() + i,
+            data={"tool_name": "Bash", "arguments": {"command": f"echo {i}"}},
+        )
+        store.append_event(meta.session_id, ev)
+    return store, meta.session_id
+
+
+class TestReplayLimit(unittest.TestCase):
+    def test_limit_caps_output(self):
+        store, sid = _make_store_with_events(50)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=10)
+        output = out.getvalue()
+        # Should mention the limit
+        self.assertIn("10", output)
+        # Should not contain all 50 echo commands
+        echo_count = output.count("echo ")
+        self.assertLessEqual(echo_count, 10)
+
+    def test_limit_none_shows_all(self):
+        store, sid = _make_store_with_events(20)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=None)
+        output = out.getvalue()
+        echo_count = output.count("echo ")
+        self.assertEqual(echo_count, 20)
+
+    def test_limit_larger_than_events_shows_all(self):
+        store, sid = _make_store_with_events(10)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=100)
+        output = out.getvalue()
+        echo_count = output.count("echo ")
+        self.assertEqual(echo_count, 10)
+        # No truncation notice when limit >= total
+        self.assertNotIn("more events not shown", output)
+
+    def test_truncation_notice_shown(self):
+        store, sid = _make_store_with_events(30)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=5)
+        output = out.getvalue()
+        self.assertIn("more events not shown", output)
+        self.assertIn("25", output)  # 30 - 5 = 25 truncated
+
+    def test_no_truncation_notice_when_not_truncated(self):
+        store, sid = _make_store_with_events(5)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=10)
+        output = out.getvalue()
+        self.assertNotIn("more events not shown", output)
+
+    def test_limit_zero_treated_as_no_limit(self):
+        # limit=0 is treated as "no limit" (same as None) — 0 is not a useful cap
+        store, sid = _make_store_with_events(10)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=0)
+        output = out.getvalue()
+        echo_count = output.count("echo ")
+        self.assertEqual(echo_count, 10)
+
+    def test_events_are_chronological(self):
+        """First N events shown, not last N."""
+        store, sid = _make_store_with_events(20)
+        out = io.StringIO()
+        replay_session(store, sid, out=out, limit=3)
+        output = out.getvalue()
+        # echo 0, 1, 2 should appear; echo 19 should not
+        self.assertIn("echo 0", output)
+        self.assertIn("echo 1", output)
+        self.assertIn("echo 2", output)
+        self.assertNotIn("echo 19", output)
+
+
+class TestReplayProgressIndicator(unittest.TestCase):
+    def test_progress_written_to_stderr_for_large_session(self):
+        n = _LARGE_SESSION_THRESHOLD + 10
+        store, sid = _make_store_with_events(n)
+        out = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = err = io.StringIO()
+        try:
+            replay_session(store, sid, out=out)
+        finally:
+            sys.stderr = old_stderr
+        self.assertIn("Loading", err.getvalue())
+        self.assertIn(str(n), err.getvalue())
+
+    def test_no_progress_for_small_session(self):
+        store, sid = _make_store_with_events(5)
+        out = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = err = io.StringIO()
+        try:
+            replay_session(store, sid, out=out)
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(err.getvalue(), "")
+
+    def test_progress_mentions_limit_when_truncated(self):
+        n = _LARGE_SESSION_THRESHOLD + 50
+        store, sid = _make_store_with_events(n)
+        out = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = err = io.StringIO()
+        try:
+            replay_session(store, sid, out=out, limit=10)
+        finally:
+            sys.stderr = old_stderr
+        self.assertIn("showing first 10", err.getvalue())
+
+
+class TestReplayCLILimitFlag(unittest.TestCase):
+    def test_limit_flag_registered(self):
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "replay", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("--limit", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sessions with 500+ events were slow to render because all events were formatted before any output appeared. This fix adds a `--limit N` flag to cap output at N events, and a progress indicator for sessions above 200 events.

### Changes

- `--limit N` / `-n N` on `agent-strace replay` — show only the first N events; a truncation notice tells the user how many were omitted and how to see all
- Progress indicator written to stderr for sessions > 200 events (does not pollute piped output)
- When `--limit` is combined with `--filter`, the limit applies after filtering
- 11 new tests in `tests/test_replay_perf.py`

### Example

```bash
# Quick inspection of a large session
agent-strace replay abc123 --limit 50

# [showing first 50 of 847 events — use --limit 847 to see all]
# ...
# [797 more events not shown — use --limit 847 to see all]
```

Closes #97