### PR TITLE
feat(retention): add session data retention management

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ agent-strace dashboard [--last N] [--html file] Aggregate stats and trends acros
 agent-strace annotate <session-id> <offset>     Add notes, labels, or bookmarks to events
 agent-strace token-budget <session-id>          Check token usage against model context limit
 agent-strace replay [session-id] [--limit N]    Replay a session (--limit caps events shown)
+agent-strace retention status                   Show session count, size, and what policy would delete
+agent-strace retention clean [--dry-run]        Delete sessions that exceed retention limits
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report
@@ -296,6 +298,39 @@ Wasted on failed phases: $0.0021 (50%)
 Supported models: `sonnet` (default), `opus`, `haiku`, `gpt4`, `gpt4o`. Token counts are estimated from payload size (`len / 4`); see [ADR-0008](ADRs/0008-token-cost-estimation-heuristic.md) for details.
 
 See [examples/session_analysis.md](examples/session_analysis.md) for a full walkthrough combining `import`, `explain`, and `cost`.
+
+### Data retention
+
+Enforce configurable retention policies to automatically delete old session data — required for GDPR, SOC 2, and internal data policies.
+
+```bash
+# Check current status and what policy would delete
+agent-strace retention status
+
+# Preview what would be deleted (no changes made)
+agent-strace retention clean --dry-run
+
+# Delete sessions older than 30 days
+agent-strace retention clean --max-age-days 30
+
+# Keep only the 1000 most recent sessions
+agent-strace retention clean --max-sessions 1000
+
+# Delete oldest sessions when storage exceeds 500 MB
+agent-strace retention clean --max-size-mb 500
+```
+
+Configure via `.agent-strace.yaml`:
+
+```yaml
+retention:
+  max_age_days: 30
+  max_sessions: 1000
+  max_size_mb: 500
+  on_delete: log    # log deletions to .agent-traces/retention.log
+```
+
+Policies are applied in order: age → count → size. Deletions are logged with session ID and timestamp (not content).
 
 ### Secret redaction
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.39.1"
+__version__ = "0.40.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -45,6 +45,7 @@ from .policy import cmd_policy
 from .postmortem import cmd_postmortem
 from .share import cmd_share
 from .token_budget import cmd_token_budget
+from .retention import cmd_retention
 from .watch import cmd_watch
 from .why import cmd_why
 from .models import EventType, SessionMeta, TraceEvent
@@ -772,6 +773,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="transport protocol (default: stdio)",
     )
 
+    # retention
+    p_ret = sub.add_parser("retention", help="manage session data retention")
+    ret_sub = p_ret.add_subparsers(dest="retention_command")
+
+    ret_sub.add_parser("status", help="show retention status and what would be deleted")
+
+    p_ret_clean = ret_sub.add_parser("clean", help="delete sessions that exceed retention limits")
+    p_ret_clean.add_argument("--dry-run", action="store_true",
+                             help="show what would be deleted without deleting")
+    p_ret_clean.add_argument("--max-age-days", type=int, dest="max_age_days", metavar="N",
+                             help="delete sessions older than N days")
+    p_ret_clean.add_argument("--max-sessions", type=int, dest="max_sessions", metavar="N",
+                             help="keep only the most recent N sessions")
+    p_ret_clean.add_argument("--max-size-mb", type=float, dest="max_size_mb", metavar="MB",
+                             help="delete oldest sessions when storage exceeds MB")
+    p_ret_clean.add_argument("--config", metavar="FILE",
+                             help="path to .agent-strace.yaml config file")
+
     # diff --semantic and --eval-config flags (extend existing diff parser)
     p_diff.add_argument("--semantic", action="store_true",
                         help="semantic outcome-level diff (files, cost, errors)")
@@ -832,6 +851,7 @@ def main() -> None:
         "freshness": cmd_freshness,
         "standup": cmd_standup,
         "mcp": cmd_mcp,
+        "retention": cmd_retention,
     }
 
     handler = handlers.get(args.command)

