### PR TITLE
feat(server): add server-side event collector

### DIFF
--- a/ADRs/0012-server-side-event-collector.md
+++ b/ADRs/0012-server-side-event-collector.md
@@ -1,0 +1,59 @@
+# ADR-0012: Server-Side Event Collector
+
+**Status:** Accepted  
+**Date:** 2026-05  
+**Deciders:** Siddhant Khare
+
+## Context
+
+agent-strace writes traces to the local filesystem. This works for a single
+developer on a single machine but breaks for:
+
+- Agents running in containers or serverless functions (no persistent local disk)
+- CI pipelines where each run is ephemeral
+- Multi-agent systems where traces from parallel agents need to be correlated
+- Teams where the person running the agent is not the person reading the traces
+
+## Decision
+
+Add `agent-strace server` — a lightweight HTTP collector that receives events
+from remote agents and stores them in the same `.agent-traces/` format as local
+mode. Agents opt in by setting `AGENT_STRACE_ENDPOINT`.
+
+### Transport
+
+HTTP/JSON only (per ADR-0006). No gRPC, no WebSockets, no message queues.
+
+### API
+
+| Method | Path | Description |
+|---|---|---|
+| POST | /events | Receive a batch of NDJSON events |
+| POST | /sessions | Create or update session metadata |
+| GET | /sessions | List all sessions |
+| GET | /sessions/\<id\>/events | Stream events for a session (NDJSON) |
+| GET | /health | Liveness check |
+
+### Storage
+
+The server writes `.agent-traces/<session-id>/` directories identical to local
+traces. All existing CLI commands work against server storage without modification.
+
+### No authentication in v1
+
+Intended for internal/private network use. Authentication can be added via a
+reverse proxy (nginx, Caddy). This is documented explicitly.
+
+### Implementation
+
+Uses Python stdlib `http.server` — no new runtime dependencies (ADR-0003).
+Thread safety via a single `threading.Lock` around all store writes.
+
+## Consequences
+
+- Agents in containers, CI, and serverless can now send traces to a central
+  collector without any code changes — just set `AGENT_STRACE_ENDPOINT`.
+- The server is single-process and not horizontally scalable in v1. This is
+  acceptable for team-scale use (< 100 concurrent agents).
+- No authentication means the server must not be exposed to the public internet.
+  This is documented in the README.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ agent-strace retention status                   Show session count, size, and wh
 agent-strace retention clean [--dry-run]        Delete sessions that exceed retention limits
 agent-strace sample --strategy worst --n 20     Export worst/diverse/random/recent sessions as JSONL
 agent-strace export <session> --format otlp-genai  Export with OTel GenAI semantic conventions
+agent-strace server [--port 4317] [--storage DIR]  Start a server-side event collector
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report
@@ -1220,6 +1221,43 @@ agent-strace scope: all tool calls logged, secrets redacted, exported to Grafana
 Any attempt by the agent to read `cvm/attestation-service/` or `cvm/auth-service/` is blocked at the authorization layer before it reaches the filesystem. agent-strace logs the denied attempt with the reason.
 
 ---
+
+## Server-side event collector
+
+Run a central collector so agents in containers, CI, and serverless functions can send traces over the network — no local disk required.
+
+```bash
+# Start the collector
+agent-strace server --port 4317 --storage ./traces
+
+# Agents point to it via environment variable — no code changes required
+AGENT_STRACE_ENDPOINT=http://collector:4317 python my_agent.py
+```
+
+The server writes traces in the same `.agent-traces/` format as local mode. All existing CLI commands work against its storage.
+
+### API
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/events` | Receive a batch of NDJSON events |
+| `POST` | `/sessions` | Create or update session metadata |
+| `GET` | `/sessions` | List all sessions |
+| `GET` | `/sessions/<id>/events` | Stream events for a session |
+| `GET` | `/health` | Liveness check |
+
+### Docker
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install agent-strace
+ENV AGENT_STRACE_STORAGE=/data
+VOLUME /data
+EXPOSE 4317
+CMD ["agent-strace", "server", "--port", "4317"]
+```
+
+No authentication in v1 — intended for internal/private network use. Add a reverse proxy (nginx, Caddy) for auth.
 
 ## Production tracing (OTLP export)
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -48,6 +48,7 @@ from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
 from .retention import cmd_retention
 from .sample import cmd_sample
