### PR TITLE
feat(otlp): add --format otlp-genai with OTel GenAI semantic conventions

### DIFF
--- a/ADRs/0011-otlp-genai-semantic-conventions.md
+++ b/ADRs/0011-otlp-genai-semantic-conventions.md
@@ -1,0 +1,59 @@
+# ADR-0011: OTLP GenAI Semantic Conventions Export Format
+
+**Status:** Accepted  
+**Date:** 2026-05  
+**Deciders:** Siddhant Khare
+
+## Context
+
+agent-strace already exports OTLP (ADR-0006). The OpenTelemetry GenAI semantic
+conventions (`gen_ai.*`) are now the standard attribute set for AI spans and are
+natively understood by Datadog LLM Observability, Grafana GenAI dashboards,
+Honeycomb, and any OTel-compatible backend.
+
+Without this mapping, agent-strace traces land in production backends as
+unrecognized custom spans. They don't get AI-specific dashboards, cost views,
+token usage charts, or anomaly detection.
+
+## Decision
+
+Add a `--format otlp-genai` flag to `agent-strace export` that applies the
+OTel GenAI semantic conventions mapping. The existing `--format otlp` output
+is unchanged for backwards compatibility.
+
+### Mapping
+
+| agent-strace event | OTel GenAI span / attribute |
+|---|---|
+| `llm_request` + `llm_response` | `gen_ai.client.operation` child span with `gen_ai.request.model`, `gen_ai.request.max_tokens`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons` |
+| `tool_call` + `tool_result` | `gen_ai.tool.call/<name>` child span with `gen_ai.tool.name`, `gen_ai.tool.call.id` |
+| `user_prompt` | `gen_ai.user.message` event on root span |
+| `assistant_response` | `gen_ai.assistant.message` event on root span |
+| `error` | OTel `exception` event with `exception.type`, `exception.message` |
+| `session_start` / `session_end` | Root span with `gen_ai.agent.id`, `gen_ai.agent.name` |
+
+### Span hierarchy
+
+```
+session root span (gen_ai.agent.session)
+  ├── gen_ai.client.operation   (one per LLM request/response pair)
+  ├── gen_ai.tool.call/<name>   (one per tool call/result pair)
+  └── gen_ai.tool.call/<name>   (error variant with exception event)
+```
+
+### Key differences from --format otlp
+
+- LLM request/response pairs become proper child spans (not events on root)
+- Root span carries `gen_ai.agent.id` and `gen_ai.agent.name`
+- Error events use the OTel `exception` event format
+- Tool input/output attributes use `gen_ai.tool.input.*` / `gen_ai.tool.output`
+- Scope name includes `genai-semconv-1.27` for version tracking
+
+## Consequences
+
+- Traces exported with `--format otlp-genai` appear in Grafana, Datadog, and
+  Honeycomb with AI-specific dashboards populated automatically.
+- Existing `--format otlp` output is unchanged — no breaking change.
+- No new runtime dependencies — the mapping is pure Python stdlib.
+- The `gen_ai.system` attribute is derived heuristically from the model name;
+  this may be incorrect for custom or fine-tuned models.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ agent-strace replay [session-id] [--limit N]    Replay a session (--limit caps e
 agent-strace retention status                   Show session count, size, and what policy would delete
 agent-strace retention clean [--dry-run]        Delete sessions that exceed retention limits
 agent-strace sample --strategy worst --n 20     Export worst/diverse/random/recent sessions as JSONL
+agent-strace export <session> --format otlp-genai  Export with OTel GenAI semantic conventions
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report
@@ -1223,6 +1224,26 @@ Any attempt by the agent to read `cvm/attestation-service/` or `cvm/auth-service
 ## Production tracing (OTLP export)
 
 Export sessions as OpenTelemetry spans to your existing observability stack. Sessions become traces. Tool calls become spans with duration and inputs. Errors get exception events. No new dependencies.
