### PR TITLE
feat(anonymize): add trace anonymization for export

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,34 @@ retention:
 
 Policies are applied in order: age → count → size. Deletions are logged with session ID and timestamp (not content).
 
+### Trace anonymization
+
+Strip identifying information from traces at export time — original session data is never modified. Complements secret redaction (which strips secrets at capture time).
+
+```bash
+# Preview what would be anonymized
+agent-strace export SESSION_ID --anonymize --dry-run
+
+# Export with anonymization applied
+agent-strace export SESSION_ID --anonymize --output trace-anon.json
+```
+
+Anonymized by default:
+- Home directory paths → `~/relative/path`
+- Hostnames → `<hostname>`
+- OS usernames → `<user>`
+- Email addresses → `<email>`
+
+Add custom patterns via `.agent-strace/anonymize.yaml`:
+
+```yaml
+rules:
+  - pattern: "ACME Corp"
+    replacement: "<company>"
+  - pattern: "192\.168\.\d+\.\d+"
+    replacement: "<internal-ip>"
+```
+
 ### Secret redaction
 
 Strip API keys, tokens, and credentials from traces before they hit disk.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/src/agent_trace/anonymize.py
+++ b/src/agent_trace/anonymize.py
@@ -1,0 +1,325 @@
+"""Trace anonymization: strip identifying information from exported traces.
+
+Applied at export time — original session data is never modified.
+Complements secret redaction (redact.py), which strips secrets at capture
+time. Anonymization strips identity: paths, hostnames, usernames, emails.
+
+Rules applied:
+  - Home directory paths → ~/relative/path
+  - Hostnames (from socket.gethostname()) → <hostname>
+  - Email addresses → <email>
+  - OS username (from os.getlogin / env) → <user>
+  - Custom regex patterns from .agent-strace/anonymize.yaml
+
+Usage:
+    agent-strace export <session-id> --anonymize --output trace.json
+    agent-strace export <session-id> --anonymize --dry-run
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TextIO
+
+from .models import TraceEvent, SessionMeta
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Built-in anonymization rules
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(
+    r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\b"
+)
+
+
+def _get_home_dir() -> str:
+    return str(Path.home())
+
+
+def _get_hostname() -> str:
+    try:
+        return socket.gethostname()
+    except Exception:
+        return ""
+
+
+def _get_username() -> str:
+    for key in ("USER", "USERNAME", "LOGNAME"):
+        val = os.environ.get(key, "")
+        if val:
+            return val
+    try:
+        return os.getlogin()
+    except Exception:
+        return ""
+
+
+@dataclass
+class AnonymizationRule:
+    """A single find-and-replace rule."""
+    pattern: re.Pattern
+    replacement: str
+    description: str = ""
+
+
+@dataclass
+class AnonymizationResult:
+    """Summary of what was anonymized."""
+    rules_applied: dict[str, int] = field(default_factory=dict)  # description → count
+
+    @property
+    def total_replacements(self) -> int:
+        return sum(self.rules_applied.values())
+
+    def record(self, description: str, count: int = 1) -> None:
+        self.rules_applied[description] = self.rules_applied.get(description, 0) + count
+
+
+def _build_builtin_rules() -> list[AnonymizationRule]:
+    """Build the default set of anonymization rules from the current environment."""
+    rules: list[AnonymizationRule] = []
+
+    # Home directory paths
+    home = _get_home_dir()
+    if home and home != "/":
+        # Match the home dir prefix in paths, replace with ~
+        escaped = re.escape(home)
+        rules.append(AnonymizationRule(
+            pattern=re.compile(escaped + r"(/[^\s\"']*)?"),
+            replacement=lambda m: "~" + (m.group(1) or ""),
+            description="home directory paths",
+        ))
+
+    # Hostname
+    hostname = _get_hostname()
+    if hostname:
+        rules.append(AnonymizationRule(
+            pattern=re.compile(re.escape(hostname)),
+            replacement="<hostname>",
+            description="hostname",
+        ))
+
+    # Username
+    username = _get_username()
+    if username and len(username) >= 3:
+        # Only replace when it looks like a standalone word to avoid false positives
+        rules.append(AnonymizationRule(
+            pattern=re.compile(r"\b" + re.escape(username) + r"\b"),
+            replacement="<user>",
+            description="username",
+        ))
+
+    # Email addresses
+    rules.append(AnonymizationRule(
+        pattern=_EMAIL_RE,
+        replacement="<email>",
+        description="email addresses",
+    ))
+
+    return rules
+
+
+def _load_custom_rules(config_path: str | Path | None = None) -> list[AnonymizationRule]:
+    """Load custom rules from .agent-strace/anonymize.yaml or the given path."""
+    paths = []
+    if config_path:
+        paths.append(Path(config_path))
+    paths += [
+        Path(".agent-strace/anonymize.yaml"),
+        Path(".agent-strace/anonymize.yml"),
+    ]
+
+    for p in paths:
+        if p.exists():
+            try:
+                return _parse_custom_rules(p.read_text())
+            except Exception:
+                pass
+    return []
+
+
+def _parse_custom_rules(text: str) -> list[AnonymizationRule]:
+    """Parse a minimal YAML rules file into AnonymizationRule objects.
+
+    Expected format:
+        rules:
+          - pattern: "regex here"
+            replacement: "<REDACTED>"
+    """
+    rules: list[AnonymizationRule] = []
+    current: dict = {}
+    in_rules = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "rules:":
+            in_rules = True
+            continue
+        if not in_rules:
+            continue
+        if stripped.startswith("- "):
+            if current:
+                _try_add_rule(current, rules)
+            current = {}
+            rest = stripped[2:].strip()
+            if ":" in rest:
+                k, _, v = rest.partition(":")
+                current[k.strip()] = v.strip().strip('"').strip("'")
+        elif current is not None and ":" in stripped:
+            k, _, v = stripped.partition(":")
+            current[k.strip()] = v.strip().strip('"').strip("'")
+
+    if current:
+        _try_add_rule(current, rules)
+
+    return rules
+
+
+def _try_add_rule(d: dict, rules: list[AnonymizationRule]) -> None:
+    pattern_str = d.get("pattern", "")
+    replacement = d.get("replacement", "<REDACTED>")
+    description = d.get("description", f"custom: {pattern_str[:40]}")
+    if pattern_str:
+        try:
+            rules.append(AnonymizationRule(
+                pattern=re.compile(pattern_str),
+                replacement=replacement,
+                description=description,
+            ))
+        except re.error:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Core anonymization engine
+# ---------------------------------------------------------------------------
+
+def _apply_rules_to_string(
+    text: str,
+    rules: list[AnonymizationRule],
+    result: AnonymizationResult,
+) -> str:
+    """Apply all rules to a string, recording replacement counts."""
+    for rule in rules:
+        new_text, count = rule.pattern.subn(rule.replacement, text)
+        if count:
+            result.record(rule.description, count)
+            text = new_text
+    return text
+
+
+def _anonymize_value(
+    value: Any,
+    rules: list[AnonymizationRule],
+    result: AnonymizationResult,
+) -> Any:
+    """Recursively anonymize a value (str, dict, list, or scalar)."""
+    if isinstance(value, str):
+        return _apply_rules_to_string(value, rules, result)
+    if isinstance(value, dict):
+        return {k: _anonymize_value(v, rules, result) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_anonymize_value(item, rules, result) for item in value]
+    return value
+
+
+def anonymize_event(
+    event: TraceEvent,
+    rules: list[AnonymizationRule],
+    result: AnonymizationResult,
+) -> TraceEvent:
+    """Return a new TraceEvent with anonymized data. Original is unchanged."""
+    new_data = _anonymize_value(event.data, rules, result)
+    # Build a new event with the same fields but anonymized data
+    import copy
+    new_event = copy.copy(event)
+    new_event.data = new_data
+    return new_event
+
+
+def anonymize_session(
+    store: TraceStore,
+    session_id: str,
+    custom_config: str | Path | None = None,
+) -> tuple[list[TraceEvent], AnonymizationResult]:
+    """Load and anonymize all events for a session.
+
+    Returns (anonymized_events, result_summary). Original store is unchanged.
+    """
+    events = store.load_events(session_id)
+    rules = _build_builtin_rules() + _load_custom_rules(custom_config)
+    result = AnonymizationResult()
+    anonymized = [anonymize_event(ev, rules, result) for ev in events]
+    return anonymized, result
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_anonymize_export(args, out: TextIO = sys.stdout) -> int:
+    """Export a session with anonymization applied."""
+    store = TraceStore(args.trace_dir)
+
+    session_id = getattr(args, "session_id", None)
+    if not session_id:
+        session_id = store.get_latest_session_id()
+    if not session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+
+    if not store.session_exists(session_id):
+        found = store.find_session(session_id)
+        if found:
+            session_id = found
+        else:
+            sys.stderr.write(f"Session not found: {session_id}\n")
+            return 1
+
+    custom_config = getattr(args, "anonymize_config", None)
+    dry_run = getattr(args, "dry_run", False)
+
+    anonymized_events, result = anonymize_session(store, session_id, custom_config)
+
+    if dry_run:
+        out.write(f"Anonymizing session {session_id[:16]}...\n\n")
+        if result.total_replacements == 0:
+            out.write("Nothing to anonymize.\n")
+        else:
+            out.write("Would redact:\n")
+            for desc, count in sorted(result.rules_applied.items()):
+                out.write(f"  {count:3d} {desc}\n")
+        return 0
+
+    output_path = getattr(args, "output", "") or f"session-{session_id[:12]}-anon.json"
+    meta = store.load_meta(session_id)
+
+    export_data = {
+        "session_id": session_id,
+        "meta": json.loads(meta.to_json()),
+        "anonymized": True,
+        "events": [json.loads(ev.to_json()) for ev in anonymized_events],
+    }
+
+    Path(output_path).write_text(json.dumps(export_data, indent=2))
+
+    out.write(f"Anonymizing session {session_id[:16]}...\n\n")
+    if result.total_replacements == 0:
+        out.write("Nothing to anonymize.\n")
+    else:
+        out.write("Redacted:\n")
+        for desc, count in sorted(result.rules_applied.items()):
+            out.write(f"  {count:3d} {desc}\n")
+    out.write(f"\nExported anonymized trace to {output_path}\n")
+    return 0

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -45,6 +45,7 @@ from .policy import cmd_policy
 from .postmortem import cmd_postmortem
 from .share import cmd_share
 from .token_budget import cmd_token_budget
+from .anonymize import cmd_anonymize_export
 from .retention import cmd_retention
 from .sample import cmd_sample
 from .watch import cmd_watch
@@ -229,11 +230,14 @@ def cmd_inspect(args: argparse.Namespace) -> int:
 
 
 def cmd_export(args: argparse.Namespace) -> int:
+    """Export a session to JSON, CSV, or OTLP."""
     # Route to Langfuse/OTLP export when --scores, --metrics, or --backend is set
     if getattr(args, "scores", False) or getattr(args, "metrics", False) or getattr(args, "backend", None):
         return cmd_export_scores(args)
 
-    """Export a session to JSON, CSV, or OTLP."""
+    # Route to anonymized export when --anonymize is set
+    if getattr(args, "anonymize", False):
+        return cmd_anonymize_export(args)
     store = TraceStore(args.trace_dir)
 
     session_id = args.session_id
@@ -496,6 +500,14 @@ def build_parser() -> argparse.ArgumentParser:
                           help="OTLP metrics endpoint (overrides OTEL_EXPORTER_OTLP_ENDPOINT)")
     p_export.add_argument("--otlp-headers", dest="otlp_headers", metavar="HEADERS",
                           help="OTLP headers as key=value,key=value")
+    p_export.add_argument("--anonymize", action="store_true",
+                          help="strip identifying information (paths, hostnames, emails, usernames) from the export")
+    p_export.add_argument("--anonymize-config", dest="anonymize_config", metavar="FILE",
+                          help="path to custom anonymization rules YAML file")
+    p_export.add_argument("--output", "-o", default="",
+                          help="output file path for anonymized export")
+    p_export.add_argument("--dry-run", action="store_true",
+                          help="show what would be anonymized without writing output (use with --anonymize)")
 
     # stats
     p_stats = sub.add_parser("stats", help="show session statistics")

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -1,0 +1,339 @@
+"""Tests for trace anonymization (issue #95)."""
+
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.anonymize import (
+    AnonymizationResult,
+    AnonymizationRule,
+    _apply_rules_to_string,
+    _anonymize_value,
+    _build_builtin_rules,
+    _load_custom_rules,
+    _parse_custom_rules,
+    anonymize_event,
+    anonymize_session,
+    cmd_anonymize_export,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+import re
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmpdir = tempfile.mkdtemp()
+    return TraceStore(tmpdir), tmpdir
+
+
+def _add_session(store: TraceStore, events_data: list[dict] | None = None) -> SessionMeta:
+    meta = SessionMeta()
+    store.create_session(meta)
+    for d in (events_data or []):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data=d,
+        )
+        store.append_event(meta.session_id, ev)
+    return meta
+
+
+def _make_rule(pattern: str, replacement: str, desc: str = "test") -> AnonymizationRule:
+    return AnonymizationRule(
+        pattern=re.compile(pattern),
+        replacement=replacement,
+        description=desc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AnonymizationResult
+# ---------------------------------------------------------------------------
+
+class TestAnonymizationResult(unittest.TestCase):
+    def test_total_replacements_zero_initially(self):
+        r = AnonymizationResult()
+        self.assertEqual(r.total_replacements, 0)
+
+    def test_record_increments_count(self):
+        r = AnonymizationResult()
+        r.record("emails", 3)
+        r.record("emails", 2)
+        self.assertEqual(r.rules_applied["emails"], 5)
+        self.assertEqual(r.total_replacements, 5)
+
+    def test_multiple_categories(self):
+        r = AnonymizationResult()
+        r.record("emails", 2)
+        r.record("paths", 5)
+        self.assertEqual(r.total_replacements, 7)
+
+
+# ---------------------------------------------------------------------------
+# _apply_rules_to_string
+# ---------------------------------------------------------------------------
+
+class TestApplyRulesToString(unittest.TestCase):
+    def test_replaces_match(self):
+        rule = _make_rule(r"\bfoo\b", "<FOO>")
+        result = AnonymizationResult()
+        out = _apply_rules_to_string("foo bar foo", [rule], result)
+        self.assertEqual(out, "<FOO> bar <FOO>")
+        self.assertEqual(result.rules_applied["test"], 2)
+
+    def test_no_match_unchanged(self):
+        rule = _make_rule(r"xyz", "<XYZ>")
+        result = AnonymizationResult()
+        out = _apply_rules_to_string("hello world", [rule], result)
+        self.assertEqual(out, "hello world")
+        self.assertEqual(result.total_replacements, 0)
+
+    def test_multiple_rules_applied_in_order(self):
+        rules = [
+            _make_rule(r"foo", "<FOO>", "foo"),
+            _make_rule(r"bar", "<BAR>", "bar"),
+        ]
+        result = AnonymizationResult()
+        out = _apply_rules_to_string("foo bar", rules, result)
+        self.assertEqual(out, "<FOO> <BAR>")
+
+
+# ---------------------------------------------------------------------------
+# _anonymize_value
+# ---------------------------------------------------------------------------
+
+class TestAnonymizeValue(unittest.TestCase):
+    def test_string_value(self):
+        rule = _make_rule(r"secret@example\.com", "<email>")
+        result = AnonymizationResult()
+        out = _anonymize_value("contact secret@example.com", [rule], result)
+        self.assertEqual(out, "contact <email>")
+
+    def test_nested_dict(self):
+        rule = _make_rule(r"alice", "<user>")
+        result = AnonymizationResult()
+        data = {"user": "alice", "nested": {"owner": "alice"}}
+        out = _anonymize_value(data, [rule], result)
+        self.assertEqual(out["user"], "<user>")
+        self.assertEqual(out["nested"]["owner"], "<user>")
+
+    def test_list_of_strings(self):
+        rule = _make_rule(r"alice", "<user>")
+        result = AnonymizationResult()
+        out = _anonymize_value(["alice", "bob", "alice"], [rule], result)
+        self.assertEqual(out, ["<user>", "bob", "<user>"])
+
+    def test_non_string_scalar_unchanged(self):
+        rule = _make_rule(r"42", "<num>")
+        result = AnonymizationResult()
+        out = _anonymize_value(42, [rule], result)
+        self.assertEqual(out, 42)  # int, not string — unchanged
+
+
+# ---------------------------------------------------------------------------
+# _build_builtin_rules — email detection
+# ---------------------------------------------------------------------------
+
+class TestBuiltinRules(unittest.TestCase):
+    def test_email_rule_present(self):
+        rules = _build_builtin_rules()
+        descriptions = [r.description for r in rules]
+        self.assertIn("email addresses", descriptions)
+
+    def test_email_replaced(self):
+        rules = _build_builtin_rules()
+        result = AnonymizationResult()
+        out = _apply_rules_to_string("contact user@example.com for help", rules, result)
+        self.assertNotIn("user@example.com", out)
+        self.assertIn("<email>", out)
+
+    def test_home_dir_replaced(self):
+        home = str(Path.home())
+        if home == "/" or not home:
+            self.skipTest("home dir is root, skip")
+        rules = _build_builtin_rules()
+        result = AnonymizationResult()
+        path = f"{home}/projects/myapp/config.py"
+        out = _apply_rules_to_string(path, rules, result)
+        self.assertNotIn(home, out)
+        self.assertIn("~/", out)
+
+
+# ---------------------------------------------------------------------------
+# _parse_custom_rules
+# ---------------------------------------------------------------------------
+
+class TestParseCustomRules(unittest.TestCase):
+    def test_parses_pattern_and_replacement(self):
+        yaml = "rules:\n  - pattern: 'ACME Corp'\n    replacement: '<company>'\n"
+        rules = _parse_custom_rules(yaml)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].replacement, "<company>")
+
+    def test_invalid_regex_skipped(self):
+        yaml = "rules:\n  - pattern: '[invalid'\n    replacement: '<x>'\n"
+        rules = _parse_custom_rules(yaml)
+        self.assertEqual(len(rules), 0)
+
+    def test_empty_yaml_returns_empty(self):
+        rules = _parse_custom_rules("")
+        self.assertEqual(rules, [])
+
+    def test_multiple_rules(self):
+        yaml = (
+            "rules:\n"
+            "  - pattern: 'foo'\n    replacement: '<foo>'\n"
+            "  - pattern: 'bar'\n    replacement: '<bar>'\n"
+        )
+        rules = _parse_custom_rules(yaml)
+        self.assertEqual(len(rules), 2)
+
+
+# ---------------------------------------------------------------------------
+# anonymize_event
+# ---------------------------------------------------------------------------
+
+class TestAnonymizeEvent(unittest.TestCase):
+    def test_original_event_unchanged(self):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "Bash", "arguments": {"command": "echo user@example.com"}},
+        )
+        rule = _make_rule(r"user@example\.com", "<email>")
+        result = AnonymizationResult()
+        new_ev = anonymize_event(ev, [rule], result)
+        # Original unchanged
+        self.assertIn("user@example.com", ev.data["arguments"]["command"])
+        # New event anonymized
+        self.assertIn("<email>", new_ev.data["arguments"]["command"])
+
+    def test_event_id_preserved(self):
+        ev = TraceEvent(event_type=EventType.TOOL_CALL, data={"x": "y"})
+        result = AnonymizationResult()
+        new_ev = anonymize_event(ev, [], result)
+        self.assertEqual(new_ev.event_id, ev.event_id)
+
+
+# ---------------------------------------------------------------------------
+# anonymize_session
+# ---------------------------------------------------------------------------
+
+class TestAnonymizeSession(unittest.TestCase):
+    def test_anonymizes_email_in_events(self):
+        store, _ = _make_store()
+        meta = _add_session(store, [
+            {"tool_name": "Bash", "arguments": {"command": "git config user.email alice@corp.com"}},
+        ])
+        events, result = anonymize_session(store, meta.session_id)
+        cmd = events[0].data["arguments"]["command"]
+        self.assertNotIn("alice@corp.com", cmd)
+        self.assertIn("<email>", cmd)
+
+    def test_result_records_replacements(self):
+        store, _ = _make_store()
+        meta = _add_session(store, [
+            {"tool_name": "Bash", "arguments": {"command": "echo bob@example.com"}},
+        ])
+        _, result = anonymize_session(store, meta.session_id)
+        self.assertGreater(result.total_replacements, 0)
+
+    def test_empty_session_no_crash(self):
+        store, _ = _make_store()
+        meta = _add_session(store, [])
+        events, result = anonymize_session(store, meta.session_id)
+        self.assertEqual(events, [])
+        self.assertEqual(result.total_replacements, 0)
+
+
+# ---------------------------------------------------------------------------
+# cmd_anonymize_export
+# ---------------------------------------------------------------------------
+
+class TestCmdAnonymizeExport(unittest.TestCase):
+    def _make_args(self, store: TraceStore, session_id: str,
+                   output: str = "", dry_run: bool = False) -> object:
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = str(store.base_dir)
+        args.session_id = session_id
+        args.anonymize_config = None
+        args.output = output
+        args.dry_run = dry_run
+        return args
+
+    def test_writes_output_file(self):
+        store, tmpdir = _make_store()
+        meta = _add_session(store, [{"tool_name": "Bash", "arguments": {"command": "echo hi"}}])
+        output = os.path.join(tmpdir, "anon.json")
+        args = self._make_args(store, meta.session_id, output=output)
+        out = io.StringIO()
+        rc = cmd_anonymize_export(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertTrue(Path(output).exists())
+        data = json.loads(Path(output).read_text())
+        self.assertEqual(data["session_id"], meta.session_id)
+        self.assertTrue(data["anonymized"])
+
+    def test_dry_run_does_not_write(self):
+        store, tmpdir = _make_store()
+        meta = _add_session(store, [{"tool_name": "Bash", "arguments": {"command": "echo hi"}}])
+        output = os.path.join(tmpdir, "anon.json")
+        args = self._make_args(store, meta.session_id, output=output, dry_run=True)
+        out = io.StringIO()
+        rc = cmd_anonymize_export(args, out=out)
+        self.assertEqual(rc, 0)
+        self.assertFalse(Path(output).exists())
+
+    def test_missing_session_returns_error(self):
+        store, _ = _make_store()
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = str(store.base_dir)
+        args.session_id = "nonexistent"
+        args.anonymize_config = None
+        args.output = ""
+        args.dry_run = False
+        out = io.StringIO()
+        rc = cmd_anonymize_export(args, out=out)
+        self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI: --anonymize flag registered on export
+# ---------------------------------------------------------------------------
+
+class TestAnonymizeCLIFlag(unittest.TestCase):
+    def test_anonymize_flag_in_export_help(self):
+        import sys
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "export", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("--anonymize", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Strips identifying information from traces at export time. Original session data is never modified. Complements secret redaction (which strips secrets at capture time).

### Changes

- `agent-strace export SESSION_ID --anonymize` — export with anonymization applied
- `--dry-run` — preview what would be anonymized without writing output
- `--anonymize-config FILE` — path to custom rules YAML
- Built-in rules: home directory paths → `~/...`, hostnames → `<hostname>`, OS usernames → `<user>`, email addresses → `<email>`
- Custom patterns via `.agent-strace/anonymize.yaml`
- 26 new tests in `tests/test_anonymize.py`

### Example

```bash
# Preview
agent-strace export abc123 --anonymize --dry-run
# Anonymizing session abc123...
# Would redact:
#    3 email addresses
#   12 home directory paths
#    1 hostname

# Export
agent-strace export abc123 --anonymize --output trace-anon.json
```

Closes #95