+from .server import cmd_server
 from .watch import cmd_watch
 from .why import cmd_why
 from .models import EventType, SessionMeta, TraceEvent
@@ -818,6 +819,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="transport protocol (default: stdio)",
     )
 
+    # server (event collector)
+    p_server = sub.add_parser(
+        "server",
+        help="start a server-side event collector (receives events from remote agents)",
+    )
+    p_server.add_argument("--port", type=int, default=4317,
+                          help="port to listen on (default: 4317)")
+    p_server.add_argument("--host", default="0.0.0.0",
+                          help="host to bind to (default: 0.0.0.0)")
+    p_server.add_argument("--storage", metavar="DIR",
+                          help="storage directory for traces "
+                               "(default: $AGENT_STRACE_STORAGE or .agent-traces)")
+
     # sample
     p_sample = sub.add_parser(
         "sample",
@@ -918,6 +932,7 @@ def main() -> None:
         "mcp": cmd_mcp,
         "retention": cmd_retention,
         "sample": cmd_sample,
+        "server": cmd_server,
     }
 
     handler = handlers.get(args.command)

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -63,6 +63,21 @@ def _get_store() -> TraceStore:
     return TraceStore(_get_store_dir())
 
 
+def _get_remote_endpoint() -> str:
+    """Return AGENT_STRACE_ENDPOINT if set, else empty string."""
+    return os.environ.get("AGENT_STRACE_ENDPOINT", "").rstrip("/")
+
+
+def _write_event(store: TraceStore, session_id: str, event: TraceEvent) -> None:
+    """Write an event to local store or remote collector, depending on env."""
+    endpoint = _get_remote_endpoint()
+    if endpoint:
+        from .server import send_event_to_endpoint
+        send_event_to_endpoint(event, endpoint)
+    else:
+        store.append_event(session_id, event)
+
+
 def _active_session_path() -> Path:
     return Path(_get_store_dir()) / ".active-session"
 
@@ -149,7 +164,7 @@ def handle_session_start(input_data: dict) -> None:
     if redact:
         event_data = redact_data(event_data)
 
