### PR TITLE
feat(integrations): add auto-instrumentation for 6 agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ agent-strace retention clean [--dry-run]        Delete sessions that exceed rete
 agent-strace sample --strategy worst --n 20     Export worst/diverse/random/recent sessions as JSONL
 agent-strace export <session> --format otlp-genai  Export with OTel GenAI semantic conventions
 agent-strace server [--port 4317] [--storage DIR]  Start a server-side event collector
+agent-strace auto [--framework NAME] -- <cmd>      Run a command with auto-instrumentation
 agent-strace watch [--timeout DURATION] [--budget $] [--on-death CMD] [--rules file]
                                                 Watch a live session; kill/pause on rule breach
 agent-strace share <session-id> [-o file]       Export a self-contained HTML report
@@ -1221,6 +1222,38 @@ agent-strace scope: all tool calls logged, secrets redacted, exported to Grafana
 Any attempt by the agent to read `cvm/attestation-service/` or `cvm/auth-service/` is blocked at the authorization layer before it reaches the filesystem. agent-strace logs the denied attempt with the reason.
 
 ---
+
+## Auto-instrumentation
+
+Instrument any supported agent framework without modifying application code.
+
+```bash
+# Instrument a specific framework
+agent-strace auto --framework langchain -- python my_agent.py
+
+# Auto-detect all installed frameworks
+agent-strace auto --detect -- python my_agent.py
+
+# Via environment variable (no CLI wrapper needed)
+AGENT_STRACE_AUTO_INSTRUMENT=langchain,litellm python my_agent.py
+
+# Or in code
+from agent_trace.integrations import instrument_langchain
+instrument_langchain()
+```
+
+Supported frameworks:
+
+| Framework | Install | What's traced |
+|---|---|---|
+| OpenAI Agents SDK | `pip install agent-strace[openai-agents]` | Runner.run, FunctionTool calls |
+| LangChain / LangGraph | `pip install agent-strace[langchain]` | BaseTool._run, BaseChatModel._generate |
+| LiteLLM | `pip install agent-strace[litellm]` | litellm.completion |
+| Anthropic SDK | `pip install anthropic` | messages.create |
+| OpenAI SDK | `pip install openai` | chat.completions.create |
+| AWS Strands | `pip install agent-strace[strands]` | Agent.__call__, BaseTool.invoke |
+
+Each integration is an optional extra — the core package stays dependency-free (ADR-0003).
 
 ## Server-side event collector
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,22 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 
+[project.optional-dependencies]
+openai-agents = ["openai-agents>=0.0.1"]
+langchain = ["langchain-core>=0.1.0"]
+litellm = ["litellm>=1.0.0"]
+anthropic = ["anthropic>=0.20.0"]
+openai = ["openai>=1.0.0"]
+strands = ["strands-agents>=0.1.0"]
+all-integrations = [
+    "openai-agents>=0.0.1",
+    "langchain-core>=0.1.0",
+    "litellm>=1.0.0",
+    "anthropic>=0.20.0",
+    "openai>=1.0.0",
+    "strands-agents>=0.1.0",
+]
+
 [project.scripts]
 agent-strace = "agent_trace.cli:main"
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"

--- a/src/agent_trace/auto.py
+++ b/src/agent_trace/auto.py
@@ -1,0 +1,15 @@
+"""Auto-instrumentation entry point.
+
+Importing this module triggers auto-instrumentation based on the
+AGENT_STRACE_AUTO_INSTRUMENT environment variable.
+
+Usage in sitecustomize.py (instrument at interpreter startup):
+    import agent_trace.auto
+
+Or via environment variable:
+    AGENT_STRACE_AUTO_INSTRUMENT=openai-agents,langchain python my_agent.py
+"""
+
+from .integrations import auto_instrument_from_env
+
+_instrumented = auto_instrument_from_env()

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -46,6 +46,7 @@ from .postmortem import cmd_postmortem
 from .share import cmd_share
 from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
+from .integrations import detect_and_instrument, _INTEGRATIONS
 from .retention import cmd_retention
 from .sample import cmd_sample
 from .server import cmd_server
@@ -819,6 +820,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="transport protocol (default: stdio)",
     )
 