--- a/src/agent_trace/retention.py
+++ b/src/agent_trace/retention.py
@@ -1,0 +1,364 @@
+"""Session data retention management.
+
+Enforces configurable retention policies on the local session store:
+  - max_age_days: delete sessions older than N days
+  - max_sessions: keep only the most recent N sessions
+  - max_size_mb: delete oldest sessions when total storage exceeds limit
+
+Config is read from .agent-strace.yaml (optional). All limits are applied
+in order: age first, then count, then size. Deletions are logged to
+.agent-traces/retention.log when on_delete=log.
+
+Usage:
+    agent-strace retention status
+    agent-strace retention clean --dry-run
+    agent-strace retention clean
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .store import TraceStore, DEFAULT_TRACE_DIR
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RetentionConfig:
+    max_age_days: int | None = None       # delete sessions older than N days
+    max_sessions: int | None = None       # keep only the most recent N sessions
+    max_size_mb: float | None = None      # delete oldest when storage > N MB
+    on_delete: str = "log"                # "log" | "silent"
+    log_path: str = ""                    # defaults to <trace_dir>/retention.log
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "RetentionConfig":
+        r = d.get("retention", d)  # accept both top-level and nested
+        return cls(
+            max_age_days=r.get("max_age_days"),
+            max_sessions=r.get("max_sessions"),
+            max_size_mb=r.get("max_size_mb"),
+            on_delete=str(r.get("on_delete", "log")),
+            log_path=str(r.get("log_path", "")),
+        )
+
+    @classmethod
+    def load(cls, config_path: str | Path | None = None) -> "RetentionConfig":
+        """Load from .agent-strace.yaml, falling back to defaults."""
+        paths = []
+        if config_path:
+            paths.append(Path(config_path))
+        paths += [Path(".agent-strace.yaml"), Path(".agent-strace.yml")]
+
+        for p in paths:
+            if p.exists():
+                try:
+                    data = _parse_simple_yaml(p.read_text())
+                    return cls.from_dict(data)
+                except Exception:
+                    pass
+        return cls()
+
+
+def _parse_simple_yaml(text: str) -> dict:
+    """Parse a minimal YAML subset sufficient for retention config.
+
+    Handles: top-level keys with scalar values and one level of nesting.
+    """
+    result: dict = {}
+    current_section: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(line) - len(stripped)
+
+        if indent == 0:
+            if stripped.endswith(":"):
+                current_section = stripped[:-1].strip()
+                result[current_section] = {}
+            elif ":" in stripped:
+                k, _, v = stripped.partition(":")
+                result[k.strip()] = _coerce(v.strip())
+                current_section = None
+        elif indent > 0 and current_section and ":" in stripped:
+            k, _, v = stripped.partition(":")
+            if isinstance(result.get(current_section), dict):
+                result[current_section][k.strip()] = _coerce(v.strip())
+
+    return result
+
+
+def _coerce(value: str) -> int | float | str | None:
+    """Coerce a YAML scalar string to a Python type."""
+    if value in ("null", "~", ""):
+        return None
+    if value.lower() in ("true", "yes"):
+        return True
+    if value.lower() in ("false", "no"):
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value.strip('"').strip("'")
+
+
+# ---------------------------------------------------------------------------
+# Storage size helpers
+# ---------------------------------------------------------------------------
+
+def _session_size_bytes(session_dir: Path) -> int:
+    """Return total bytes used by a session directory."""
+    total = 0
+    try:
+        for f in session_dir.iterdir():
+            if f.is_file():
+                total += f.stat().st_size
+    except OSError:
+        pass
+    return total
+
+
+def _store_size_bytes(store: TraceStore) -> int:
+    """Return total bytes used by all sessions in the store."""
+    total = 0
+    if not store.base_dir.exists():
+        return 0
+    for d in store.base_dir.iterdir():
+        if d.is_dir():
+            total += _session_size_bytes(d)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Retention logic
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RetentionStatus:
+    session_count: int
+    oldest_session_id: str
+    oldest_session_age_days: float
+    total_size_bytes: int
+    sessions_to_delete: list[str] = field(default_factory=list)
+    bytes_to_free: int = 0
+
+    @property
+    def total_size_mb(self) -> float:
+        return self.total_size_bytes / (1024 * 1024)
+
+    @property
+    def bytes_to_free_mb(self) -> float:
+        return self.bytes_to_free / (1024 * 1024)
+
+
+def compute_sessions_to_delete(
+    store: TraceStore,
+    config: RetentionConfig,
+) -> list[str]:
+    """Return session IDs that should be deleted under the given policy.
+
+    Sessions are sorted oldest-first. Policies are applied in order:
+    age → count → size. A session marked for deletion by any policy is
+    included once in the result.
+    """
+    sessions = store.list_sessions()
+    if not sessions:
+        return []
+
+    # list_sessions() returns newest-first; reverse for oldest-first processing
+    sessions_oldest_first = list(reversed(sessions))
+    to_delete: set[str] = set()
+    now = time.time()
+
+    # --- Age policy ---
+    if config.max_age_days is not None:
+        cutoff = now - config.max_age_days * 86400
+        for meta in sessions_oldest_first:
+            if meta.started_at < cutoff:
+                to_delete.add(meta.session_id)
+
+    # --- Count policy ---
+    if config.max_sessions is not None:
+        surviving = [m for m in sessions_oldest_first if m.session_id not in to_delete]
+        # sessions_oldest_first[0] is oldest; keep the most recent max_sessions
+        excess = len(surviving) - config.max_sessions
+        if excess > 0:
+            for meta in surviving[:excess]:
+                to_delete.add(meta.session_id)
+
+    # --- Size policy ---
+    if config.max_size_mb is not None:
+        max_bytes = config.max_size_mb * 1024 * 1024
+        total = _store_size_bytes(store)
+        if total > max_bytes:
+            surviving = [m for m in sessions_oldest_first if m.session_id not in to_delete]
+            for meta in surviving:
+                if total <= max_bytes:
+                    break
+                size = _session_size_bytes(store._session_dir(meta.session_id))
+                to_delete.add(meta.session_id)
+                total -= size
+
+    # Return in oldest-first order for deterministic output
+    ordered = [m.session_id for m in sessions_oldest_first if m.session_id in to_delete]
+    return ordered
+
+
+def get_retention_status(store: TraceStore, config: RetentionConfig) -> RetentionStatus:
+    sessions = store.list_sessions()
+    if not sessions:
+        return RetentionStatus(
+            session_count=0,
+            oldest_session_id="",
+            oldest_session_age_days=0.0,
+            total_size_bytes=0,
+        )
+
+    oldest = min(sessions, key=lambda m: m.started_at)
+    now = time.time()
+    age_days = (now - oldest.started_at) / 86400
+    total_bytes = _store_size_bytes(store)
+    to_delete = compute_sessions_to_delete(store, config)
+    bytes_to_free = sum(
+        _session_size_bytes(store._session_dir(sid)) for sid in to_delete
+    )
+
+    return RetentionStatus(
+        session_count=len(sessions),
+        oldest_session_id=oldest.session_id,
+        oldest_session_age_days=age_days,
+        total_size_bytes=total_bytes,
+        sessions_to_delete=to_delete,
+        bytes_to_free=bytes_to_free,
+    )
+
+
+def delete_sessions(
+    store: TraceStore,
+    session_ids: list[str],
+    config: RetentionConfig,
+    log_path: str = "",
+) -> int:
+    """Delete the given sessions. Returns count of sessions deleted."""
+    deleted = 0
+    effective_log = log_path or config.log_path or str(store.base_dir / "retention.log")
+
+    for sid in session_ids:
+        session_dir = store._session_dir(sid)
+        if not session_dir.exists():
+            continue
+        try:
+            shutil.rmtree(session_dir)
+            deleted += 1
+            if config.on_delete == "log":
+                _log_deletion(sid, effective_log)
+        except OSError as exc:
+            sys.stderr.write(f"[retention] failed to delete {sid}: {exc}\n")
+
+    return deleted
+
+
+def _log_deletion(session_id: str, log_path: str) -> None:
+    """Append a deletion record to the retention log."""
+    p = Path(log_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with open(p, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"deleted_at": ts, "session_id": session_id}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers
+# ---------------------------------------------------------------------------
+
+def cmd_retention_status(args: argparse.Namespace, out: TextIO = sys.stdout) -> int:
+    store = TraceStore(args.trace_dir)
+    config = RetentionConfig.load(getattr(args, "config", None))
+    status = get_retention_status(store, config)
+
+    if status.session_count == 0:
+        out.write("No sessions found.\n")
+        return 0
+
+    out.write(f"Sessions:    {status.session_count}\n")
+    out.write(f"Oldest:      {status.oldest_session_id[:16]} "
+              f"({status.oldest_session_age_days:.1f} days ago)\n")
+    out.write(f"Size:        {status.total_size_mb:.1f} MB\n")
+
+    if status.sessions_to_delete:
+        out.write(f"\nPolicy would delete: {len(status.sessions_to_delete)} session(s) "
+                  f"({status.bytes_to_free_mb:.1f} MB)\n")
+        out.write("Run `agent-strace retention clean` to apply.\n")
+    else:
+        out.write("\nNo sessions exceed retention limits.\n")
+
+    return 0
+
+
+def cmd_retention_clean(args: argparse.Namespace, out: TextIO = sys.stdout) -> int:
+    store = TraceStore(args.trace_dir)
+    config = RetentionConfig.load(getattr(args, "config", None))
+
+    # Allow CLI overrides
+    if getattr(args, "max_age_days", None) is not None:
+        config.max_age_days = args.max_age_days
+    if getattr(args, "max_sessions", None) is not None:
+        config.max_sessions = args.max_sessions
+    if getattr(args, "max_size_mb", None) is not None:
+        config.max_size_mb = args.max_size_mb
+
+    to_delete = compute_sessions_to_delete(store, config)
+
+    if not to_delete:
+        out.write("Nothing to delete — all sessions are within retention limits.\n")
+        return 0
+
+    bytes_to_free = sum(
+        _session_size_bytes(store._session_dir(sid)) for sid in to_delete
+    )
+    mb_to_free = bytes_to_free / (1024 * 1024)
+
+    dry_run = getattr(args, "dry_run", False)
+    if dry_run:
+        out.write(f"Would delete: {len(to_delete)} session(s) ({mb_to_free:.1f} MB)\n")
+        for sid in to_delete:
+            out.write(f"  {sid}\n")
+        return 0
+
+    deleted = delete_sessions(store, to_delete, config)
+    out.write(f"Deleted: {deleted} session(s) ({mb_to_free:.1f} MB freed)\n")
+    return 0
+
+
+def cmd_retention(args: argparse.Namespace) -> int:
+    sub = getattr(args, "retention_command", None)
+    if sub == "status":
+        return cmd_retention_status(args)
+    if sub == "clean":
+        return cmd_retention_clean(args)
+    sys.stderr.write(
+        "Usage: agent-strace retention <status|clean> [--dry-run]\n"
+        "Run `agent-strace retention --help` for details.\n"
+    )
+    return 1

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,375 @@
+"""Tests for session data retention management."""
+
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.retention import (
+    RetentionConfig,
+    RetentionStatus,
+    _parse_simple_yaml,
+    _session_size_bytes,
+    _store_size_bytes,
+    compute_sessions_to_delete,
+    delete_sessions,
+    get_retention_status,
+    cmd_retention_status,
+    cmd_retention_clean,
+)
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmpdir = tempfile.mkdtemp()
+    return TraceStore(tmpdir), tmpdir
+
+
+def _add_session(store: TraceStore, age_days: float = 0.0, name: str = "") -> SessionMeta:
+    """Add a session with started_at set to `age_days` days ago."""
+    meta = SessionMeta(agent_name=name)
+    meta.started_at = time.time() - age_days * 86400
+    store.create_session(meta)
+    # Write a small event so the session has non-zero size
+    ev = TraceEvent(
+        event_type=EventType.TOOL_CALL,
+        session_id=meta.session_id,
+        data={"tool_name": "Bash", "arguments": {"command": "echo hi"}},
+    )
+    store.append_event(meta.session_id, ev)
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# _parse_simple_yaml
+# ---------------------------------------------------------------------------
+
+class TestParseSimpleYaml(unittest.TestCase):
+    def test_flat_keys(self):
+        text = "max_age_days: 30\nmax_sessions: 100\n"
+        result = _parse_simple_yaml(text)
+        self.assertEqual(result["max_age_days"], 30)
+        self.assertEqual(result["max_sessions"], 100)
+
+    def test_nested_retention_section(self):
+        text = "retention:\n  max_age_days: 14\n  max_sessions: 500\n"
+        result = _parse_simple_yaml(text)
+        self.assertEqual(result["retention"]["max_age_days"], 14)
+        self.assertEqual(result["retention"]["max_sessions"], 500)
+
+    def test_comments_ignored(self):
+        text = "# comment\nmax_age_days: 7\n"
+        result = _parse_simple_yaml(text)
+        self.assertEqual(result["max_age_days"], 7)
+
+    def test_null_value(self):
+        result = _parse_simple_yaml("max_age_days: null\n")
+        self.assertIsNone(result["max_age_days"])
+
+    def test_float_value(self):
+        result = _parse_simple_yaml("max_size_mb: 500.5\n")
+        self.assertAlmostEqual(result["max_size_mb"], 500.5)
+
+
+# ---------------------------------------------------------------------------
+# RetentionConfig
+# ---------------------------------------------------------------------------
+
+class TestRetentionConfig(unittest.TestCase):
+    def test_defaults(self):
+        config = RetentionConfig()
+        self.assertIsNone(config.max_age_days)
+        self.assertIsNone(config.max_sessions)
+        self.assertIsNone(config.max_size_mb)
+        self.assertEqual(config.on_delete, "log")
+
+    def test_from_dict_nested(self):
+        config = RetentionConfig.from_dict({
+            "retention": {"max_age_days": 30, "max_sessions": 1000, "on_delete": "silent"}
+        })
+        self.assertEqual(config.max_age_days, 30)
+        self.assertEqual(config.max_sessions, 1000)
+        self.assertEqual(config.on_delete, "silent")
+
+    def test_from_dict_flat(self):
+        config = RetentionConfig.from_dict({"max_age_days": 7})
+        self.assertEqual(config.max_age_days, 7)
+
+    def test_load_missing_file_returns_defaults(self):
+        config = RetentionConfig.load("/nonexistent/path.yaml")
+        self.assertIsInstance(config, RetentionConfig)
+        self.assertIsNone(config.max_age_days)
+
+    def test_load_from_yaml_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("retention:\n  max_age_days: 14\n  max_sessions: 200\n")
+            path = f.name
+        try:
+            config = RetentionConfig.load(path)
+            self.assertEqual(config.max_age_days, 14)
+            self.assertEqual(config.max_sessions, 200)
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# compute_sessions_to_delete
+# ---------------------------------------------------------------------------
+
+class TestComputeSessionsToDelete(unittest.TestCase):
+    def test_no_policy_deletes_nothing(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=100)
+        config = RetentionConfig()
+        result = compute_sessions_to_delete(store, config)
+        self.assertEqual(result, [])
+
+    def test_age_policy_deletes_old_sessions(self):
+        store, _ = _make_store()
+        old = _add_session(store, age_days=40)
+        _add_session(store, age_days=5)
+        config = RetentionConfig(max_age_days=30)
+        result = compute_sessions_to_delete(store, config)
+        self.assertIn(old.session_id, result)
+        self.assertEqual(len(result), 1)
+
+    def test_age_policy_keeps_recent_sessions(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=5)
+        _add_session(store, age_days=10)
+        config = RetentionConfig(max_age_days=30)
+        result = compute_sessions_to_delete(store, config)
+        self.assertEqual(result, [])
+
+    def test_count_policy_keeps_most_recent(self):
+        store, _ = _make_store()
+        old1 = _add_session(store, age_days=10)
+        old2 = _add_session(store, age_days=5)
+        _add_session(store, age_days=1)  # newest — should be kept
+        config = RetentionConfig(max_sessions=1)
+        result = compute_sessions_to_delete(store, config)
+        self.assertIn(old1.session_id, result)
+        self.assertIn(old2.session_id, result)
+        self.assertEqual(len(result), 2)
+
+    def test_count_policy_no_excess(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=5)
+        _add_session(store, age_days=1)
+        config = RetentionConfig(max_sessions=5)
+        result = compute_sessions_to_delete(store, config)
+        self.assertEqual(result, [])
+
+    def test_empty_store_returns_empty(self):
+        store, _ = _make_store()
+        config = RetentionConfig(max_age_days=30, max_sessions=10)
+        result = compute_sessions_to_delete(store, config)
+        self.assertEqual(result, [])
+
+    def test_age_and_count_combined(self):
+        store, _ = _make_store()
+        very_old = _add_session(store, age_days=60)
+        old = _add_session(store, age_days=20)
+        _add_session(store, age_days=1)
+        config = RetentionConfig(max_age_days=30, max_sessions=1)
+        result = compute_sessions_to_delete(store, config)
+        # very_old deleted by age; old deleted by count (only 1 kept)
+        self.assertIn(very_old.session_id, result)
+        self.assertIn(old.session_id, result)
+
+    def test_no_duplicates_in_result(self):
+        store, _ = _make_store()
+        old = _add_session(store, age_days=60)
+        _add_session(store, age_days=1)
+        # Both age and count would select the old session
+        config = RetentionConfig(max_age_days=30, max_sessions=1)
+        result = compute_sessions_to_delete(store, config)
+        self.assertEqual(len(result), len(set(result)))
+
+
+# ---------------------------------------------------------------------------
+# delete_sessions
+# ---------------------------------------------------------------------------
+
+class TestDeleteSessions(unittest.TestCase):
+    def test_deletes_session_directory(self):
+        store, _ = _make_store()
+        meta = _add_session(store, age_days=40)
+        config = RetentionConfig(on_delete="silent")
+        session_dir = store._session_dir(meta.session_id)
+        self.assertTrue(session_dir.exists())
+        deleted = delete_sessions(store, [meta.session_id], config)
+        self.assertEqual(deleted, 1)
+        self.assertFalse(session_dir.exists())
+
+    def test_logs_deletion_when_on_delete_log(self):
+        store, tmpdir = _make_store()
+        meta = _add_session(store, age_days=40)
+        log_path = os.path.join(tmpdir, "retention.log")
+        config = RetentionConfig(on_delete="log", log_path=log_path)
+        delete_sessions(store, [meta.session_id], config, log_path=log_path)
+        self.assertTrue(Path(log_path).exists())
+        log_content = Path(log_path).read_text()
+        self.assertIn(meta.session_id, log_content)
+
+    def test_no_log_when_silent(self):
+        store, tmpdir = _make_store()
+        meta = _add_session(store, age_days=40)
+        log_path = os.path.join(tmpdir, "retention.log")
+        config = RetentionConfig(on_delete="silent", log_path=log_path)
+        delete_sessions(store, [meta.session_id], config, log_path=log_path)
+        self.assertFalse(Path(log_path).exists())
+
+    def test_nonexistent_session_skipped(self):
+        store, _ = _make_store()
+        config = RetentionConfig(on_delete="silent")
+        deleted = delete_sessions(store, ["nonexistent-id"], config)
+        self.assertEqual(deleted, 0)
+
+
+# ---------------------------------------------------------------------------
+# get_retention_status
+# ---------------------------------------------------------------------------
+
+class TestGetRetentionStatus(unittest.TestCase):
+    def test_empty_store(self):
+        store, _ = _make_store()
+        config = RetentionConfig()
+        status = get_retention_status(store, config)
+        self.assertEqual(status.session_count, 0)
+
+    def test_reports_session_count(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=5)
+        _add_session(store, age_days=10)
+        config = RetentionConfig()
+        status = get_retention_status(store, config)
+        self.assertEqual(status.session_count, 2)
+
+    def test_reports_sessions_to_delete(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=40)
+        _add_session(store, age_days=5)
+        config = RetentionConfig(max_age_days=30)
+        status = get_retention_status(store, config)
+        self.assertEqual(len(status.sessions_to_delete), 1)
+
+    def test_bytes_to_free_positive(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=40)
+        config = RetentionConfig(max_age_days=30)
+        status = get_retention_status(store, config)
+        self.assertGreater(status.bytes_to_free, 0)
+
+
+# ---------------------------------------------------------------------------
+# cmd_retention_status / cmd_retention_clean
+# ---------------------------------------------------------------------------
+
+class TestCmdRetentionStatus(unittest.TestCase):
+    def _make_args(self, store: TraceStore) -> object:
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = str(store.base_dir)
+        args.config = None
+        return args
+
+    def test_status_empty_store(self):
+        store, _ = _make_store()
+        args = self._make_args(store)
+        out = io.StringIO()
+        rc = cmd_retention_status(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertIn("No sessions", out.getvalue())
+
+    def test_status_shows_count(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=5)
+        args = self._make_args(store)
+        out = io.StringIO()
+        rc = cmd_retention_status(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertIn("1", out.getvalue())
+
+
+class TestCmdRetentionClean(unittest.TestCase):
+    def _make_args(self, store: TraceStore, dry_run: bool = False,
+                   max_age_days: int | None = None) -> object:
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = str(store.base_dir)
+        args.config = None
+        args.dry_run = dry_run
+        args.max_age_days = max_age_days
+        args.max_sessions = None
+        args.max_size_mb = None
+        return args
+
+    def test_clean_dry_run_does_not_delete(self):
+        store, _ = _make_store()
+        meta = _add_session(store, age_days=40)
+        args = self._make_args(store, dry_run=True, max_age_days=30)
+        out = io.StringIO()
+        rc = cmd_retention_clean(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertIn("Would delete", out.getvalue())
+        # Session still exists
+        self.assertTrue(store._session_dir(meta.session_id).exists())
+
+    def test_clean_deletes_old_sessions(self):
+        store, _ = _make_store()
+        meta = _add_session(store, age_days=40)
+        args = self._make_args(store, dry_run=False, max_age_days=30)
+        out = io.StringIO()
+        rc = cmd_retention_clean(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertIn("Deleted", out.getvalue())
+        self.assertFalse(store._session_dir(meta.session_id).exists())
+
+    def test_clean_nothing_to_delete(self):
+        store, _ = _make_store()
+        _add_session(store, age_days=5)
+        args = self._make_args(store, dry_run=False, max_age_days=30)
+        out = io.StringIO()
+        rc = cmd_retention_clean(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertIn("Nothing to delete", out.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+class TestRetentionCLIRegistered(unittest.TestCase):
+    def test_retention_command_in_help(self):
+        import sys
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("retention", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds configurable data retention policies for the local session store. Required for GDPR, SOC 2, and internal data policies.

### Changes

- `agent-strace retention status` — shows session count, oldest session age, total storage size, and what the current policy would delete
- `agent-strace retention clean [--dry-run]` — deletes sessions that exceed configured limits; `--dry-run` previews without deleting
- Three limit types: `--max-age-days N`, `--max-sessions N`, `--max-size-mb MB`
- Config via `.agent-strace.yaml` under a `retention:` section
- Deletions logged to `.agent-traces/retention.log` (session ID + timestamp, not content) when `on_delete: log`
- 32 new tests in `tests/test_retention.py`

### Example

```bash
# Preview what a 30-day retention policy would delete
agent-strace retention clean --max-age-days 30 --dry-run

# Apply it
agent-strace retention clean --max-age-days 30
# Deleted: 23 session(s) (18.4 MB freed)
```

Closes #89