-    store.append_event(
+    _write_event(store, 
         meta.session_id,
         TraceEvent(
             event_type=EventType.SESSION_START,
@@ -171,7 +186,7 @@ def handle_session_end(input_data: dict) -> None:
         meta.ended_at = time.time()
         meta.total_duration_ms = (meta.ended_at - meta.started_at) * 1000
 
-        store.append_event(
+        _write_event(store, 
             session_id,
             TraceEvent(
                 event_type=EventType.SESSION_END,
@@ -207,7 +222,7 @@ def handle_pre_tool(input_data: dict) -> None:
         session_id=session_id,
         data=event_data,
     )
-    store.append_event(session_id, event)
+    _write_event(store, session_id, event)
 
     # Update meta
     meta = store.load_meta(session_id)
@@ -238,7 +253,7 @@ def handle_user_prompt(input_data: dict) -> None:
     if redact:
         event_data = redact_data(event_data)
 
-    store.append_event(
+    _write_event(store, 
         session_id,
         TraceEvent(
             event_type=EventType.USER_PROMPT,
@@ -269,7 +284,7 @@ def handle_stop(input_data: dict) -> None:
     if redact:
         event_data = redact_data(event_data)
 
-    store.append_event(
+    _write_event(store, 
         session_id,
         TraceEvent(
             event_type=EventType.ASSISTANT_RESPONSE,
@@ -325,7 +340,7 @@ def handle_post_tool(input_data: dict, failed: bool = False) -> None:
         event.duration_ms = (event.timestamp - call_info["timestamp"]) * 1000
         _write_pending_calls(pending)
 
-    store.append_event(session_id, event)
+    _write_event(store, session_id, event)
 
     # Update meta on errors
     if failed:

--- a/src/agent_trace/server.py
+++ b/src/agent_trace/server.py
@@ -1,0 +1,299 @@
+"""Server-side event collector.
+
+A lightweight HTTP server that receives events from remote agents and stores
+them in the same .agent-traces/ format as local mode. Zero new dependencies —
+uses Python stdlib http.server only.
+
+API:
+    POST /events              Receive a batch of NDJSON events
+    POST /sessions            Create or update session metadata
+    GET  /sessions            List all sessions (JSON array)
+    GET  /sessions/<id>/events  Stream events for a session (NDJSON)
+    GET  /health              Liveness check
+
+Usage:
+    agent-strace server --port 4317 --storage ./traces
+
+Agents point to it via environment variable:
+    AGENT_STRACE_ENDPOINT=http://collector:4317 python my_agent.py
+
+No authentication in v1 — intended for internal/private network use.
+Add a reverse proxy (nginx, Caddy) for auth.
+
+See ADR-0012 for architecture decisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from .models import SessionMeta, TraceEvent
+from .store import TraceStore, DEFAULT_TRACE_DIR
+
+
+# ---------------------------------------------------------------------------
+# Remote event sender (used by hooks when AGENT_STRACE_ENDPOINT is set)
+# ---------------------------------------------------------------------------
+
+def send_event_to_endpoint(event: TraceEvent, endpoint: str) -> bool:
+    """POST a single event to a remote collector.
+
+    Returns True on success. Failures are logged to stderr but never raise —
+    the hook must not block the agent.
+    """
+    import urllib.request
+    import urllib.error
+
+    url = endpoint.rstrip("/") + "/events"
+    body = (event.to_json() + "\n").encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/x-ndjson"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status in (200, 202)
+    except Exception as exc:
+        sys.stderr.write(f"[agent-strace] remote send failed: {exc}\n")
+        return False
+
+
+def send_session_meta_to_endpoint(meta: SessionMeta, endpoint: str) -> bool:
+    """POST session metadata to a remote collector."""
+    import urllib.request
+    import urllib.error
+
+    url = endpoint.rstrip("/") + "/sessions"
+    body = meta.to_json().encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status in (200, 202)
+    except Exception as exc:
+        sys.stderr.write(f"[agent-strace] remote session meta send failed: {exc}\n")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# HTTP request handler
+# ---------------------------------------------------------------------------
+
+class CollectorHandler(BaseHTTPRequestHandler):
+    """HTTP handler for the event collector server."""
+
+    # Injected by the server setup
+    store: TraceStore
+    _lock: threading.Lock
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Suppress default access log; write to stderr with our prefix
+        sys.stderr.write(f"[server] {fmt % args}\n")
+
+    def _send_json(self, status: int, data: dict) -> None:
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_ndjson(self, status: int, lines: list[str]) -> None:
+        body = "\n".join(lines).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/x-ndjson")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            return self.rfile.read(length)
+        return b""
+
+    # ------------------------------------------------------------------
+    # GET
+    # ------------------------------------------------------------------
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path.rstrip("/")
+
+        if path == "/health":
+            self._send_json(200, {"status": "ok", "sessions": len(self.store.list_sessions())})
+            return
+
+        if path == "/sessions":
+            sessions = self.store.list_sessions()
+            data = [json.loads(m.to_json()) for m in sessions]
+            self._send_json(200, data)
+            return
+
+        # /sessions/<id>/events
+        parts = path.split("/")
+        if len(parts) == 4 and parts[1] == "sessions" and parts[3] == "events":
+            session_id = parts[2]
+            if not self.store.session_exists(session_id):
+                found = self.store.find_session(session_id)
+                if found:
+                    session_id = found
+                else:
+                    self._send_json(404, {"error": f"session not found: {session_id}"})
+                    return
+            events = self.store.load_events(session_id)
+            self._send_ndjson(200, [e.to_json() for e in events])
+            return
+
+        # /sessions/<id>
+        if len(parts) == 3 and parts[1] == "sessions":
+            session_id = parts[2]
+            if not self.store.session_exists(session_id):
+                found = self.store.find_session(session_id)
+                if found:
+                    session_id = found
+                else:
+                    self._send_json(404, {"error": f"session not found: {session_id}"})
+                    return
+            meta = self.store.load_meta(session_id)
+            self._send_json(200, json.loads(meta.to_json()))
+            return
+
+        self._send_json(404, {"error": "not found"})
+
+    # ------------------------------------------------------------------
+    # POST
+    # ------------------------------------------------------------------
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path.rstrip("/")
+        body = self._read_body()
+
+        if path == "/events":
+            self._handle_post_events(body)
+            return
+
+        if path == "/sessions":
+            self._handle_post_sessions(body)
+            return
+
+        self._send_json(404, {"error": "not found"})
+
+    def _handle_post_events(self, body: bytes) -> None:
+        """Accept a batch of NDJSON events."""
+        accepted = 0
+        errors = 0
+        for line in body.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = TraceEvent.from_json(line)
+                session_id = event.session_id
+                if not session_id:
+                    errors += 1
+                    continue
+                with self._lock:
+                    # Auto-create session if it doesn't exist
+                    if not self.store.session_exists(session_id):
+                        meta = SessionMeta()
+                        meta.session_id = session_id
+                        self.store.create_session(meta)
+                    self.store.append_event(session_id, event)
+                accepted += 1
+            except Exception as exc:
+                sys.stderr.write(f"[server] event parse error: {exc}\n")
+                errors += 1
+
+        status = 200 if errors == 0 else 202
+        self._send_json(status, {"accepted": accepted, "errors": errors})
+
+    def _handle_post_sessions(self, body: bytes) -> None:
+        """Create or update session metadata."""
+        try:
+            data = json.loads(body.decode("utf-8"))
+            session_id = data.get("session_id", "")
+            if not session_id:
+                self._send_json(400, {"error": "session_id required"})
+                return
+
+            with self._lock:
+                if self.store.session_exists(session_id):
+                    # Update existing meta
+                    meta = self.store.load_meta(session_id)
+                    for k, v in data.items():
+                        if hasattr(meta, k):
+                            setattr(meta, k, v)
+                    self.store.update_meta(meta)
+                else:
+                    meta = SessionMeta.from_json(body.decode("utf-8"))
+                    self.store.create_session(meta)
+
+            self._send_json(200, {"session_id": session_id, "status": "ok"})
+        except Exception as exc:
+            self._send_json(400, {"error": str(exc)})
+
+
+def _make_handler(store: TraceStore, lock: threading.Lock) -> type:
+    """Return a CollectorHandler subclass with store and lock injected."""
+    class Handler(CollectorHandler):
+        pass
+    Handler.store = store
+    Handler._lock = lock
+    return Handler
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+def run_server(
+    port: int,
+    storage_dir: str,
+    host: str = "0.0.0.0",
+) -> None:
+    """Start the collector server and block until interrupted."""
+    store = TraceStore(storage_dir)
+    lock = threading.Lock()
+    handler_class = _make_handler(store, lock)
+
+    server = HTTPServer((host, port), handler_class)
+    sys.stderr.write(
+        f"[agent-strace server] listening on {host}:{port}\n"
+        f"[agent-strace server] storage: {Path(storage_dir).resolve()}\n"
+        f"[agent-strace server] health: http://{host}:{port}/health\n"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("\n[agent-strace server] shutting down\n")
+    finally:
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_server(args: argparse.Namespace) -> int:
+    port = getattr(args, "port", 4317)
+    storage = getattr(args, "storage", None) or os.environ.get(
+        "AGENT_STRACE_STORAGE", DEFAULT_TRACE_DIR
+    )
+    host = getattr(args, "host", "0.0.0.0")
+    run_server(port=port, storage_dir=storage, host=host)
+    return 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,306 @@
+"""Tests for the server-side event collector (issue #101)."""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.server import (
+    CollectorHandler,
+    _make_handler,
+    send_event_to_endpoint,
+    send_session_meta_to_endpoint,
+)
+from agent_trace.store import TraceStore
+from http.server import HTTPServer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmpdir = tempfile.mkdtemp()
+    return TraceStore(tmpdir), tmpdir
+
+
+def _start_test_server(store: TraceStore) -> tuple[HTTPServer, int, threading.Thread]:
+    """Start a test server on a random port. Returns (server, port, thread)."""
+    lock = threading.Lock()
+    handler = _make_handler(store, lock)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, port, thread
+
+
+def _get(url: str) -> tuple[int, bytes]:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _post(url: str, body: bytes, content_type: str = "application/json") -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        url, data=body,
+        headers={"Content-Type": content_type},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint
+# ---------------------------------------------------------------------------
+
+class TestHealthEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_health_returns_200(self):
+        status, body = _get(f"{self.base}/health")
+        self.assertEqual(status, 200)
+
+    def test_health_returns_ok(self):
+        status, body = _get(f"{self.base}/health")
+        data = json.loads(body)
+        self.assertEqual(data["status"], "ok")
+
+    def test_health_includes_session_count(self):
+        status, body = _get(f"{self.base}/health")
+        data = json.loads(body)
+        self.assertIn("sessions", data)
+
+
+# ---------------------------------------------------------------------------
+# POST /events
+# ---------------------------------------------------------------------------
+
+class TestPostEvents(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def _make_event_ndjson(self, session_id: str, n: int = 1) -> bytes:
+        lines = []
+        for i in range(n):
+            ev = TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                session_id=session_id,
+                data={"tool_name": "Bash", "arguments": {"command": f"echo {i}"}},
+            )
+            lines.append(ev.to_json())
+        return "\n".join(lines).encode("utf-8")
+
+    def test_post_events_returns_200(self):
+        sid = "test-session-001"
+        body = self._make_event_ndjson(sid, 2)
+        status, resp = _post(f"{self.base}/events", body, "application/x-ndjson")
+        self.assertIn(status, (200, 202))
+
+    def test_post_events_accepted_count(self):
+        sid = "test-session-002"
+        body = self._make_event_ndjson(sid, 3)
+        status, resp = _post(f"{self.base}/events", body, "application/x-ndjson")
+        data = json.loads(resp)
+        self.assertEqual(data["accepted"], 3)
+
+    def test_post_events_stored_on_disk(self):
+        sid = "test-session-003"
+        body = self._make_event_ndjson(sid, 2)
+        _post(f"{self.base}/events", body, "application/x-ndjson")
+        time.sleep(0.05)
+        events = self.store.load_events(sid)
+        self.assertEqual(len(events), 2)
+
+    def test_post_events_auto_creates_session(self):
+        sid = "auto-created-session"
+        body = self._make_event_ndjson(sid, 1)
+        _post(f"{self.base}/events", body, "application/x-ndjson")
+        time.sleep(0.05)
+        self.assertTrue(self.store.session_exists(sid))
+
+    def test_post_events_empty_body_returns_200(self):
+        status, resp = _post(f"{self.base}/events", b"", "application/x-ndjson")
+        self.assertIn(status, (200, 202))
+
+    def test_post_events_invalid_json_counted_as_error(self):
+        body = b"not valid json\n"
+        status, resp = _post(f"{self.base}/events", body, "application/x-ndjson")
+        data = json.loads(resp)
+        self.assertGreater(data["errors"], 0)
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions
+# ---------------------------------------------------------------------------
+
+class TestPostSessions(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_post_session_creates_session(self):
+        meta = SessionMeta(agent_name="test-agent")
+        body = meta.to_json().encode("utf-8")
+        status, resp = _post(f"{self.base}/sessions", body)
+        self.assertEqual(status, 200)
+        time.sleep(0.05)
+        self.assertTrue(self.store.session_exists(meta.session_id))
+
+    def test_post_session_missing_session_id_returns_400(self):
+        body = json.dumps({"agent_name": "test"}).encode("utf-8")
+        status, resp = _post(f"{self.base}/sessions", body)
+        self.assertEqual(status, 400)
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions
+# ---------------------------------------------------------------------------
+
+class TestGetSessions(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_get_sessions_empty(self):
+        status, body = _get(f"{self.base}/sessions")
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertEqual(data, [])
+
+    def test_get_sessions_returns_created_sessions(self):
+        meta = SessionMeta(agent_name="agent-a")
+        self.store.create_session(meta)
+        status, body = _get(f"{self.base}/sessions")
+        data = json.loads(body)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["session_id"], meta.session_id)
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/<id>/events
+# ---------------------------------------------------------------------------
+
+class TestGetSessionEvents(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_get_events_returns_ndjson(self):
+        meta = SessionMeta()
+        self.store.create_session(meta)
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={"tool_name": "Bash"},
+        )
+        self.store.append_event(meta.session_id, ev)
+        status, body = _get(f"{self.base}/sessions/{meta.session_id}/events")
+        self.assertEqual(status, 200)
+        lines = body.decode("utf-8").strip().splitlines()
+        self.assertEqual(len(lines), 1)
+        parsed = json.loads(lines[0])
+        self.assertEqual(parsed["event_type"], "tool_call")
+
+    def test_get_events_unknown_session_returns_404(self):
+        status, body = _get(f"{self.base}/sessions/nonexistent/events")
+        self.assertEqual(status, 404)
+
+
+# ---------------------------------------------------------------------------
+# send_event_to_endpoint helper
+# ---------------------------------------------------------------------------
+
+class TestSendEventToEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.store, _ = _make_store()
+        self.server, self.port, _ = _start_test_server(self.store)
+        self.endpoint = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_send_event_returns_true_on_success(self):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id="remote-session-1",
+            data={"tool_name": "Bash"},
+        )
+        result = send_event_to_endpoint(ev, self.endpoint)
+        self.assertTrue(result)
+
+    def test_send_event_to_bad_endpoint_returns_false(self):
+        ev = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id="x",
+            data={},
+        )
+        result = send_event_to_endpoint(ev, "http://127.0.0.1:1")
+        self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+class TestServerCLIRegistered(unittest.TestCase):
+    def test_server_in_help(self):
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("server", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `agent-strace server` — a lightweight HTTP collector that receives events from remote agents and stores them in the same `.agent-traces/` format as local mode. Agents in containers, CI, and serverless functions can now send traces over the network without any code changes.

### Changes

- `agent-strace server --port 4317 --storage ./traces` — start the collector
- `AGENT_STRACE_ENDPOINT=http://collector:4317` — agents opt in via env var (no code changes)
- HTTP API: `POST /events`, `POST /sessions`, `GET /sessions`, `GET /sessions/<id>/events`, `GET /health`
- Hooks module routes events to remote endpoint when `AGENT_STRACE_ENDPOINT` is set
- No new dependencies — uses stdlib `http.server`; thread-safe via a single lock
- ADR-0012 documenting the architecture decisions
- 18 new tests in `tests/test_server.py`

### Example

```bash
# Start collector
agent-strace server --port 4317

# Agent in a container
docker run -e AGENT_STRACE_ENDPOINT=http://host:4317 my-agent

# Read traces from the collector's storage
agent-strace replay --trace-dir ./traces
```

Closes #101