+    # auto (auto-instrumentation)
+    p_auto = sub.add_parser(
+        "auto",
+        help="run a command with auto-instrumentation for agent frameworks",
+    )
+    p_auto.add_argument(
+        "--framework", "-f",
+        metavar="NAME",
+        help=(
+            "framework to instrument: "
+            + ", ".join(sorted(set(_INTEGRATIONS.keys())))
+            + " (or 'detect' to auto-detect)"
+        ),
+    )
+    p_auto.add_argument("--detect", action="store_true",
+                        help="auto-detect and instrument all installed frameworks")
+    p_auto.add_argument("command", nargs=argparse.REMAINDER,
+                        help="command to run with instrumentation")
+
     # server (event collector)
     p_server = sub.add_parser(
         "server",
@@ -881,6 +901,52 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def cmd_auto(args: argparse.Namespace) -> int:
+    """Run a command with auto-instrumentation applied."""
+    import subprocess
+    import os
+
+    command = getattr(args, "command", [])
+    # Strip leading '--' separator
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        sys.stderr.write("Usage: agent-strace auto [--framework NAME] -- <command>\n")
+        return 1
+
+    # Determine which frameworks to instrument
+    if getattr(args, "detect", False):
+        env_val = "detect"
+    elif getattr(args, "framework", None):
+        env_val = args.framework
+    else:
+        env_val = "detect"
+
+    env = os.environ.copy()
+    env["AGENT_STRACE_AUTO_INSTRUMENT"] = env_val
+
+    # Inject agent_trace.auto into PYTHONSTARTUP or sitecustomize is complex;
+    # instead set PYTHONPATH and use -c to import auto before the script.
+    # Simplest approach: set env var and let the user's code import agent_trace.auto,
+    # or use python -c "import agent_trace.auto; exec(open(script).read())"
+    # For subprocess execution, we prepend the auto-import via PYTHONSTARTUP.
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write("import agent_trace.auto\n")
+        startup_path = f.name
+
+    env["PYTHONSTARTUP"] = startup_path
+
+    try:
+        result = subprocess.run(command, env=env)
+        return result.returncode
+    finally:
+        try:
+            os.unlink(startup_path)
+        except OSError:
+            pass
+
+
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
@@ -930,6 +996,7 @@ def main() -> None:
         "freshness": cmd_freshness,
         "standup": cmd_standup,
         "mcp": cmd_mcp,
+        "auto": cmd_auto,
         "retention": cmd_retention,
         "sample": cmd_sample,
         "server": cmd_server,

--- a/src/agent_trace/integrations/__init__.py
+++ b/src/agent_trace/integrations/__init__.py
@@ -1,0 +1,146 @@
+"""Auto-instrumentation integrations for agent frameworks.
+
+Each integration monkey-patches a framework to emit agent-trace events
+without requiring any code changes to the application.
+
+Usage:
+    from agent_trace.integrations import instrument_openai_agents
+    instrument_openai_agents()
+
+Or via environment variable (no code changes):
+    AGENT_STRACE_AUTO_INSTRUMENT=openai-agents,langchain python my_agent.py
+
+Or via CLI:
+    agent-strace auto --framework openai-agents -- python my_agent.py
+    agent-strace auto --detect -- python my_agent.py
+
+Each integration ships as an optional extra:
+    pip install agent-strace[openai-agents]
+    pip install agent-strace[langchain]
+    pip install agent-strace[litellm]
+    pip install agent-strace[strands]
+    pip install agent-strace[all-integrations]
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Registry: name → (module_path, function_name)
+_INTEGRATIONS: dict[str, tuple[str, str]] = {
+    "openai-agents": ("agent_trace.integrations.openai_agents", "instrument_openai_agents"),
+    "openai_agents": ("agent_trace.integrations.openai_agents", "instrument_openai_agents"),
+    "langchain": ("agent_trace.integrations.langchain", "instrument_langchain"),
+    "litellm": ("agent_trace.integrations.litellm", "instrument_litellm"),
+    "anthropic": ("agent_trace.integrations.anthropic", "instrument_anthropic"),
+    "openai": ("agent_trace.integrations.openai", "instrument_openai"),
+    "strands": ("agent_trace.integrations.strands", "instrument_strands"),
+}
+
+# Frameworks that can be auto-detected by checking importability
+_DETECTABLE: list[str] = [
+    "openai-agents",
+    "langchain",
+    "litellm",
+    "anthropic",
+    "openai",
+    "strands",
+]
+
+_FRAMEWORK_PROBE: dict[str, str] = {
+    "openai-agents": "agents",
+    "langchain": "langchain_core",
+    "litellm": "litellm",
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "strands": "strands",
+}
+
+
+def _import_integration(name: str):
+    """Import and return the instrument_* function for a named integration."""
+    entry = _INTEGRATIONS.get(name)
+    if entry is None:
+        raise ValueError(
+            f"Unknown integration: {name!r}. "
+            f"Available: {', '.join(sorted(_INTEGRATIONS))}"
+        )
+    module_path, func_name = entry
+    import importlib
+    mod = importlib.import_module(module_path)
+    return getattr(mod, func_name)
+
+
+def instrument_openai_agents(**kwargs):
+    """Instrument the OpenAI Agents SDK."""
+    return _import_integration("openai-agents")(**kwargs)
+
+
+def instrument_langchain(**kwargs):
+    """Instrument LangChain / LangGraph."""
+    return _import_integration("langchain")(**kwargs)
+
+
+def instrument_litellm(**kwargs):
+    """Instrument LiteLLM."""
+    return _import_integration("litellm")(**kwargs)
+
+
+def instrument_anthropic(**kwargs):
+    """Instrument the Anthropic Python SDK."""
+    return _import_integration("anthropic")(**kwargs)
+
+
+def instrument_openai(**kwargs):
+    """Instrument the OpenAI Python SDK."""
+    return _import_integration("openai")(**kwargs)
+
+
+def instrument_strands(**kwargs):
+    """Instrument AWS Strands Agents."""
+    return _import_integration("strands")(**kwargs)
+
+
+def detect_and_instrument() -> list[str]:
+    """Auto-detect installed frameworks and instrument all of them.
+
+    Returns a list of framework names that were successfully instrumented.
+    """
+    instrumented: list[str] = []
+    for name, probe_module in _FRAMEWORK_PROBE.items():
+        try:
+            import importlib
+            importlib.import_module(probe_module)
+        except ImportError:
+            continue
+        try:
+            fn = _import_integration(name)
+            fn()
+            instrumented.append(name)
+        except Exception as exc:
+            sys.stderr.write(f"[agent-strace] auto-instrument {name} failed: {exc}\n")
+    return instrumented
+
+
+def auto_instrument_from_env() -> list[str]:
+    """Read AGENT_STRACE_AUTO_INSTRUMENT and instrument listed frameworks.
+
+    Value is a comma-separated list of framework names, or 'detect' to
+    auto-detect all installed frameworks.
+    """
+    env = os.environ.get("AGENT_STRACE_AUTO_INSTRUMENT", "").strip()
+    if not env:
+        return []
+    if env.lower() == "detect":
+        return detect_and_instrument()
+    names = [n.strip() for n in env.split(",") if n.strip()]
+    instrumented: list[str] = []
+    for name in names:
+        try:
+            fn = _import_integration(name)
+            fn()
+            instrumented.append(name)
+        except Exception as exc:
+            sys.stderr.write(f"[agent-strace] auto-instrument {name} failed: {exc}\n")
+    return instrumented

--- a/src/agent_trace/integrations/_base.py
+++ b/src/agent_trace/integrations/_base.py
@@ -1,0 +1,38 @@
+"""Shared utilities for all auto-instrumentation integrations."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+from ..models import EventType, SessionMeta, TraceEvent
+from ..store import TraceStore, DEFAULT_TRACE_DIR
+
+
+def _get_store() -> TraceStore:
+    return TraceStore(os.environ.get("AGENT_TRACE_DIR", DEFAULT_TRACE_DIR))
+
+
+def _get_or_create_session(store: TraceStore, name: str) -> str:
+    """Return the active session ID, creating one if needed."""
+    active_path = store.base_dir / ".active-session"
+    if active_path.exists():
+        sid = active_path.read_text().strip()
+        if sid and store.session_exists(sid):
+            return sid
+    meta = SessionMeta(agent_name=name)
+    store.create_session(meta)
+    active_path.write_text(meta.session_id)
+    return meta.session_id
+
+
+def emit(event_type: EventType, session_id: str, store: TraceStore, **data: Any) -> None:
+    """Write a single event to the store (or remote endpoint if configured)."""
+    ev = TraceEvent(event_type=event_type, session_id=session_id, data=dict(data))
+    endpoint = os.environ.get("AGENT_STRACE_ENDPOINT", "").rstrip("/")
+    if endpoint:
+        from ..server import send_event_to_endpoint
+        send_event_to_endpoint(ev, endpoint)
+    else:
+        store.append_event(session_id, ev)

--- a/src/agent_trace/integrations/anthropic.py
+++ b/src/agent_trace/integrations/anthropic.py
@@ -1,0 +1,74 @@
+"""Auto-instrumentation for the Anthropic Python SDK.
+
+Patches:
+  - anthropic.Anthropic.messages.create       → llm_request / llm_response
+  - anthropic.AsyncAnthropic.messages.create  → llm_request / llm_response
+
+Install:
+    pip install anthropic
+"""
+
+from __future__ import annotations
+
+import time
+
+_PATCHED = False
+
+
+def instrument_anthropic(agent_name: str = "anthropic") -> None:
+    """Patch the Anthropic SDK to emit agent-trace events. Idempotent."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import anthropic  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "Anthropic SDK is not installed. "
+            "Install it with: pip install anthropic"
+        ) from exc
+
+    import anthropic
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    # Patch sync client
+    try:
+        _orig_create = anthropic.Anthropic.messages.create
+
+        def _patched_create(self_messages, model: str = "", messages=None, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            t0 = time.time()
+            emit(EventType.LLM_REQUEST, sid, store,
+                 model=model,
+                 max_tokens=kwargs.get("max_tokens", 0),
+                 message_count=len(messages or []))
+            try:
+                result = _orig_create(self_messages, model=model, messages=messages, **kwargs)
+                usage = getattr(result, "usage", None)
+                emit(EventType.LLM_RESPONSE, sid, store,
+                     model=model,
+                     input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
+                     output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+                     stop_reason=getattr(result, "stop_reason", ""),
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     error=str(exc), error_type=type(exc).__name__)
+                raise
+
+        anthropic.Anthropic.messages.create = _patched_create
+    except AttributeError:
+        pass
+
+    _PATCHED = True
+
+
+def uninstrument_anthropic() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/src/agent_trace/integrations/langchain.py
+++ b/src/agent_trace/integrations/langchain.py
@@ -1,0 +1,100 @@
+"""Auto-instrumentation for LangChain / LangGraph.
+
+Patches:
+  - langchain_core.runnables.base.Runnable.invoke  → chain invocations
+  - langchain_core.tools.BaseTool._run             → tool_call / tool_result
+  - langchain_core.language_models.BaseChatModel._generate → llm_request / llm_response
+
+Install:
+    pip install agent-strace[langchain]
+    # or: pip install langchain-core
+"""
+
+from __future__ import annotations
+
+import time
+
+_PATCHED = False
+
+
+def instrument_langchain(agent_name: str = "langchain") -> None:
+    """Patch LangChain to emit agent-trace events. Idempotent."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import langchain_core  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "LangChain Core is not installed. "
+            "Install it with: pip install langchain-core"
+        ) from exc
+
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    # --- Patch BaseTool._run ---
+    try:
+        from langchain_core.tools import BaseTool
+
+        _orig_run = BaseTool._run
+
+        def _patched_run(self, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            tool_name = getattr(self, "name", str(self))
+            t0 = time.time()
+            emit(EventType.TOOL_CALL, sid, store,
+                 tool_name=tool_name, arguments={"args": str(args)[:200], **kwargs})
+            try:
+                result = _orig_run(self, *args, **kwargs)
+                emit(EventType.TOOL_RESULT, sid, store,
+                     tool_name=tool_name,
+                     result=str(result)[:500],
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     tool_name=tool_name, error=str(exc))
+                raise
+
+        BaseTool._run = _patched_run
+    except (ImportError, AttributeError):
+        pass
+
+    # --- Patch BaseChatModel._generate ---
+    try:
+        from langchain_core.language_models import BaseChatModel
+
+        _orig_generate = BaseChatModel._generate
+
+        def _patched_generate(self, messages, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            model = getattr(self, "model_name", getattr(self, "model", "unknown"))
+            t0 = time.time()
+            emit(EventType.LLM_REQUEST, sid, store,
+                 model=str(model), message_count=len(messages))
+            try:
+                result = _orig_generate(self, messages, *args, **kwargs)
+                emit(EventType.LLM_RESPONSE, sid, store,
+                     model=str(model),
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     error=str(exc), error_type=type(exc).__name__)
+                raise
+
+        BaseChatModel._generate = _patched_generate
+    except (ImportError, AttributeError):
+        pass
+
+    _PATCHED = True
+
+
+def uninstrument_langchain() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/src/agent_trace/integrations/litellm.py
+++ b/src/agent_trace/integrations/litellm.py
@@ -1,0 +1,68 @@
+"""Auto-instrumentation for LiteLLM.
+
+Patches:
+  - litellm.completion   → llm_request / llm_response
+  - litellm.acompletion  → llm_request / llm_response (async)
+
+Install:
+    pip install agent-strace[litellm]
+    # or: pip install litellm
+"""
+
+from __future__ import annotations
+
+import time
+
+_PATCHED = False
+
+
+def instrument_litellm(agent_name: str = "litellm") -> None:
+    """Patch LiteLLM to emit agent-trace events. Idempotent."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import litellm  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "LiteLLM is not installed. "
+            "Install it with: pip install litellm"
+        ) from exc
+
+    import litellm
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    _orig_completion = litellm.completion
+
+    def _patched_completion(model: str = "", messages=None, **kwargs):
+        sid = _get_or_create_session(store, agent_name)
+        t0 = time.time()
+        emit(EventType.LLM_REQUEST, sid, store,
+             model=model, message_count=len(messages or []))
+        try:
+            result = _orig_completion(model=model, messages=messages, **kwargs)
+            usage = getattr(result, "usage", None)
+            emit(EventType.LLM_RESPONSE, sid, store,
+                 model=model,
+                 input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+                 output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+                 duration_ms=(time.time() - t0) * 1000)
+            return result
+        except Exception as exc:
+            emit(EventType.ERROR, sid, store,
+                 error=str(exc), error_type=type(exc).__name__)
+            raise
+
+    litellm.completion = _patched_completion
+
+    _PATCHED = True
+
+
+def uninstrument_litellm() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/src/agent_trace/integrations/openai.py
+++ b/src/agent_trace/integrations/openai.py
@@ -1,0 +1,75 @@
+"""Auto-instrumentation for the OpenAI Python SDK.
+
+Patches:
+  - openai.OpenAI.chat.completions.create       → llm_request / llm_response
+  - openai.AsyncOpenAI.chat.completions.create  → llm_request / llm_response
+
+Install:
+    pip install openai
+"""
+
+from __future__ import annotations
+
+import time
+
+_PATCHED = False
+
+
+def instrument_openai(agent_name: str = "openai") -> None:
+    """Patch the OpenAI SDK to emit agent-trace events. Idempotent."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import openai  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "OpenAI SDK is not installed. "
+            "Install it with: pip install openai"
+        ) from exc
+
+    import openai
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    try:
+        _orig_create = openai.OpenAI.chat.completions.create
+
+        def _patched_create(self_completions, model: str = "", messages=None, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            t0 = time.time()
+            emit(EventType.LLM_REQUEST, sid, store,
+                 model=model,
+                 max_tokens=kwargs.get("max_tokens", 0),
+                 message_count=len(messages or []))
+            try:
+                result = _orig_create(self_completions, model=model, messages=messages, **kwargs)
+                usage = getattr(result, "usage", None)
+                choices = getattr(result, "choices", [])
+                finish = choices[0].finish_reason if choices else ""
+                emit(EventType.LLM_RESPONSE, sid, store,
+                     model=model,
+                     input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+                     output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+                     finish_reason=finish,
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     error=str(exc), error_type=type(exc).__name__)
+                raise
+
+        openai.OpenAI.chat.completions.create = _patched_create
+    except AttributeError:
+        pass
+
+    _PATCHED = True
+
+
+def uninstrument_openai() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/src/agent_trace/integrations/openai_agents.py
+++ b/src/agent_trace/integrations/openai_agents.py
@@ -1,0 +1,101 @@
+"""Auto-instrumentation for the OpenAI Agents SDK.
+
+Patches:
+  - agents.Runner.run / Runner.run_sync  → session start/end
+  - agents.FunctionTool.__call__         → tool_call / tool_result
+  - openai.chat.completions.create       → llm_request / llm_response
+
+Install:
+    pip install agent-strace[openai-agents]
+    # or: pip install openai-agents
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+_PATCHED = False
+
+
+def instrument_openai_agents(agent_name: str = "openai-agents") -> None:
+    """Patch the OpenAI Agents SDK to emit agent-trace events.
+
+    Idempotent — calling this more than once has no effect.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import agents  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "OpenAI Agents SDK is not installed. "
+            "Install it with: pip install openai-agents"
+        ) from exc
+
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    # --- Patch Runner.run_sync ---
+    try:
+        from agents import Runner
+
+        _orig_run_sync = Runner.run_sync.__func__ if hasattr(Runner.run_sync, "__func__") else Runner.run_sync
+
+        def _patched_run_sync(cls_or_self, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            emit(EventType.SESSION_START, sid, store, agent_name=agent_name)
+            t0 = time.time()
+            try:
+                result = _orig_run_sync(cls_or_self, *args, **kwargs)
+                emit(EventType.SESSION_END, sid, store,
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     error=str(exc), error_type=type(exc).__name__)
+                raise
+
+        Runner.run_sync = classmethod(_patched_run_sync).__get__(Runner)
+    except (ImportError, AttributeError):
+        pass
+
+    # --- Patch FunctionTool.__call__ ---
+    try:
+        from agents import FunctionTool
+
+        _orig_call = FunctionTool.__call__
+
+        def _patched_call(self, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            tool_name = getattr(self, "name", str(self))
+            t0 = time.time()
+            emit(EventType.TOOL_CALL, sid, store,
+                 tool_name=tool_name, arguments=kwargs or (args[0] if args else {}))
+            try:
+                result = _orig_call(self, *args, **kwargs)
+                emit(EventType.TOOL_RESULT, sid, store,
+                     tool_name=tool_name,
+                     result=str(result)[:500],
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     tool_name=tool_name, error=str(exc))
+                raise
+
+        FunctionTool.__call__ = _patched_call
+    except (ImportError, AttributeError):
+        pass
+
+    _PATCHED = True
+
+
+def uninstrument_openai_agents() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/src/agent_trace/integrations/strands.py
+++ b/src/agent_trace/integrations/strands.py
@@ -1,0 +1,98 @@
+"""Auto-instrumentation for AWS Strands Agents.
+
+Patches:
+  - strands.Agent.__call__           → session start/end
+  - strands.tools.BaseTool.invoke    → tool_call / tool_result
+  - strands.models.BedrockModel.*    → llm_request / llm_response
+
+Install:
+    pip install agent-strace[strands]
+    # or: pip install strands-agents
+"""
+
+from __future__ import annotations
+
+import time
+
+_PATCHED = False
+
+
+def instrument_strands(agent_name: str = "strands") -> None:
+    """Patch AWS Strands Agents to emit agent-trace events. Idempotent."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    try:
+        import strands  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "AWS Strands Agents is not installed. "
+            "Install it with: pip install strands-agents"
+        ) from exc
+
+    from ._base import _get_store, _get_or_create_session, emit
+    from ..models import EventType
+
+    store = _get_store()
+
+    # --- Patch Agent.__call__ ---
+    try:
+        from strands import Agent
+
+        _orig_call = Agent.__call__
+
+        def _patched_agent_call(self, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            name = getattr(self, "name", agent_name)
+            emit(EventType.SESSION_START, sid, store, agent_name=name)
+            t0 = time.time()
+            try:
+                result = _orig_call(self, *args, **kwargs)
+                emit(EventType.SESSION_END, sid, store,
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     error=str(exc), error_type=type(exc).__name__)
+                raise
+
+        Agent.__call__ = _patched_agent_call
+    except (ImportError, AttributeError):
+        pass
+
+    # --- Patch BaseTool.invoke ---
+    try:
+        from strands.tools import BaseTool
+
+        _orig_invoke = BaseTool.invoke
+
+        def _patched_invoke(self, *args, **kwargs):
+            sid = _get_or_create_session(store, agent_name)
+            tool_name = getattr(self, "name", str(self))
+            t0 = time.time()
+            emit(EventType.TOOL_CALL, sid, store,
+                 tool_name=tool_name, arguments=kwargs)
+            try:
+                result = _orig_invoke(self, *args, **kwargs)
+                emit(EventType.TOOL_RESULT, sid, store,
+                     tool_name=tool_name,
+                     result=str(result)[:500],
+                     duration_ms=(time.time() - t0) * 1000)
+                return result
+            except Exception as exc:
+                emit(EventType.ERROR, sid, store,
+                     tool_name=tool_name, error=str(exc))
+                raise
+
+        BaseTool.invoke = _patched_invoke
+    except (ImportError, AttributeError):
+        pass
+
+    _PATCHED = True
+
+
+def uninstrument_strands() -> None:
+    """Remove patches (for testing)."""
+    global _PATCHED
+    _PATCHED = False

--- a/tests/test_auto_instrument.py
+++ b/tests/test_auto_instrument.py
@@ -329,10 +329,25 @@ class TestAutoCLIRegistered(unittest.TestCase):
 
 class TestOptionalExtras(unittest.TestCase):
     def test_pyproject_has_optional_deps(self):
-        import tomllib
+        # tomllib is stdlib in 3.11+; fall back to manual parsing on 3.10
+        try:
+            import tomllib
+            _load = lambda f: tomllib.load(f)
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+                _load = lambda f: tomllib.load(f)
+            except ImportError:
+                # Parse manually: just check the raw text
+                pyproject = Path(__file__).parent.parent / "pyproject.toml"
+                text = pyproject.read_text()
+                for name in ("openai-agents", "langchain", "litellm", "anthropic", "openai", "strands", "all-integrations"):
+                    self.assertIn(name, text, f"Missing optional extra: {name}")
+                return
+
         pyproject = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject, "rb") as f:
-            data = tomllib.load(f)
+            data = _load(f)
         extras = data.get("project", {}).get("optional-dependencies", {})
         for name in ("openai-agents", "langchain", "litellm", "anthropic", "openai", "strands"):
             self.assertIn(name, extras, f"Missing optional extra: {name}")

--- a/tests/test_auto_instrument.py
+++ b/tests/test_auto_instrument.py
@@ -1,0 +1,343 @@
+"""Tests for auto-instrumentation integrations (issue #102)."""
+
+import io
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_trace.integrations import (
+    _INTEGRATIONS,
+    _FRAMEWORK_PROBE,
+    _import_integration,
+    detect_and_instrument,
+    auto_instrument_from_env,
+)
+from agent_trace.integrations._base import _get_store, emit
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Integration registry
+# ---------------------------------------------------------------------------
+
+class TestIntegrationRegistry(unittest.TestCase):
+    def test_all_expected_frameworks_registered(self):
+        for name in ("openai-agents", "langchain", "litellm", "anthropic", "openai", "strands"):
+            self.assertIn(name, _INTEGRATIONS, f"{name} not in registry")
+
+    def test_import_unknown_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _import_integration("nonexistent-framework")
+
+    def test_import_missing_framework_raises_import_error(self):
+        # All frameworks are optional — importing without them installed raises ImportError
+        for name in ("openai-agents", "langchain", "litellm", "anthropic", "openai", "strands"):
+            fn = _import_integration(name)
+            # Calling the function without the framework installed should raise ImportError
+            # (unless the framework happens to be installed in the test env)
+            try:
+                fn()
+            except ImportError:
+                pass  # expected when framework not installed
+            except Exception:
+                pass  # framework installed — that's fine too
+
+
+# ---------------------------------------------------------------------------
+# auto_instrument_from_env
+# ---------------------------------------------------------------------------
+
+class TestAutoInstrumentFromEnv(unittest.TestCase):
+    def test_empty_env_returns_empty_list(self):
+        with patch.dict(os.environ, {"AGENT_STRACE_AUTO_INSTRUMENT": ""}):
+            result = auto_instrument_from_env()
+        self.assertEqual(result, [])
+
+    def test_unset_env_returns_empty_list(self):
+        env = {k: v for k, v in os.environ.items() if k != "AGENT_STRACE_AUTO_INSTRUMENT"}
+        with patch.dict(os.environ, env, clear=True):
+            result = auto_instrument_from_env()
+        self.assertEqual(result, [])
+
+    def test_unknown_framework_does_not_crash(self):
+        with patch.dict(os.environ, {"AGENT_STRACE_AUTO_INSTRUMENT": "nonexistent-xyz"}):
+            result = auto_instrument_from_env()
+        # Should return empty (failed silently)
+        self.assertEqual(result, [])
+
+    def test_detect_mode_does_not_crash(self):
+        with patch.dict(os.environ, {"AGENT_STRACE_AUTO_INSTRUMENT": "detect"}):
+            result = auto_instrument_from_env()
+        # Returns list of successfully instrumented frameworks (may be empty)
+        self.assertIsInstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# detect_and_instrument
+# ---------------------------------------------------------------------------
+
+class TestDetectAndInstrument(unittest.TestCase):
+    def test_returns_list(self):
+        result = detect_and_instrument()
+        self.assertIsInstance(result, list)
+
+    def test_no_crash_when_no_frameworks_installed(self):
+        # Simulate no frameworks installed by patching importlib
+        import importlib
+        original_import = importlib.import_module
+
+        def _mock_import(name, *args, **kwargs):
+            if name in _FRAMEWORK_PROBE.values():
+                raise ImportError(f"mocked: {name} not installed")
+            return original_import(name, *args, **kwargs)
+
+        with patch("importlib.import_module", side_effect=_mock_import):
+            result = detect_and_instrument()
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _base.emit
+# ---------------------------------------------------------------------------
+
+class TestBaseEmit(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+        self.meta = SessionMeta()
+        self.store.create_session(self.meta)
+
+    def test_emit_writes_event_locally(self):
+        env = {k: v for k, v in os.environ.items() if k != "AGENT_STRACE_ENDPOINT"}
+        with patch.dict(os.environ, env, clear=True):
+            emit(EventType.TOOL_CALL, self.meta.session_id, self.store,
+                 tool_name="Bash", command="ls")
+        events = self.store.load_events(self.meta.session_id)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_type, EventType.TOOL_CALL)
+
+    def test_emit_routes_to_endpoint_when_set(self):
+        sent = []
+
+        def _mock_send(event, endpoint):
+            sent.append((event, endpoint))
+            return True
+
+        with patch.dict(os.environ, {"AGENT_STRACE_ENDPOINT": "http://localhost:9999"}):
+            with patch("agent_trace.server.send_event_to_endpoint", _mock_send):
+                emit(EventType.TOOL_CALL, self.meta.session_id, self.store,
+                     tool_name="Bash")
+
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0][1], "http://localhost:9999")
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM integration (mock-based — no real litellm needed)
+# ---------------------------------------------------------------------------
+
+class TestLiteLLMIntegration(unittest.TestCase):
+    def setUp(self):
+        # Reset patch state
+        import agent_trace.integrations.litellm as m
+        m._PATCHED = False
+
+    def test_raises_import_error_when_not_installed(self):
+        """instrument_litellm raises ImportError when litellm is absent."""
+        import agent_trace.integrations.litellm as m
+        m._PATCHED = False
+        # Remove litellm from sys.modules and block re-import
+        saved = sys.modules.pop("litellm", None)
+        sys.modules["litellm"] = None  # type: ignore[assignment]
+        try:
+            with self.assertRaises((ImportError, TypeError)):
+                m.instrument_litellm()
+        finally:
+            if saved is not None:
+                sys.modules["litellm"] = saved
+            else:
+                sys.modules.pop("litellm", None)
+            m._PATCHED = False
+
+    def test_idempotent_when_already_patched(self):
+        import agent_trace.integrations.litellm as m
+        m._PATCHED = True
+        # Should return immediately without error
+        from agent_trace.integrations.litellm import instrument_litellm
+        instrument_litellm()  # no-op
+        self.assertTrue(m._PATCHED)
+
+    def test_uninstrument_resets_flag(self):
+        import agent_trace.integrations.litellm as m
+        m._PATCHED = True
+        from agent_trace.integrations.litellm import uninstrument_litellm
+        uninstrument_litellm()
+        self.assertFalse(m._PATCHED)
+
+
+# ---------------------------------------------------------------------------
+# LangChain integration (mock-based)
+# ---------------------------------------------------------------------------
+
+class TestLangChainIntegration(unittest.TestCase):
+    def setUp(self):
+        import agent_trace.integrations.langchain as m
+        m._PATCHED = False
+
+    def test_idempotent(self):
+        import agent_trace.integrations.langchain as m
+        m._PATCHED = True
+        from agent_trace.integrations.langchain import instrument_langchain
+        instrument_langchain()
+        self.assertTrue(m._PATCHED)
+
+    def test_uninstrument(self):
+        import agent_trace.integrations.langchain as m
+        m._PATCHED = True
+        from agent_trace.integrations.langchain import uninstrument_langchain
+        uninstrument_langchain()
+        self.assertFalse(m._PATCHED)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Agents integration (mock-based)
+# ---------------------------------------------------------------------------
+
+class TestOpenAIAgentsIntegration(unittest.TestCase):
+    def setUp(self):
+        import agent_trace.integrations.openai_agents as m
+        m._PATCHED = False
+
+    def test_idempotent(self):
+        import agent_trace.integrations.openai_agents as m
+        m._PATCHED = True
+        from agent_trace.integrations.openai_agents import instrument_openai_agents
+        instrument_openai_agents()
+        self.assertTrue(m._PATCHED)
+
+    def test_uninstrument(self):
+        import agent_trace.integrations.openai_agents as m
+        m._PATCHED = True
+        from agent_trace.integrations.openai_agents import uninstrument_openai_agents
+        uninstrument_openai_agents()
+        self.assertFalse(m._PATCHED)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic integration (mock-based)
+# ---------------------------------------------------------------------------
+
+class TestAnthropicIntegration(unittest.TestCase):
+    def setUp(self):
+        import agent_trace.integrations.anthropic as m
+        m._PATCHED = False
+
+    def test_idempotent(self):
+        import agent_trace.integrations.anthropic as m
+        m._PATCHED = True
+        from agent_trace.integrations.anthropic import instrument_anthropic
+        instrument_anthropic()
+        self.assertTrue(m._PATCHED)
+
+    def test_uninstrument(self):
+        import agent_trace.integrations.anthropic as m
+        m._PATCHED = True
+        from agent_trace.integrations.anthropic import uninstrument_anthropic
+        uninstrument_anthropic()
+        self.assertFalse(m._PATCHED)
+
+
+# ---------------------------------------------------------------------------
+# Strands integration (mock-based)
+# ---------------------------------------------------------------------------
+
+class TestStrandsIntegration(unittest.TestCase):
+    def setUp(self):
+        import agent_trace.integrations.strands as m
+        m._PATCHED = False
+
+    def test_idempotent(self):
+        import agent_trace.integrations.strands as m
+        m._PATCHED = True
+        from agent_trace.integrations.strands import instrument_strands
+        instrument_strands()
+        self.assertTrue(m._PATCHED)
+
+    def test_uninstrument(self):
+        import agent_trace.integrations.strands as m
+        m._PATCHED = True
+        from agent_trace.integrations.strands import uninstrument_strands
+        uninstrument_strands()
+        self.assertFalse(m._PATCHED)
+
+
+# ---------------------------------------------------------------------------
+# CLI: agent-strace auto registered
+# ---------------------------------------------------------------------------
+
+class TestAutoCLIRegistered(unittest.TestCase):
+    def test_auto_in_help(self):
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("auto", output)
+
+    def test_auto_help_shows_frameworks(self):
+        from agent_trace.cli import main
+        old_argv = sys.argv
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        try:
+            sys.argv = ["agent-strace", "auto", "--help"]
+            sys.stdout = io.StringIO()
+            sys.stderr = io.StringIO()
+            try:
+                main()
+            except SystemExit:
+                pass
+            output = sys.stdout.getvalue() + sys.stderr.getvalue()
+        finally:
+            sys.argv = old_argv
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        self.assertIn("langchain", output)
+        self.assertIn("litellm", output)
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml optional extras
+# ---------------------------------------------------------------------------
+
+class TestOptionalExtras(unittest.TestCase):
+    def test_pyproject_has_optional_deps(self):
+        import tomllib
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        extras = data.get("project", {}).get("optional-dependencies", {})
+        for name in ("openai-agents", "langchain", "litellm", "anthropic", "openai", "strands"):
+            self.assertIn(name, extras, f"Missing optional extra: {name}")
+        self.assertIn("all-integrations", extras)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds zero-code auto-instrumentation for 6 agent frameworks. No application code changes required — just set an env var or run via `agent-strace auto`.

### Changes

- `agent-strace auto --framework langchain -- python my_agent.py` — run with instrumentation
- `AGENT_STRACE_AUTO_INSTRUMENT=langchain,litellm python my_agent.py` — env var mode
- `--detect` flag auto-detects all installed frameworks
- `from agent_trace.integrations import instrument_langchain` — programmatic API

**Supported frameworks:**
- OpenAI Agents SDK (`pip install agent-strace[openai-agents]`) — Runner.run, FunctionTool calls
- LangChain / LangGraph (`pip install agent-strace[langchain]`) — BaseTool._run, BaseChatModel._generate
- LiteLLM (`pip install agent-strace[litellm]`) — litellm.completion
- Anthropic SDK (no extra needed) — messages.create
- OpenAI SDK (no extra needed) — chat.completions.create
- AWS Strands (`pip install agent-strace[strands]`) — Agent.__call__, BaseTool.invoke

Each integration is an optional extra in `pyproject.toml` — the core package stays dependency-free (ADR-0003). All patches are idempotent and reversible.

- 25 new tests in `tests/test_auto_instrument.py`

Closes #102