### PR TITLE
feat(sample): add dataset auto-sampler for regression suite export

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ agent-strace token-budget <session-id>          Check token usage against model 
 agent-strace replay [session-id] [--limit N]    Replay a session (--limit caps events shown)
 agent-strace retention status                   Show session count, size, and what policy would delete
 agent-strace retention clean [--dry-run]        Delete sessions that exceed retention limits
+agent-strace sample --strategy worst --n 20     Export worst/diverse/random/recent sessions as JSONL
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report
@@ -796,6 +797,29 @@ agent-strace dashboard --html report.html # self-contained HTML export
 ```
 
 The terminal view shows total tool calls, errors, tokens, and estimated cost, plus ASCII sparkline charts for each metric over time and a top-tools frequency table. The HTML export is self-contained. No server needed.
+
+### Dataset auto-sampler
+
+Export the sessions most useful for regression suites and eval datasets — without manual inspection.
+
+```bash
+# Export the 20 worst-performing sessions (highest error/retry/cost)
+agent-strace sample --strategy worst --n 20 --output regression.jsonl
+
+# Export 10 sessions that maximise behavioral variety
+agent-strace sample --strategy diverse --n 10 --output diverse.jsonl
+
+# Export the 5 most recent sessions
+agent-strace sample --strategy recent --n 5 --output recent.jsonl
+
+# Random sample, reproducible with a seed
+agent-strace sample --strategy random --n 15 --seed 42 --output random.jsonl
+
+# Skip sessions with identical tool call sequences
+agent-strace sample --strategy worst --n 20 --deduplicate --output regression.jsonl
+```
+
+Output is JSONL — one session per line — with full event data and a score breakdown. Compatible with LangSmith, Braintrust, and any custom eval framework.
 
 ### Eval trend dashboard
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -46,6 +46,7 @@ from .postmortem import cmd_postmortem
 from .share import cmd_share
 from .token_budget import cmd_token_budget
 from .retention import cmd_retention
+from .sample import cmd_sample
 from .watch import cmd_watch
 from .why import cmd_why
 from .models import EventType, SessionMeta, TraceEvent
@@ -773,6 +774,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="transport protocol (default: stdio)",
     )
 
+    # sample
+    p_sample = sub.add_parser(
+        "sample",
+        help="export worst/diverse/random/recent sessions as a JSONL regression suite",
+    )
+    p_sample.add_argument(
+        "--strategy",
+        choices=["worst", "diverse", "random", "recent"],
+        default="worst",
+        help="sampling strategy (default: worst)",
+    )
+    p_sample.add_argument("--n", type=int, default=20, metavar="N",
+                          help="number of sessions to sample (default: 20)")
+    p_sample.add_argument("--output", "-o", default="sample.jsonl",
+                          help="output JSONL file path (default: sample.jsonl)")
+    p_sample.add_argument("--deduplicate", action="store_true",
+                          help="skip sessions with identical tool call sequences")
+    p_sample.add_argument("--seed", type=int, default=None,
+                          help="random seed for reproducible random sampling")
+
     # retention
     p_ret = sub.add_parser("retention", help="manage session data retention")
     ret_sub = p_ret.add_subparsers(dest="retention_command")
@@ -852,6 +873,7 @@ def main() -> None:
         "standup": cmd_standup,
         "mcp": cmd_mcp,
         "retention": cmd_retention,
+        "sample": cmd_sample,
     }
 
     handler = handlers.get(args.command)

--- a/src/agent_trace/sample.py
+++ b/src/agent_trace/sample.py
@@ -1,0 +1,329 @@
+"""Dataset auto-sampler: export worst/diverse/random/recent sessions as JSONL.
+
+Surfaces the sessions most useful for building regression suites and eval
+datasets, without manual inspection. Zero new dependencies.
+
+Usage:
+    agent-strace sample --strategy worst --n 20 --output regression.jsonl
+    agent-strace sample --strategy diverse --n 10 --output diverse.jsonl
+    agent-strace sample --strategy recent --n 5 --output recent.jsonl
+    agent-strace sample --strategy random --n 15 --output random.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random as _random
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Per-session scoring
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionScore:
+    session_id: str
+    started_at: float
+    error_rate: float       # errors / max(tool_calls, 1)
+    retry_rate: float       # retries / max(tool_calls, 1)
+    blast_radius: int       # distinct files written
+    cost_estimate: float    # estimated cost in dollars
+    duration_s: float
+    tool_calls: int
+    # Composite "worst" score (higher = worse session)
+    worst_score: float = 0.0
+
+
+def _estimate_cost(events: list[TraceEvent]) -> float:
+    """Rough cost estimate: $3/M input tokens, $15/M output tokens (Sonnet-class)."""
+    total = 0.0
+    for ev in events:
+        if ev.event_type == EventType.LLM_RESPONSE:
+            tokens = ev.data.get("total_tokens", 0) or 0
+            # Assume 80/20 input/output split
+            inp = int(tokens * 0.8)
+            out = int(tokens * 0.2)
+            total += (inp / 1_000_000) * 3.0 + (out / 1_000_000) * 15.0
+    return total
+
+
+def _score_session(
+    session_id: str,
+    meta: SessionMeta,
+    events: list[TraceEvent],
+) -> SessionScore:
+    tool_calls = 0
+    errors = 0
+    retries = 0
+    files_written: set[str] = set()
+    prev_tool: str | None = None
+    prev_count = 0
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            tool_calls += 1
+            name = ev.data.get("tool_name", "")
+            if name == prev_tool:
+                prev_count += 1
+                if prev_count >= 2:
+                    retries += 1
+            else:
+                prev_tool = name
+                prev_count = 1
+            # Track writes
+            if name.lower() in ("write", "edit", "create", "str_replace"):
+                path = str(
+                    ev.data.get("arguments", {}).get("file_path")
+                    or ev.data.get("arguments", {}).get("path")
+                    or ""
+                )
+                if path:
+                    files_written.add(path)
+        elif ev.event_type == EventType.FILE_WRITE:
+            path = ev.data.get("path") or ev.data.get("file_path") or ""
+            if path:
+                files_written.add(str(path))
+        elif ev.event_type == EventType.ERROR:
+            errors += 1
+
+    denom = max(tool_calls, 1)
+    error_rate = errors / denom
+    retry_rate = retries / denom
+    blast_radius = len(files_written)
+    cost = _estimate_cost(events)
+    duration_s = (events[-1].timestamp - events[0].timestamp) if len(events) >= 2 else 0.0
+
+    # Composite worst score: weighted sum of normalised dimensions
+    # Weights chosen so a session with many errors + high retry + high cost
+    # ranks clearly above a clean session.
+    worst_score = (
+        error_rate * 0.35
+        + retry_rate * 0.30
+        + min(blast_radius / 20.0, 1.0) * 0.15
+        + min(cost / 5.0, 1.0) * 0.20
+    )
+
+    return SessionScore(
+        session_id=session_id,
+        started_at=meta.started_at,
+        error_rate=error_rate,
+        retry_rate=retry_rate,
+        blast_radius=blast_radius,
+        cost_estimate=cost,
+        duration_s=duration_s,
+        tool_calls=tool_calls,
+        worst_score=worst_score,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sampling strategies
+# ---------------------------------------------------------------------------
+
+def _sample_worst(scores: list[SessionScore], n: int) -> list[SessionScore]:
+    """Return the N sessions with the highest worst_score."""
+    return sorted(scores, key=lambda s: s.worst_score, reverse=True)[:n]
+
+
+def _sample_diverse(scores: list[SessionScore], n: int) -> list[SessionScore]:
+    """Return N sessions that maximise variety across dimensions.
+
+    Uses a greedy max-min distance approach: start with the worst session,
+    then repeatedly pick the session most different from those already chosen.
+    Distance is Euclidean in the (error_rate, retry_rate, blast_radius_norm,
+    cost_norm) feature space.
+    """
+    if not scores or n <= 0:
+        return []
+    if len(scores) <= n:
+        return list(scores)
+
+    def _features(s: SessionScore) -> tuple[float, ...]:
+        return (
+            s.error_rate,
+            s.retry_rate,
+            min(s.blast_radius / 20.0, 1.0),
+            min(s.cost_estimate / 5.0, 1.0),
+        )
+
+    def _dist(a: tuple, b: tuple) -> float:
+        return sum((x - y) ** 2 for x, y in zip(a, b)) ** 0.5
+
+    remaining = list(scores)
+    # Seed with the worst session
+    chosen = [max(remaining, key=lambda s: s.worst_score)]
+    remaining = [s for s in remaining if s.session_id != chosen[0].session_id]
+
+    while len(chosen) < n and remaining:
+        chosen_feats = [_features(c) for c in chosen]
+        # Pick the session with the maximum minimum distance to any chosen session
+        best = max(
+            remaining,
+            key=lambda s: min(_dist(_features(s), cf) for cf in chosen_feats),
+        )
+        chosen.append(best)
+        remaining = [s for s in remaining if s.session_id != best.session_id]
+
+    return chosen
+
+
+def _sample_random(scores: list[SessionScore], n: int, seed: int | None = None) -> list[SessionScore]:
+    """Return N sessions chosen uniformly at random."""
+    pool = list(scores)
+    if seed is not None:
+        _random.seed(seed)
+    _random.shuffle(pool)
+    return pool[:n]
+
+
+def _sample_recent(scores: list[SessionScore], n: int) -> list[SessionScore]:
+    """Return the N most recent sessions."""
+    return sorted(scores, key=lambda s: s.started_at, reverse=True)[:n]
+
+
+STRATEGIES = {
+    "worst": _sample_worst,
+    "diverse": _sample_diverse,
+    "random": _sample_random,
+    "recent": _sample_recent,
+}
+
+
+# ---------------------------------------------------------------------------
+# JSONL export
+# ---------------------------------------------------------------------------
+
+def _session_to_jsonl_record(
+    meta: SessionMeta,
+    events: list[TraceEvent],
+    score: SessionScore,
+) -> dict:
+    """Serialise a session to a single JSONL record."""
+    return {
+        "session_id": meta.session_id,
+        "started_at": meta.started_at,
+        "agent_name": meta.agent_name,
+        "command": meta.command,
+        "score": {
+            "error_rate": round(score.error_rate, 4),
+            "retry_rate": round(score.retry_rate, 4),
+            "blast_radius": score.blast_radius,
+            "cost_estimate": round(score.cost_estimate, 6),
+            "worst_score": round(score.worst_score, 4),
+        },
+        "events": [json.loads(ev.to_json()) for ev in events],
+    }
+
+
+def run_sample(
+    store: TraceStore,
+    strategy: str,
+    n: int,
+    output_path: str,
+    deduplicate: bool = False,
+    seed: int | None = None,
+    out: TextIO = sys.stdout,
+) -> int:
+    """Run the sampler and write JSONL output. Returns exit code."""
+    sessions = store.list_sessions()
+    if not sessions:
+        out.write("No sessions found.\n")
+        return 1
+
+    out.write(f"Sampling {n} sessions by strategy '{strategy}'...\n")
+    out.write(f"Scoring {len(sessions)} session(s)...\n")
+
+    scores: list[SessionScore] = []
+    seen_tool_sequences: set[str] = set()
+
+    for meta in sessions:
+        try:
+            events = store.load_events(meta.session_id)
+        except Exception:
+            continue
+
+        if deduplicate:
+            # Fingerprint: sorted tuple of (tool_name, command) pairs
+            seq = tuple(sorted(
+                (ev.data.get("tool_name", ""), str(ev.data.get("arguments", {}).get("command", "")))
+                for ev in events
+                if ev.event_type == EventType.TOOL_CALL
+            ))
+            key = str(seq)
+            if key in seen_tool_sequences:
+                continue
+            seen_tool_sequences.add(key)
+
+        scores.append(_score_session(meta.session_id, meta, events))
+
+    if not scores:
+        out.write("No sessions available after filtering.\n")
+        return 1
+
+    # Apply strategy
+    sampler = STRATEGIES.get(strategy)
+    if sampler is None:
+        out.write(f"Unknown strategy: {strategy!r}. Choose from: {', '.join(STRATEGIES)}\n")
+        return 1
+
+    if strategy == "random":
+        selected = _sample_random(scores, n, seed=seed)
+    else:
+        selected = sampler(scores, n)
+
+    # Write JSONL
+    p = Path(output_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with open(p, "w", encoding="utf-8") as f:
+        for score in selected:
+            try:
+                meta = store.load_meta(score.session_id)
+                events = store.load_events(score.session_id)
+                record = _session_to_jsonl_record(meta, events, score)
+                f.write(json.dumps(record, separators=(",", ":")) + "\n")
+                written += 1
+            except Exception:
+                continue
+
+    out.write(f"\nExported {written} session(s) to {output_path}\n")
+    if selected:
+        out.write("\nCriteria used:\n")
+        if strategy == "worst":
+            out.write("  - highest error rate\n")
+            out.write("  - highest retry rate\n")
+            out.write("  - highest blast radius\n")
+            out.write("  - highest estimated cost\n")
+        elif strategy == "diverse":
+            out.write("  - maximum behavioral variety (greedy max-min distance)\n")
+        elif strategy == "random":
+            out.write("  - uniform random sample\n")
+        elif strategy == "recent":
+            out.write("  - most recent sessions by start time\n")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_sample(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    return run_sample(
+        store=store,
+        strategy=getattr(args, "strategy", "worst"),
+        n=getattr(args, "n", 20),
+        output_path=getattr(args, "output", "sample.jsonl"),
+        deduplicate=getattr(args, "deduplicate", False),
+        seed=getattr(args, "seed", None),
+    )

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,370 @@
+"""Tests for dataset auto-sampler (issue #94)."""
+
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.sample import (
+    SessionScore,
+    _score_session,
+    _sample_worst,
+    _sample_diverse,
+    _sample_random,
+    _sample_recent,
+    _session_to_jsonl_record,
+    run_sample,
+)
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmpdir = tempfile.mkdtemp()
+    return TraceStore(tmpdir), tmpdir
+
+
+def _add_session(
+    store: TraceStore,
+    age_days: float = 0.0,
+    errors: int = 0,
+    tool_calls: int = 5,
+    retries: int = 0,
+) -> SessionMeta:
+    meta = SessionMeta()
+    meta.started_at = time.time() - age_days * 86400
+    store.create_session(meta)
+    base_ts = meta.started_at
+
+    for i in range(tool_calls):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            timestamp=base_ts + i,
+            data={"tool_name": "Bash", "arguments": {"command": f"echo {i}"}},
+        )
+        store.append_event(meta.session_id, ev)
+
+    for _ in range(retries):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            timestamp=base_ts + tool_calls,
+            data={"tool_name": "Bash", "arguments": {"command": "echo 0"}},
+        )
+        store.append_event(meta.session_id, ev)
+
+    for _ in range(errors):
+        ev = TraceEvent(
+            event_type=EventType.ERROR,
+            session_id=meta.session_id,
+            timestamp=base_ts + tool_calls + 1,
+            data={"message": "something failed"},
+        )
+        store.append_event(meta.session_id, ev)
+
+    return meta
+
+
+def _make_score(
+    session_id: str = "abc",
+    started_at: float | None = None,
+    error_rate: float = 0.0,
+    retry_rate: float = 0.0,
+    blast_radius: int = 0,
+    cost_estimate: float = 0.0,
+    worst_score: float = 0.0,
+) -> SessionScore:
+    return SessionScore(
+        session_id=session_id,
+        started_at=started_at or time.time(),
+        error_rate=error_rate,
+        retry_rate=retry_rate,
+        blast_radius=blast_radius,
+        cost_estimate=cost_estimate,
+        duration_s=10.0,
+        tool_calls=5,
+        worst_score=worst_score,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _score_session
+# ---------------------------------------------------------------------------
+
+class TestScoreSession(unittest.TestCase):
+    def _make_events(self, tool_calls=5, errors=0, retries=0):
+        events = []
+        base = time.time()
+        for i in range(tool_calls):
+            events.append(TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                timestamp=base + i,
+                data={"tool_name": "Bash", "arguments": {"command": f"echo {i}"}},
+            ))
+        for _ in range(retries):
+            events.append(TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                timestamp=base + tool_calls,
+                data={"tool_name": "Bash", "arguments": {"command": "echo 0"}},
+            ))
+        for _ in range(errors):
+            events.append(TraceEvent(
+                event_type=EventType.ERROR,
+                timestamp=base + tool_calls + 1,
+                data={"message": "fail"},
+            ))
+        return events
+
+    def test_no_errors_zero_error_rate(self):
+        meta = SessionMeta()
+        events = self._make_events(tool_calls=5, errors=0)
+        score = _score_session(meta.session_id, meta, events)
+        self.assertEqual(score.error_rate, 0.0)
+
+    def test_errors_increase_error_rate(self):
+        meta = SessionMeta()
+        events = self._make_events(tool_calls=5, errors=2)
+        score = _score_session(meta.session_id, meta, events)
+        self.assertGreater(score.error_rate, 0.0)
+
+    def test_worst_score_higher_for_bad_session(self):
+        meta = SessionMeta()
+        good = _score_session(meta.session_id, meta, self._make_events(5, 0, 0))
+        bad = _score_session(meta.session_id, meta, self._make_events(5, 3, 2))
+        self.assertGreater(bad.worst_score, good.worst_score)
+
+    def test_empty_events_no_crash(self):
+        meta = SessionMeta()
+        score = _score_session(meta.session_id, meta, [])
+        self.assertEqual(score.tool_calls, 0)
+        self.assertEqual(score.error_rate, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Sampling strategies
+# ---------------------------------------------------------------------------
+
+class TestSampleWorst(unittest.TestCase):
+    def test_returns_n_sessions(self):
+        scores = [_make_score(str(i), worst_score=float(i)) for i in range(10)]
+        result = _sample_worst(scores, 3)
+        self.assertEqual(len(result), 3)
+
+    def test_returns_highest_worst_score(self):
+        scores = [_make_score(str(i), worst_score=float(i)) for i in range(10)]
+        result = _sample_worst(scores, 3)
+        ids = {s.session_id for s in result}
+        self.assertIn("9", ids)
+        self.assertIn("8", ids)
+        self.assertIn("7", ids)
+
+    def test_n_larger_than_pool(self):
+        scores = [_make_score(str(i)) for i in range(3)]
+        result = _sample_worst(scores, 10)
+        self.assertEqual(len(result), 3)
+
+
+class TestSampleDiverse(unittest.TestCase):
+    def test_returns_n_sessions(self):
+        scores = [
+            _make_score(str(i), error_rate=i * 0.1, retry_rate=(9 - i) * 0.1)
+            for i in range(10)
+        ]
+        result = _sample_diverse(scores, 4)
+        self.assertEqual(len(result), 4)
+
+    def test_no_duplicates(self):
+        scores = [_make_score(str(i), error_rate=i * 0.1) for i in range(10)]
+        result = _sample_diverse(scores, 5)
+        ids = [s.session_id for s in result]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_empty_input(self):
+        result = _sample_diverse([], 5)
+        self.assertEqual(result, [])
+
+    def test_n_zero(self):
+        scores = [_make_score(str(i)) for i in range(5)]
+        result = _sample_diverse(scores, 0)
+        self.assertEqual(result, [])
+
+
+class TestSampleRandom(unittest.TestCase):
+    def test_returns_n_sessions(self):
+        scores = [_make_score(str(i)) for i in range(20)]
+        result = _sample_random(scores, 5, seed=42)
+        self.assertEqual(len(result), 5)
+
+    def test_reproducible_with_seed(self):
+        scores = [_make_score(str(i)) for i in range(20)]
+        r1 = [s.session_id for s in _sample_random(scores, 5, seed=42)]
+        r2 = [s.session_id for s in _sample_random(scores, 5, seed=42)]
+        self.assertEqual(r1, r2)
+
+    def test_n_larger_than_pool(self):
+        scores = [_make_score(str(i)) for i in range(3)]
+        result = _sample_random(scores, 10, seed=0)
+        self.assertEqual(len(result), 3)
+
+
+class TestSampleRecent(unittest.TestCase):
+    def test_returns_most_recent(self):
+        now = time.time()
+        scores = [_make_score(str(i), started_at=now - i * 3600) for i in range(10)]
+        result = _sample_recent(scores, 3)
+        ids = {s.session_id for s in result}
+        self.assertIn("0", ids)  # most recent
+        self.assertIn("1", ids)
+        self.assertIn("2", ids)
+        self.assertNotIn("9", ids)  # oldest
+
+    def test_returns_n_sessions(self):
+        now = time.time()
+        scores = [_make_score(str(i), started_at=now - i) for i in range(10)]
+        result = _sample_recent(scores, 4)
+        self.assertEqual(len(result), 4)
+
+
+# ---------------------------------------------------------------------------
+# _session_to_jsonl_record
+# ---------------------------------------------------------------------------
+
+class TestSessionToJsonlRecord(unittest.TestCase):
+    def test_record_has_required_fields(self):
+        meta = SessionMeta()
+        events = [TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={"tool_name": "Bash"},
+        )]
+        score = _make_score(meta.session_id)
+        record = _session_to_jsonl_record(meta, events, score)
+        self.assertIn("session_id", record)
+        self.assertIn("events", record)
+        self.assertIn("score", record)
+        self.assertEqual(len(record["events"]), 1)
+
+    def test_record_is_json_serialisable(self):
+        meta = SessionMeta()
+        score = _make_score(meta.session_id)
+        record = _session_to_jsonl_record(meta, [], score)
+        # Should not raise
+        json.dumps(record)
+
+
+# ---------------------------------------------------------------------------
+# run_sample (integration)
+# ---------------------------------------------------------------------------
+
+class TestRunSample(unittest.TestCase):
+    def setUp(self):
+        self.store, self.tmpdir = _make_store()
+        self.output = os.path.join(self.tmpdir, "out.jsonl")
+
+    def test_worst_strategy_writes_jsonl(self):
+        for i in range(5):
+            _add_session(self.store, errors=i, tool_calls=5)
+        out = io.StringIO()
+        rc = run_sample(self.store, "worst", n=3, output_path=self.output, out=out)
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            record = json.loads(line)
+            self.assertIn("session_id", record)
+            self.assertIn("events", record)
+
+    def test_recent_strategy(self):
+        for i in range(5):
+            _add_session(self.store, age_days=float(i))
+        out = io.StringIO()
+        rc = run_sample(self.store, "recent", n=2, output_path=self.output, out=out)
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        self.assertEqual(len(lines), 2)
+
+    def test_random_strategy(self):
+        for i in range(10):
+            _add_session(self.store)
+        out = io.StringIO()
+        rc = run_sample(self.store, "random", n=4, output_path=self.output, seed=7, out=out)
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        self.assertEqual(len(lines), 4)
+
+    def test_diverse_strategy(self):
+        for i in range(8):
+            _add_session(self.store, errors=i % 3, tool_calls=5)
+        out = io.StringIO()
+        rc = run_sample(self.store, "diverse", n=3, output_path=self.output, out=out)
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        self.assertEqual(len(lines), 3)
+
+    def test_empty_store_returns_error(self):
+        out = io.StringIO()
+        rc = run_sample(self.store, "worst", n=5, output_path=self.output, out=out)
+        self.assertEqual(rc, 1)
+        self.assertIn("No sessions", out.getvalue())
+
+    def test_n_larger_than_sessions(self):
+        _add_session(self.store)
+        _add_session(self.store)
+        out = io.StringIO()
+        rc = run_sample(self.store, "worst", n=100, output_path=self.output, out=out)
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        self.assertEqual(len(lines), 2)
+
+    def test_deduplicate_flag(self):
+        # Add two sessions with identical tool call sequences
+        for _ in range(3):
+            _add_session(self.store, tool_calls=3)
+        out = io.StringIO()
+        rc = run_sample(
+            self.store, "worst", n=10, output_path=self.output,
+            deduplicate=True, out=out,
+        )
+        self.assertEqual(rc, 0)
+        lines = Path(self.output).read_text().strip().splitlines()
+        # All three have identical sequences — only 1 should survive dedup
+        self.assertEqual(len(lines), 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+class TestSampleCLIRegistered(unittest.TestCase):
+    def test_sample_in_help(self):
+        import sys
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("sample", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `agent-strace sample` to automatically surface the sessions most useful for regression suites and eval datasets, without manual inspection.

### Changes

- Four sampling strategies: `worst` (highest error/retry/cost), `diverse` (greedy max-min distance across behavioral dimensions), `random` (uniform, reproducible with `--seed`), `recent` (most recent N)
- `--deduplicate` skips sessions with identical tool call sequences
- Output is JSONL — one session per line — with full event data and a score breakdown (error_rate, retry_rate, blast_radius, cost_estimate, worst_score)
- Compatible with LangSmith, Braintrust, and any custom eval framework
- 26 new tests in `tests/test_sample.py`

### Example

```bash
agent-strace sample --strategy worst --n 20 --output regression.jsonl

# Sampling 20 sessions by strategy 'worst'...
# Scoring 847 session(s)...
# Exported 20 session(s) to regression.jsonl
```

Closes #94