+
+### OTel GenAI semantic conventions
+
+Use `--format otlp-genai` to export with strict [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This produces AI-native spans that populate token usage charts, cost views, and LLM dashboards in Datadog, Grafana, and Honeycomb automatically.
+
+```bash
+agent-strace export <session-id> --format otlp-genai \
+  --endpoint http://localhost:4318
+```
+
+Key differences from `--format otlp`:
+
+| Aspect | `--format otlp` | `--format otlp-genai` |
+|---|---|---|
+| LLM calls | Events on root span | `gen_ai.client.operation` child spans |
+| Tool calls | `tool/<name>` spans | `gen_ai.tool.call/<name>` spans |
+| Root span | `agent.name` attribute | `gen_ai.agent.id` + `gen_ai.agent.name` |
+| Errors | Custom error span | OTel `exception` event format |
+
+`--format otlp` is unchanged for backwards compatibility.
 
 ### Datadog
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.42.1"
+__version__ = "0.43.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -272,14 +272,25 @@ def cmd_export(args: argparse.Namespace) -> int:
         for e in events:
             sys.stdout.write(e.to_json() + "\n")
 
-    elif args.format == "otlp":
-        from .otlp import export_otlp, session_to_otlp
+    elif args.format in ("otlp", "otlp-genai"):
+        from .otlp import export_otlp, session_to_otlp, session_to_otlp_genai
 
+        use_genai = args.format == "otlp-genai"
         endpoint = args.endpoint
+
+        # When --endpoint is set and format is plain otlp, default to otlp-genai
+        # for better backend compatibility (backwards-compat: explicit --format otlp
+        # always uses the legacy mapping)
+        if endpoint and not use_genai:
+            use_genai = False  # explicit --format otlp keeps legacy behaviour
+
         if not endpoint:
             # No endpoint: dump OTLP JSON to stdout
             meta = store.load_meta(session_id)
-            payload = session_to_otlp(meta, events, service_name=args.service_name)
+            if use_genai:
+                payload = session_to_otlp_genai(meta, events, service_name=args.service_name)
+            else:
+                payload = session_to_otlp(meta, events, service_name=args.service_name)
             sys.stdout.write(json.dumps(payload, indent=2) + "\n")
             return 0
 
@@ -290,14 +301,33 @@ def cmd_export(args: argparse.Namespace) -> int:
                 key, val = h.split(":", 1)
                 headers[key.strip()] = val.strip()
 
-        ok = export_otlp(
-            store=store,
-            session_id=session_id,
-            endpoint=endpoint,
-            headers=headers,
-            service_name=args.service_name,
-        )
-        return 0 if ok else 1
+        if use_genai:
+            # Export using GenAI conventions
+            import urllib.request, urllib.error
+            meta = store.load_meta(session_id)
+            payload = session_to_otlp_genai(meta, events, service_name=args.service_name)
+            body = json.dumps(payload).encode("utf-8")
+            url = endpoint.rstrip("/") + "/v1/traces"
+            req_headers = {"Content-Type": "application/json"}
+            req_headers.update(headers)
+            req = urllib.request.Request(url, data=body, headers=req_headers, method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    ok = resp.status in (200, 202)
+                    sys.stderr.write(f"Exported {len(events)} events to {url} (HTTP {resp.status})\n")
+                    return 0 if ok else 1
+            except Exception as exc:
+                sys.stderr.write(f"OTLP GenAI export failed: {exc}\n")
+                return 1
+        else:
+            ok = export_otlp(
+                store=store,
+                session_id=session_id,
+                endpoint=endpoint,
+                headers=headers,
+                service_name=args.service_name,
+            )
+            return 0 if ok else 1
 
     return 0
 
@@ -477,7 +507,9 @@ def build_parser() -> argparse.ArgumentParser:
     # export
     p_export = sub.add_parser("export", help="export a session")
     p_export.add_argument("session_id", nargs="?", help="session ID or prefix")
-    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp"], default="json")
+    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp", "otlp-genai"],
+                          default="json",
+                          help="output format (otlp-genai uses strict OTel GenAI semantic conventions)")
     p_export.add_argument("--endpoint", help="OTLP collector URL (e.g. http://localhost:4318)")
     p_export.add_argument("--header", action="append", help="HTTP header for OTLP (e.g. 'x-honeycomb-team: KEY')")
     p_export.add_argument("--service-name", default="agent-trace", help="OTel service name (default: agent-trace)")

--- a/src/agent_trace/otlp.py
+++ b/src/agent_trace/otlp.py
@@ -392,6 +392,292 @@ def tree_to_otlp(
     }
 
 
+def session_to_otlp_genai(
+    meta: SessionMeta,
+    events: list[TraceEvent],
+    service_name: str = "agent-trace",
+    parent_span_id: str = "",
+    parent_trace_id: str = "",
+) -> dict:
+    """Convert a session to OTLP JSON using strict OTel GenAI semantic conventions.
+
+    Differences from session_to_otlp():
+    - LLM request/response pairs become gen_ai.client.operation child spans
+      (not just events on the root span)
+    - Root span carries gen_ai.agent.id and gen_ai.agent.name
+    - Error events use the OTel exception event format
+    - Tool calls carry gen_ai.tool.name and gen_ai.tool.call.id
+    - gen_ai.system is derived from the model name when possible
+
+    See: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+    """
+    trace_id = parent_trace_id if parent_trace_id else _to_trace_id(meta.session_id)
+    root_span_id = _to_span_id(f"root-{meta.session_id}")
+    root_start = _ts_to_nanos(meta.started_at)
+    root_end = _ts_to_nanos(
+        meta.ended_at or (meta.started_at + (meta.total_duration_ms or 0) / 1000)
+    )
+
+    # Detect provider
+    agent_lower = (meta.agent_name or "").lower()
+    if "claude" in agent_lower or "anthropic" in agent_lower:
+        gen_ai_system = "anthropic"
+    elif "gpt" in agent_lower or "openai" in agent_lower:
+        gen_ai_system = "openai"
+    elif "gemini" in agent_lower or "google" in agent_lower:
+        gen_ai_system = "google"
+    else:
+        gen_ai_system = "unknown"
+
+    root_attrs = _make_attributes({
+        # GenAI agent attributes
+        "gen_ai.agent.id": meta.session_id,
+        "gen_ai.agent.name": meta.agent_name or "agent",
+        _SEMCONV_SYSTEM: gen_ai_system,
+        _SEMCONV_OP: "agent.session",
+        # Standard resource attributes
+        "agent.session_id": meta.session_id,
+        "agent.tool_calls": meta.tool_calls,
+        "agent.llm_requests": meta.llm_requests,
+        "agent.errors": meta.errors,
+    })
+
+    root_events: list[dict] = []
+    child_spans: list[dict] = []
+
+    # Pair LLM requests with their responses
+    pending_llm: dict[str, TraceEvent] = {}
+    pending_calls: dict[str, TraceEvent] = {}
+
+    for event in events:
+        if event.event_type == EventType.USER_PROMPT:
+            root_events.append(_make_event(
+                "gen_ai.user.message",
+                event.timestamp,
+                {"gen_ai.prompt": event.data.get("prompt", "")[:1000]},
+            ))
+
+        elif event.event_type == EventType.ASSISTANT_RESPONSE:
+            text = event.data.get("text", "")
+            root_events.append(_make_event(
+                "gen_ai.assistant.message",
+                event.timestamp,
+                {"gen_ai.completion": text[:1000]},
+            ))
+
+        elif event.event_type == EventType.LLM_REQUEST:
+            pending_llm[event.event_id] = event
+
+        elif event.event_type == EventType.LLM_RESPONSE:
+            # Find matching request
+            req_event = None
+            if event.parent_id and event.parent_id in pending_llm:
+                req_event = pending_llm.pop(event.parent_id)
+            elif pending_llm:
+                # Take the oldest unmatched request
+                oldest_id = next(iter(pending_llm))
+                req_event = pending_llm.pop(oldest_id)
+
+            span_start = req_event.timestamp if req_event else event.timestamp
+            span_end = event.timestamp
+
+            # Derive gen_ai.system from model name if not already known
+            model = event.data.get("model", "") or (
+                req_event.data.get("model", "") if req_event else ""
+            )
+            system = gen_ai_system
+            if model:
+                m = model.lower()
+                if "claude" in m:
+                    system = "anthropic"
+                elif "gpt" in m or "o1" in m or "o3" in m:
+                    system = "openai"
+                elif "gemini" in m:
+                    system = "google"
+
+            llm_attrs: dict = {
+                _SEMCONV_SYSTEM: system,
+                _SEMCONV_OP: "chat",
+            }
+            if model:
+                llm_attrs[_SEMCONV_MODEL] = model
+            if req_event:
+                max_tok = req_event.data.get("max_tokens")
+                if max_tok:
+                    llm_attrs["gen_ai.request.max_tokens"] = max_tok
+                inp_tok = req_event.data.get("input_tokens", 0)
+                if inp_tok:
+                    llm_attrs[_SEMCONV_INPUT_TOKENS] = inp_tok
+
+            out_tok = event.data.get("output_tokens", 0)
+            if out_tok:
+                llm_attrs[_SEMCONV_OUTPUT_TOKENS] = out_tok
+            finish = event.data.get("stop_reason") or event.data.get("finish_reason", "")
+            if finish:
+                llm_attrs[_SEMCONV_FINISH_REASON] = finish
+
+            llm_span_id = _to_span_id(
+                req_event.event_id if req_event else event.event_id
+            )
+            child_spans.append({
+                "traceId": trace_id,
+                "spanId": llm_span_id,
+                "parentSpanId": root_span_id,
+                "name": "gen_ai.client.operation",
+                "kind": 3,  # SPAN_KIND_CLIENT
+                "startTimeUnixNano": _ts_to_nanos(span_start),
+                "endTimeUnixNano": _ts_to_nanos(max(span_end, span_start + 0.001)),
+                "attributes": _make_attributes(llm_attrs),
+                "status": {"code": 1},  # STATUS_CODE_OK
+            })
+
+        elif event.event_type == EventType.TOOL_CALL:
+            pending_calls[event.event_id] = event
+
+        elif event.event_type == EventType.TOOL_RESULT:
+            call_event = None
+            if event.parent_id and event.parent_id in pending_calls:
+                call_event = pending_calls.pop(event.parent_id)
+
+            tool_name = event.data.get("tool_name", "") or (
+                call_event.data.get("tool_name", "tool") if call_event else "tool"
+            )
+            span_start = call_event.timestamp if call_event else event.timestamp
+            duration_ns = _duration_to_nanos(event.duration_ms)
+
+            tool_attrs: dict = {
+                _SEMCONV_TOOL_NAME: tool_name,
+                _SEMCONV_OP: "execute",
+                _SEMCONV_TOOL_CALL_ID: (
+                    call_event.event_id if call_event else event.event_id
+                ),
+            }
+            if call_event:
+                for k, v in call_event.data.get("arguments", {}).items():
+                    tool_attrs[f"gen_ai.tool.input.{k}"] = str(v)[:200]
+            result = event.data.get("result", "")
+            if result:
+                tool_attrs["gen_ai.tool.output"] = str(result)[:500]
+
+            child_spans.append({
+                "traceId": trace_id,
+                "spanId": _to_span_id(
+                    call_event.event_id if call_event else event.event_id
+                ),
+                "parentSpanId": root_span_id,
+                "name": f"gen_ai.tool.call/{tool_name}",
+                "kind": 3,  # SPAN_KIND_CLIENT
+                "startTimeUnixNano": _ts_to_nanos(span_start),
+                "endTimeUnixNano": _ts_to_nanos(
+                    span_start + duration_ns / 1_000_000_000
+                ),
+                "attributes": _make_attributes(tool_attrs),
+                "status": {"code": 1},
+            })
+
+        elif event.event_type == EventType.ERROR:
+            call_event = None
+            if event.parent_id and event.parent_id in pending_calls:
+                call_event = pending_calls.pop(event.parent_id)
+
+            tool_name = event.data.get("tool_name", "error")
+            error_msg = event.data.get("error", "") or event.data.get("message", "")
+            span_start = call_event.timestamp if call_event else event.timestamp
+            duration_ns = _duration_to_nanos(event.duration_ms)
+
+            exc_event = _make_event("exception", event.timestamp, {
+                "exception.type": event.data.get("error_type", "Error"),
+                "exception.message": str(error_msg)[:500],
+                "exception.escaped": False,
+            })
+
+            child_spans.append({
+                "traceId": trace_id,
+                "spanId": _to_span_id(
+                    call_event.event_id if call_event else event.event_id
+                ),
+                "parentSpanId": root_span_id,
+                "name": f"gen_ai.tool.call/{tool_name}",
+                "kind": 3,
+                "startTimeUnixNano": _ts_to_nanos(span_start),
+                "endTimeUnixNano": _ts_to_nanos(
+                    span_start + duration_ns / 1_000_000_000
+                ),
+                "attributes": _make_attributes({
+                    _SEMCONV_TOOL_NAME: tool_name,
+                    _SEMCONV_OP: "execute",
+                }),
+                "events": [exc_event],
+                "status": {"code": 2, "message": str(error_msg)[:200]},
+            })
+
+    # Emit unmatched LLM requests as minimal spans
+    for req_event in pending_llm.values():
+        model = req_event.data.get("model", "")
+        llm_attrs = {_SEMCONV_SYSTEM: gen_ai_system, _SEMCONV_OP: "chat"}
+        if model:
+            llm_attrs[_SEMCONV_MODEL] = model
+        child_spans.append({
+            "traceId": trace_id,
+            "spanId": _to_span_id(req_event.event_id),
+            "parentSpanId": root_span_id,
+            "name": "gen_ai.client.operation",
+            "kind": 3,
+            "startTimeUnixNano": _ts_to_nanos(req_event.timestamp),
+            "endTimeUnixNano": _ts_to_nanos(req_event.timestamp + 0.001),
+            "attributes": _make_attributes(llm_attrs),
+            "status": {"code": 0},
+        })
+
+    # Emit unmatched tool calls
+    for call_event in pending_calls.values():
+        tool_name = call_event.data.get("tool_name", "tool")
+        child_spans.append({
+            "traceId": trace_id,
+            "spanId": _to_span_id(call_event.event_id),
+            "parentSpanId": root_span_id,
+            "name": f"gen_ai.tool.call/{tool_name}",
+            "kind": 3,
+            "startTimeUnixNano": _ts_to_nanos(call_event.timestamp),
+            "endTimeUnixNano": _ts_to_nanos(call_event.timestamp + 0.001),
+            "attributes": _make_attributes({
+                _SEMCONV_TOOL_NAME: tool_name,
+                _SEMCONV_OP: "execute",
+            }),
+            "status": {"code": 0},
+        })
+
+    root_span: dict = {
+        "traceId": trace_id,
+        "spanId": root_span_id,
+        "name": f"gen_ai.agent.session ({meta.agent_name or 'agent'})",
+        "kind": 1,  # SPAN_KIND_INTERNAL
+        "startTimeUnixNano": root_start,
+        "endTimeUnixNano": root_end,
+        "attributes": root_attrs,
+        "events": root_events,
+        "status": {"code": 2 if meta.errors > 0 else 1},
+    }
+    if parent_span_id:
+        root_span["parentSpanId"] = parent_span_id
+
+    return {
+        "resourceSpans": [{
+            "resource": {
+                "attributes": _make_attributes({
+                    "service.name": service_name,
+                    "service.version": "agent-trace",
+                    "agent.session_id": meta.session_id,
+                }),
+            },
+            "scopeSpans": [{
+                "scope": {"name": "agent-trace", "version": "genai-semconv-1.27"},
+                "spans": [root_span] + child_spans,
+            }],
+        }],
+    }
+
+
 def export_otlp(
     store: TraceStore,
     session_id: str,

--- a/tests/test_otlp_genai.py
+++ b/tests/test_otlp_genai.py
@@ -1,0 +1,360 @@
+"""Tests for OTLP GenAI semantic conventions export (issue #100)."""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.otlp import session_to_otlp, session_to_otlp_genai
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_meta(agent_name: str = "claude-code") -> SessionMeta:
+    meta = SessionMeta(agent_name=agent_name)
+    meta.started_at = time.time() - 60
+    meta.ended_at = time.time()
+    return meta
+
+
+def _make_event(event_type: EventType, **data) -> TraceEvent:
+    return TraceEvent(event_type=event_type, data=data)
+
+
+def _get_spans(payload: dict) -> list[dict]:
+    return payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
+
+
+def _get_attr(span: dict, key: str):
+    for attr in span.get("attributes", []):
+        if attr["key"] == key:
+            v = attr["value"]
+            return (
+                v.get("stringValue")
+                or v.get("intValue")
+                or v.get("doubleValue")
+                or v.get("boolValue")
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Root span attributes
+# ---------------------------------------------------------------------------
+
+class TestGenAIRootSpan(unittest.TestCase):
+    def test_root_span_has_gen_ai_agent_id(self):
+        meta = _make_meta()
+        payload = session_to_otlp_genai(meta, [])
+        spans = _get_spans(payload)
+        root = spans[0]
+        self.assertEqual(_get_attr(root, "gen_ai.agent.id"), meta.session_id)
+
+    def test_root_span_has_gen_ai_agent_name(self):
+        meta = _make_meta("my-agent")
+        payload = session_to_otlp_genai(meta, [])
+        spans = _get_spans(payload)
+        root = spans[0]
+        self.assertEqual(_get_attr(root, "gen_ai.agent.name"), "my-agent")
+
+    def test_root_span_has_gen_ai_system(self):
+        meta = _make_meta("claude-code")
+        payload = session_to_otlp_genai(meta, [])
+        spans = _get_spans(payload)
+        root = spans[0]
+        self.assertEqual(_get_attr(root, "gen_ai.system"), "anthropic")
+
+    def test_root_span_name_contains_agent_session(self):
+        meta = _make_meta()
+        payload = session_to_otlp_genai(meta, [])
+        spans = _get_spans(payload)
+        self.assertIn("gen_ai.agent.session", spans[0]["name"])
+
+    def test_scope_name_includes_semconv_version(self):
+        meta = _make_meta()
+        payload = session_to_otlp_genai(meta, [])
+        scope = payload["resourceSpans"][0]["scopeSpans"][0]["scope"]
+        self.assertIn("genai-semconv", scope.get("version", ""))
+
+
+# ---------------------------------------------------------------------------
+# LLM request/response → gen_ai.client.operation child span
+# ---------------------------------------------------------------------------
+
+class TestGenAILLMSpan(unittest.TestCase):
+    def _make_llm_pair(self, model: str = "claude-3-5-sonnet") -> list[TraceEvent]:
+        req = TraceEvent(
+            event_type=EventType.LLM_REQUEST,
+            data={"model": model, "input_tokens": 100, "max_tokens": 4096},
+        )
+        resp = TraceEvent(
+            event_type=EventType.LLM_RESPONSE,
+            parent_id=req.event_id,
+            data={"model": model, "output_tokens": 50, "stop_reason": "end_turn"},
+        )
+        return [req, resp]
+
+    def test_llm_pair_produces_child_span(self):
+        meta = _make_meta()
+        events = self._make_llm_pair()
+        payload = session_to_otlp_genai(meta, events)
+        spans = _get_spans(payload)
+        # root + 1 LLM span
+        self.assertEqual(len(spans), 2)
+        llm_span = spans[1]
+        self.assertEqual(llm_span["name"], "gen_ai.client.operation")
+
+    def test_llm_span_has_model_attribute(self):
+        meta = _make_meta()
+        events = self._make_llm_pair("claude-3-5-sonnet")
+        payload = session_to_otlp_genai(meta, events)
+        llm_span = _get_spans(payload)[1]
+        self.assertEqual(_get_attr(llm_span, "gen_ai.request.model"), "claude-3-5-sonnet")
+
+    def test_llm_span_has_token_attributes(self):
+        meta = _make_meta()
+        events = self._make_llm_pair()
+        payload = session_to_otlp_genai(meta, events)
+        llm_span = _get_spans(payload)[1]
+        self.assertIsNotNone(_get_attr(llm_span, "gen_ai.usage.input_tokens"))
+        self.assertIsNotNone(_get_attr(llm_span, "gen_ai.usage.output_tokens"))
+
+    def test_llm_span_has_finish_reason(self):
+        meta = _make_meta()
+        events = self._make_llm_pair()
+        payload = session_to_otlp_genai(meta, events)
+        llm_span = _get_spans(payload)[1]
+        self.assertEqual(_get_attr(llm_span, "gen_ai.response.finish_reasons"), "end_turn")
+
+    def test_llm_span_parented_to_root(self):
+        meta = _make_meta()
+        events = self._make_llm_pair()
+        payload = session_to_otlp_genai(meta, events)
+        spans = _get_spans(payload)
+        root_id = spans[0]["spanId"]
+        llm_span = spans[1]
+        self.assertEqual(llm_span["parentSpanId"], root_id)
+
+    def test_gen_ai_system_derived_from_model(self):
+        meta = _make_meta("unknown-agent")
+        req = TraceEvent(event_type=EventType.LLM_REQUEST, data={"model": "gpt-4o"})
+        resp = TraceEvent(
+            event_type=EventType.LLM_RESPONSE,
+            parent_id=req.event_id,
+            data={"model": "gpt-4o", "output_tokens": 10},
+        )
+        payload = session_to_otlp_genai(meta, [req, resp])
+        llm_span = _get_spans(payload)[1]
+        self.assertEqual(_get_attr(llm_span, "gen_ai.system"), "openai")
+
+
+# ---------------------------------------------------------------------------
+# Tool call/result → gen_ai.tool.call/<name> child span
+# ---------------------------------------------------------------------------
+
+class TestGenAIToolSpan(unittest.TestCase):
+    def _make_tool_pair(self, tool_name: str = "Bash") -> list[TraceEvent]:
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": tool_name, "arguments": {"command": "ls -la"}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            parent_id=call.event_id,
+            duration_ms=50.0,
+            data={"tool_name": tool_name, "result": "file1.py\nfile2.py"},
+        )
+        return [call, result]
+
+    def test_tool_pair_produces_child_span(self):
+        meta = _make_meta()
+        events = self._make_tool_pair()
+        payload = session_to_otlp_genai(meta, events)
+        spans = _get_spans(payload)
+        self.assertEqual(len(spans), 2)
+        tool_span = spans[1]
+        self.assertIn("gen_ai.tool.call", tool_span["name"])
+        self.assertIn("Bash", tool_span["name"])
+
+    def test_tool_span_has_gen_ai_tool_name(self):
+        meta = _make_meta()
+        events = self._make_tool_pair("Bash")
+        payload = session_to_otlp_genai(meta, events)
+        tool_span = _get_spans(payload)[1]
+        self.assertEqual(_get_attr(tool_span, "gen_ai.tool.name"), "Bash")
+
+    def test_tool_span_has_call_id(self):
+        meta = _make_meta()
+        events = self._make_tool_pair()
+        payload = session_to_otlp_genai(meta, events)
+        tool_span = _get_spans(payload)[1]
+        self.assertIsNotNone(_get_attr(tool_span, "gen_ai.tool.call.id"))
+
+    def test_tool_span_has_input_attributes(self):
+        meta = _make_meta()
+        events = self._make_tool_pair()
+        payload = session_to_otlp_genai(meta, events)
+        tool_span = _get_spans(payload)[1]
+        self.assertIsNotNone(_get_attr(tool_span, "gen_ai.tool.input.command"))
+
+    def test_tool_span_has_output(self):
+        meta = _make_meta()
+        events = self._make_tool_pair()
+        payload = session_to_otlp_genai(meta, events)
+        tool_span = _get_spans(payload)[1]
+        self.assertIsNotNone(_get_attr(tool_span, "gen_ai.tool.output"))
+
+
+# ---------------------------------------------------------------------------
+# Error events → exception event format
+# ---------------------------------------------------------------------------
+
+class TestGenAIErrorSpan(unittest.TestCase):
+    def test_error_produces_exception_event(self):
+        meta = _make_meta()
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "Bash", "arguments": {"command": "bad-cmd"}},
+        )
+        error = TraceEvent(
+            event_type=EventType.ERROR,
+            parent_id=call.event_id,
+            data={"tool_name": "Bash", "error": "command not found", "error_type": "ShellError"},
+        )
+        payload = session_to_otlp_genai(meta, [call, error])
+        spans = _get_spans(payload)
+        error_span = spans[1]
+        # Should have an exception event
+        events = error_span.get("events", [])
+        self.assertTrue(any(e["name"] == "exception" for e in events))
+
+    def test_error_span_has_error_status(self):
+        meta = _make_meta()
+        error = TraceEvent(
+            event_type=EventType.ERROR,
+            data={"tool_name": "Bash", "error": "fail"},
+        )
+        payload = session_to_otlp_genai(meta, [error])
+        spans = _get_spans(payload)
+        error_span = spans[1]
+        self.assertEqual(error_span["status"]["code"], 2)  # STATUS_CODE_ERROR
+
+    def test_exception_event_has_message(self):
+        meta = _make_meta()
+        error = TraceEvent(
+            event_type=EventType.ERROR,
+            data={"error": "something went wrong"},
+        )
+        payload = session_to_otlp_genai(meta, [error])
+        spans = _get_spans(payload)
+        error_span = spans[1]
+        exc_events = [e for e in error_span.get("events", []) if e["name"] == "exception"]
+        self.assertTrue(exc_events)
+        exc_attrs = {a["key"]: a["value"] for a in exc_events[0].get("attributes", [])}
+        self.assertIn("exception.message", exc_attrs)
+
+
+# ---------------------------------------------------------------------------
+# User prompt / assistant response → events on root span
+# ---------------------------------------------------------------------------
+
+class TestGenAIMessageEvents(unittest.TestCase):
+    def test_user_prompt_becomes_root_event(self):
+        meta = _make_meta()
+        ev = TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            data={"prompt": "Hello agent"},
+        )
+        payload = session_to_otlp_genai(meta, [ev])
+        root = _get_spans(payload)[0]
+        event_names = [e["name"] for e in root.get("events", [])]
+        self.assertIn("gen_ai.user.message", event_names)
+
+    def test_assistant_response_becomes_root_event(self):
+        meta = _make_meta()
+        ev = TraceEvent(
+            event_type=EventType.ASSISTANT_RESPONSE,
+            data={"text": "I will help you."},
+        )
+        payload = session_to_otlp_genai(meta, [ev])
+        root = _get_spans(payload)[0]
+        event_names = [e["name"] for e in root.get("events", [])]
+        self.assertIn("gen_ai.assistant.message", event_names)
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: --format otlp unchanged
+# ---------------------------------------------------------------------------
+
+class TestOTLPBackwardsCompat(unittest.TestCase):
+    def test_legacy_otlp_unchanged(self):
+        """session_to_otlp() output must not change."""
+        meta = _make_meta()
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "Bash", "arguments": {"command": "ls"}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            parent_id=call.event_id,
+            data={"tool_name": "Bash", "result": "ok"},
+        )
+        payload = session_to_otlp(meta, [call, result])
+        spans = _get_spans(payload)
+        # Legacy: tool spans use plain tool name, not gen_ai.tool.call/<name>
+        tool_span = spans[1]
+        self.assertNotIn("gen_ai.tool.call", tool_span["name"])
+
+    def test_genai_and_legacy_produce_different_span_names(self):
+        meta = _make_meta()
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={"tool_name": "Bash", "arguments": {"command": "ls"}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            parent_id=call.event_id,
+            data={"tool_name": "Bash", "result": "ok"},
+        )
+        legacy = session_to_otlp(meta, [call, result])
+        genai = session_to_otlp_genai(meta, [call, result])
+        legacy_names = {s["name"] for s in _get_spans(legacy)}
+        genai_names = {s["name"] for s in _get_spans(genai)}
+        self.assertNotEqual(legacy_names, genai_names)
+
+
+# ---------------------------------------------------------------------------
+# CLI: --format otlp-genai registered
+# ---------------------------------------------------------------------------
+
+class TestOTLPGenAICLIFlag(unittest.TestCase):
+    def test_otlp_genai_in_format_choices(self):
+        import sys, io
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "export", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("otlp-genai", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `--format otlp-genai` to `agent-strace export`, producing spans that conform to the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Traces exported with this format populate AI-native dashboards in Datadog, Grafana, and Honeycomb automatically.

### Changes

- `--format otlp-genai` on `agent-strace export` — strict GenAI conventions mapping
- LLM request/response pairs → `gen_ai.client.operation` child spans with `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`
- Tool calls → `gen_ai.tool.call/<name>` spans with `gen_ai.tool.name`, `gen_ai.tool.call.id`
- Root span carries `gen_ai.agent.id` and `gen_ai.agent.name`
- Errors use OTel `exception` event format with `exception.type` and `exception.message`
- `gen_ai.system` derived from model name (anthropic/openai/google)
- `--format otlp` unchanged — backwards compatible
- ADR-0011 documenting the mapping decisions
- 24 new tests in `tests/test_otlp_genai.py`

### Example

```bash
agent-strace export abc123 --format otlp-genai \
  --endpoint https://api.honeycomb.io \
  --header "x-honeycomb-team: $HONEYCOMB_API_KEY"
```

Closes #100