### PR TITLE
feat: push-based event streaming via --stream-to flag (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,39 @@ Example `.watch-rules.json`:
 - `kill`: SIGTERM, then SIGKILL after 5s; auto-generates a postmortem
 - `alert`: log only, no interruption
 
+### Push-based event streaming
+
+Stream events to an external HTTP endpoint in real-time as they arrive during a watched session. Events are batched and POSTed as [NDJSON](https://ndjsonl.org) (`application/x-ndjson`), so any HTTP server or log aggregator can consume them.
+
+```bash
+# Stream all events to a collector
+agent-strace watch --stream-to https://collector.example.com/events SESSION_ID
+
+# Tune batch size and flush interval
+agent-strace watch \
+  --stream-to https://collector.example.com/events \
+  --stream-batch-size 20 \
+  --stream-flush-interval 5.0 \
+  SESSION_ID
+```
+
+Each POST body contains one JSON object per line:
+
+```
+{"event_type":"tool_call","timestamp":1700000001.0,"session_id":"abc123","data":{...}}
+{"event_type":"llm_response","timestamp":1700000002.5,"session_id":"abc123","data":{...}}
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--stream-to URL` | — | HTTP endpoint to POST events to |
+| `--stream-batch-size N` | `10` | Max events per POST |
+| `--stream-flush-interval S` | `2.0` | Max seconds between flushes |
+
+HTTP failures are logged to stderr but never interrupt the watch loop. The background flush thread is a daemon and is stopped cleanly when the session ends or the watcher exits.
+
 ### Behavioral drift detection
 
 Detect when agent behavior has shifted across sessions without an LLM. Computes a behavioral fingerprint across six dimensions (tool mix, error rate, retry pattern, blast radius, session duration, decision depth) and measures divergence from a baseline using Jensen-Shannon divergence.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -682,6 +682,14 @@ def build_parser() -> argparse.ArgumentParser:
                          help="YAML/JSON rules file for rule-based kill switch (nanny mode)")
     p_watch.add_argument("--dry-run", action="store_true", dest="dry_run",
                          help="evaluate rules without taking action (for testing)")
+    p_watch.add_argument("--stream-to", dest="stream_to", metavar="URL",
+                         help="push events in real-time to this HTTP endpoint as NDJSON")
+    p_watch.add_argument("--stream-batch-size", dest="stream_batch_size", type=int, default=10,
+                         metavar="N",
+                         help="number of events per batch when streaming (default: 10)")
+    p_watch.add_argument("--stream-flush-interval", dest="stream_flush_interval", type=float,
+                         default=2.0, metavar="SECONDS",
+                         help="max seconds between flushes when streaming (default: 2.0)")
 
     # policy
     p_policy = sub.add_parser("policy", help="suggest a .agent-scope.json policy from observed traces")

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -22,10 +22,12 @@ import argparse
 import fnmatch
 import json
 import os
+import queue
 import re
 import signal
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from collections import Counter, deque
@@ -331,6 +333,101 @@ class WatcherConfig:
     max_context_pct: int = 90
     # Watchdog: command to run after kill, with {post_mortem_path} substituted
     on_death_cmd: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Push-based event streaming
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StreamConfig:
+    """Configuration for push-based event streaming."""
+    url: str = ""                    # webhook URL or collector endpoint
+    batch_size: int = 10             # max events per POST
+    flush_interval: float = 1.0     # max seconds between flushes
+    headers: dict[str, str] = field(default_factory=dict)
+    # Filter: only stream these event types (empty = all)
+    event_types: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_url(cls, url: str, headers: dict[str, str] | None = None) -> "StreamConfig":
+        return cls(url=url, headers=headers or {})
+
+
+class EventStreamer:
+    """Background thread that batches and POSTs events to a remote URL.
+
+    Thread-safe: events are enqueued from the watch loop and flushed by a
+    dedicated daemon thread. Failures are logged to stderr but never block
+    the watch loop.
+    """
+
+    def __init__(self, config: StreamConfig) -> None:
+        self.config = config
+        self._queue: queue.Queue[TraceEvent | None] = queue.Queue()
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def enqueue(self, event: TraceEvent) -> None:
+        """Add an event to the outbound queue (non-blocking)."""
+        if self.config.event_types:
+            if event.event_type.value not in self.config.event_types:
+                return
+        self._queue.put(event)
+
+    def stop(self) -> None:
+        """Signal the worker to flush and exit."""
+        self._queue.put(None)  # sentinel
+        self._thread.join(timeout=5.0)
+
+    def _worker(self) -> None:
+        batch: list[TraceEvent] = []
+        last_flush = time.time()
+
+        while True:
+            try:
+                timeout = max(0.01, self.config.flush_interval - (time.time() - last_flush))
+                item = self._queue.get(timeout=timeout)
+                if item is None:
+                    # Sentinel: flush remaining and exit
+                    if batch:
+                        self._flush(batch)
+                    return
+                batch.append(item)
+            except queue.Empty:
+                pass
+
+            now = time.time()
+            should_flush = (
+                len(batch) >= self.config.batch_size
+                or (batch and now - last_flush >= self.config.flush_interval)
+            )
+            if should_flush:
+                self._flush(batch)
+                batch = []
+                last_flush = now
+
+    def _flush(self, events: list[TraceEvent]) -> None:
+        """POST a batch of events as NDJSON."""
+        if not events or not self.config.url:
+            return
+        body = "\n".join(e.to_json() for e in events).encode("utf-8")
+        headers = {"Content-Type": "application/x-ndjson"}
+        headers.update(self.config.headers)
+        req = urllib.request.Request(
+            self.config.url,
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status not in (200, 202):
+                    sys.stderr.write(
+                        f"[stream] POST to {self.config.url} returned {resp.status}\n"
+                    )
+        except Exception as exc:
+            sys.stderr.write(f"[stream] POST to {self.config.url} failed: {exc}\n")
 
     @classmethod
     def from_dict(cls, d: dict) -> "WatcherConfig":
@@ -804,8 +901,13 @@ def watch_session(
     max_idle_seconds: float = 300.0,
     nanny_rules: list[NannyRule] | None = None,
     dry_run: bool = False,
+    stream_config: StreamConfig | None = None,
 ) -> None:
-    """Watch a session's event stream and fire alerts on violations."""
+    """Watch a session's event stream and fire alerts on violations.
+
+    stream_config: when set, events are pushed in real-time to the configured
+    URL as they arrive (push-based streaming).
+    """
     events_file = store._session_dir(session_id) / "events.ndjson"
     if not events_file.exists():
         out.write(f"[watch] events file not found: {events_file}\n")
@@ -817,7 +919,13 @@ def watch_session(
     out.write(f"[watch] Monitoring session {session_id[:12]}...{mode}\n")
     if nanny_rules:
         out.write(f"[watch] {len(nanny_rules)} nanny rule(s) active\n")
+    if stream_config and stream_config.url:
+        out.write(f"[watch] Streaming events to {stream_config.url}\n")
     out.flush()
+
+    streamer: EventStreamer | None = None
+    if stream_config and stream_config.url:
+        streamer = EventStreamer(stream_config)
 
     last_event_time = time.time()
     event_count = 0
@@ -838,6 +946,10 @@ def watch_session(
             event: TraceEvent = item  # type: ignore[assignment]
             event_count += 1
             last_event_time = time.time()
+
+            # Push event to stream if configured
+            if streamer:
+                streamer.enqueue(event)
 
             violations = check_event(event, config, state)
             for msg in violations:
@@ -865,6 +977,9 @@ def watch_session(
 
     except KeyboardInterrupt:
         out.write("\n[watch] Stopped.\n")
+    finally:
+        if streamer:
+            streamer.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -930,5 +1045,16 @@ def cmd_watch(args: argparse.Namespace) -> int:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
 
-    watch_session(store, full_id, config, nanny_rules=nanny_rules, dry_run=dry_run)
+    # Build StreamConfig if --stream-to was provided
+    stream_cfg: StreamConfig | None = None
+    stream_url = getattr(args, "stream_to", None)
+    if stream_url:
+        stream_cfg = StreamConfig(
+            url=stream_url,
+            batch_size=getattr(args, "stream_batch_size", 10),
+            flush_interval=getattr(args, "stream_flush_interval", 2.0),
+        )
+
+    watch_session(store, full_id, config, nanny_rules=nanny_rules, dry_run=dry_run,
+                  stream_config=stream_cfg)
     return 0

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -334,6 +334,49 @@ class WatcherConfig:
     # Watchdog: command to run after kill, with {post_mortem_path} substituted
     on_death_cmd: str = ""
 
+    @classmethod
+    def from_dict(cls, d: dict) -> "WatcherConfig":
+        watchers = d.get("watchers", {})
+        retry_cfg = watchers.get("retry", {})
+        cost_cfg = watchers.get("cost", {})
+        dur_cfg = watchers.get("duration", {})
+        loop_cfg = watchers.get("loop", {})
+        scope_cfg = watchers.get("scope", {})
+        webhook = d.get("webhook", {})
+
+        # Parse per-operation rules
+        rules: list[OperationRule] = []
+        for rule_dict in d.get("operation_rules", []):
+            rules.append(OperationRule(
+                tool_name=rule_dict.get("tool", "*"),
+                pattern=rule_dict.get("pattern", "*"),
+                action=rule_dict.get("action", "alert"),
+                reason=rule_dict.get("reason", ""),
+            ))
+
+        return cls(
+            max_retries=int(retry_cfg.get("max", 5)),
+            max_cost_dollars=float(cost_cfg.get("max_dollars", 10.0)),
+            max_duration_seconds=float(dur_cfg.get("max_minutes", 30)) * 60,
+            loop_sequence_length=int(loop_cfg.get("sequence_length", 3)),
+            loop_max_repeats=int(loop_cfg.get("max_repeats", 3)),
+            scope_policy=str(scope_cfg.get("policy", ".agent-scope.json")),
+            on_violation=str(retry_cfg.get("alert", "terminal")),
+            webhook_url=str(webhook.get("url", "")),
+            operation_rules=rules,
+            max_context_pct=int(d.get("max_context_pct", 90)),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "WatcherConfig":
+        p = Path(path)
+        if not p.exists():
+            return cls()
+        try:
+            return cls.from_dict(json.loads(p.read_text()))
+        except Exception:
+            return cls()
+
 
 # ---------------------------------------------------------------------------
 # Push-based event streaming
@@ -428,49 +471,6 @@ class EventStreamer:
                     )
         except Exception as exc:
             sys.stderr.write(f"[stream] POST to {self.config.url} failed: {exc}\n")
-
-    @classmethod
-    def from_dict(cls, d: dict) -> "WatcherConfig":
-        watchers = d.get("watchers", {})
-        retry_cfg = watchers.get("retry", {})
-        cost_cfg = watchers.get("cost", {})
-        dur_cfg = watchers.get("duration", {})
-        loop_cfg = watchers.get("loop", {})
-        scope_cfg = watchers.get("scope", {})
-        webhook = d.get("webhook", {})
-
-        # Parse per-operation rules
-        rules: list[OperationRule] = []
-        for rule_dict in d.get("operation_rules", []):
-            rules.append(OperationRule(
-                tool_name=rule_dict.get("tool", "*"),
-                pattern=rule_dict.get("pattern", "*"),
-                action=rule_dict.get("action", "alert"),
-                reason=rule_dict.get("reason", ""),
-            ))
-
-        return cls(
-            max_retries=int(retry_cfg.get("max", 5)),
-            max_cost_dollars=float(cost_cfg.get("max_dollars", 10.0)),
-            max_duration_seconds=float(dur_cfg.get("max_minutes", 30)) * 60,
-            loop_sequence_length=int(loop_cfg.get("sequence_length", 3)),
-            loop_max_repeats=int(loop_cfg.get("max_repeats", 3)),
-            scope_policy=str(scope_cfg.get("policy", ".agent-scope.json")),
-            on_violation=str(retry_cfg.get("alert", "terminal")),
-            webhook_url=str(webhook.get("url", "")),
-            operation_rules=rules,
-            max_context_pct=int(d.get("max_context_pct", 90)),
-        )
-
-    @classmethod
-    def load(cls, path: str) -> "WatcherConfig":
-        p = Path(path)
-        if not p.exists():
-            return cls()
-        try:
-            return cls.from_dict(json.loads(p.read_text()))
-        except Exception:
-            return cls()
 
 
 @dataclass

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,349 @@
+"""Tests for push-based event streaming (Issue #103)."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import StringIO
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+from agent_trace.models import EventType, TraceEvent
+from agent_trace.watch import EventStreamer, StreamConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(event_type: EventType = EventType.TOOL_CALL, ts: float = 0.0) -> TraceEvent:
+    return TraceEvent(event_type=event_type, timestamp=ts, session_id="s1", data={})
+
+
+class _CollectorHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler that collects NDJSON POST bodies."""
+
+    received: ClassVar[list[bytes]] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        _CollectorHandler.received.append(body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args: object) -> None:  # suppress access logs
+        pass
+
+
+# ---------------------------------------------------------------------------
+# StreamConfig tests
+# ---------------------------------------------------------------------------
+
+class TestStreamConfig(unittest.TestCase):
+    def test_from_url(self) -> None:
+        cfg = StreamConfig.from_url("http://example.com/events")
+        self.assertEqual(cfg.url, "http://example.com/events")
+        self.assertEqual(cfg.headers, {})
+
+    def test_from_url_with_headers(self) -> None:
+        cfg = StreamConfig.from_url("http://x.com", headers={"Authorization": "Bearer tok"})
+        self.assertEqual(cfg.headers["Authorization"], "Bearer tok")
+
+    def test_defaults(self) -> None:
+        cfg = StreamConfig(url="http://x.com")
+        self.assertEqual(cfg.batch_size, 10)
+        self.assertEqual(cfg.flush_interval, 1.0)
+        self.assertEqual(cfg.event_types, [])
+
+
+# ---------------------------------------------------------------------------
+# EventStreamer unit tests (mock HTTP)
+# ---------------------------------------------------------------------------
+
+class TestEventStreamerUnit(unittest.TestCase):
+    def _make_streamer(self, **kwargs) -> EventStreamer:
+        cfg = StreamConfig(url="http://localhost:9999/events", **kwargs)
+        return EventStreamer(cfg)
+
+    def test_enqueue_and_flush_on_stop(self) -> None:
+        """Events enqueued before stop() are flushed."""
+        flushed: list[list[TraceEvent]] = []
+
+        streamer = self._make_streamer(batch_size=100, flush_interval=60.0)
+        streamer._flush = lambda batch: flushed.append(list(batch))  # type: ignore[method-assign]
+
+        for _ in range(3):
+            streamer.enqueue(_make_event())
+        streamer.stop()
+
+        self.assertEqual(len(flushed), 1)
+        self.assertEqual(len(flushed[0]), 3)
+
+    def test_batch_size_triggers_flush(self) -> None:
+        """Reaching batch_size triggers an intermediate flush."""
+        flushed: list[list[TraceEvent]] = []
+
+        streamer = self._make_streamer(batch_size=3, flush_interval=60.0)
+        streamer._flush = lambda batch: flushed.append(list(batch))  # type: ignore[method-assign]
+
+        for _ in range(6):
+            streamer.enqueue(_make_event())
+        # Give worker time to process
+        time.sleep(0.1)
+        streamer.stop()
+
+        total = sum(len(b) for b in flushed)
+        self.assertEqual(total, 6)
+        # Each batch should be <= batch_size
+        for batch in flushed:
+            self.assertLessEqual(len(batch), 3)
+
+    def test_flush_interval_triggers_flush(self) -> None:
+        """flush_interval causes a flush even when batch_size not reached."""
+        flushed: list[list[TraceEvent]] = []
+
+        streamer = self._make_streamer(batch_size=100, flush_interval=0.05)
+        streamer._flush = lambda batch: flushed.append(list(batch))  # type: ignore[method-assign]
+
+        streamer.enqueue(_make_event())
+        time.sleep(0.2)  # wait for interval flush
+        streamer.stop()
+
+        self.assertGreater(len(flushed), 0)
+        self.assertEqual(flushed[0][0].session_id, "s1")
+
+    def test_event_type_filter(self) -> None:
+        """Only events matching event_types are enqueued."""
+        flushed: list[list[TraceEvent]] = []
+
+        streamer = self._make_streamer(
+            batch_size=100,
+            flush_interval=60.0,
+            event_types=["tool_call"],
+        )
+        streamer._flush = lambda batch: flushed.append(list(batch))  # type: ignore[method-assign]
+
+        streamer.enqueue(_make_event(EventType.TOOL_CALL))
+        streamer.enqueue(_make_event(EventType.LLM_RESPONSE))
+        streamer.enqueue(_make_event(EventType.TOOL_CALL))
+        streamer.stop()
+
+        total = sum(len(b) for b in flushed)
+        self.assertEqual(total, 2)
+
+    def test_empty_event_types_passes_all(self) -> None:
+        """Empty event_types list means no filtering."""
+        flushed: list[list[TraceEvent]] = []
+
+        streamer = self._make_streamer(batch_size=100, flush_interval=60.0)
+        streamer._flush = lambda batch: flushed.append(list(batch))  # type: ignore[method-assign]
+
+        streamer.enqueue(_make_event(EventType.TOOL_CALL))
+        streamer.enqueue(_make_event(EventType.LLM_RESPONSE))
+        streamer.enqueue(_make_event(EventType.SESSION_END))
+        streamer.stop()
+
+        total = sum(len(b) for b in flushed)
+        self.assertEqual(total, 3)
+
+    def test_stop_is_idempotent(self) -> None:
+        """Calling stop() twice does not raise."""
+        streamer = self._make_streamer()
+        streamer._flush = lambda batch: None  # type: ignore[method-assign]
+        streamer.stop()
+        # Second stop should not hang or raise
+        streamer._queue.put(None)  # re-add sentinel so join returns quickly
+        streamer.stop()
+
+
+# ---------------------------------------------------------------------------
+# EventStreamer HTTP integration test
+# ---------------------------------------------------------------------------
+
+class TestEventStreamerHTTP(unittest.TestCase):
+    """Spin up a real HTTP server and verify NDJSON payloads arrive."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        _CollectorHandler.received = []
+        cls.server = HTTPServer(("127.0.0.1", 0), _CollectorHandler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+
+    def setUp(self) -> None:
+        _CollectorHandler.received.clear()
+
+    def test_events_arrive_as_ndjson(self) -> None:
+        url = f"http://127.0.0.1:{self.port}/events"
+        cfg = StreamConfig(url=url, batch_size=2, flush_interval=0.1)
+        streamer = EventStreamer(cfg)
+
+        streamer.enqueue(_make_event(EventType.TOOL_CALL, ts=1.0))
+        streamer.enqueue(_make_event(EventType.LLM_RESPONSE, ts=2.0))
+        streamer.stop()
+
+        self.assertGreater(len(_CollectorHandler.received), 0)
+        # Parse all received lines
+        all_lines: list[dict] = []
+        for body in _CollectorHandler.received:
+            for line in body.decode().strip().splitlines():
+                all_lines.append(json.loads(line))
+
+        self.assertEqual(len(all_lines), 2)
+        types = {e["event_type"] for e in all_lines}
+        self.assertIn("tool_call", types)
+        self.assertIn("llm_response", types)
+
+    def test_content_type_header(self) -> None:
+        """Requests must carry Content-Type: application/x-ndjson."""
+        received_headers: list[dict] = []
+
+        class HeaderCapture(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                received_headers.append(dict(self.headers))
+                length = int(self.headers.get("Content-Length", 0))
+                self.rfile.read(length)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), HeaderCapture)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+
+        try:
+            url = f"http://127.0.0.1:{port}/events"
+            cfg = StreamConfig(url=url, batch_size=1, flush_interval=60.0)
+            streamer = EventStreamer(cfg)
+            streamer.enqueue(_make_event())
+            streamer.stop()
+
+            self.assertGreater(len(received_headers), 0)
+            ct = received_headers[0].get("Content-Type", "")
+            self.assertEqual(ct, "application/x-ndjson")
+        finally:
+            srv.shutdown()
+
+    def test_http_error_does_not_crash_watch(self) -> None:
+        """A 500 from the server is logged but does not raise."""
+        class ErrorHandler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                self.rfile.read(length)
+                self.send_response(500)
+                self.end_headers()
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), ErrorHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+
+        try:
+            url = f"http://127.0.0.1:{port}/events"
+            cfg = StreamConfig(url=url, batch_size=1, flush_interval=60.0)
+            streamer = EventStreamer(cfg)
+            streamer.enqueue(_make_event())
+            # Should not raise
+            streamer.stop()
+        finally:
+            srv.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# watch_session integration: streamer is wired in
+# ---------------------------------------------------------------------------
+
+class TestWatchSessionStreaming(unittest.TestCase):
+    """Verify watch_session passes events to EventStreamer.
+
+    _tail_events seeks to EOF and waits for new writes, so we patch it to
+    replay a fixed sequence of events without touching the filesystem.
+    """
+
+    def _fake_tail(self, events: list[TraceEvent]):
+        """Return a generator that yields the given events then stops."""
+        def _gen(_path, poll_interval=0.5):
+            yield from events
+        return _gen
+
+    def test_streamer_receives_events(self) -> None:
+        import tempfile
+        from agent_trace.store import TraceStore
+        from agent_trace.watch import WatcherConfig, watch_session, _IDLE_SENTINEL
+
+        fake_events = [
+            TraceEvent(event_type=EventType.TOOL_CALL, timestamp=1.0,
+                       session_id="s1", data={}),
+            TraceEvent(event_type=EventType.SESSION_END, timestamp=2.0,
+                       session_id="s1", data={}),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            from agent_trace.models import SessionMeta
+            meta = SessionMeta(agent_name="test", command="test")
+            session_path = store.create_session(meta)
+            session_id = session_path.name
+            # Create the events file so watch_session doesn't bail early
+            (store._session_dir(session_id) / "events.ndjson").touch()
+
+            enqueued: list[TraceEvent] = []
+            mock_streamer = MagicMock()
+            mock_streamer.enqueue.side_effect = enqueued.append
+
+            cfg = WatcherConfig()
+            stream_cfg = StreamConfig(url="http://localhost:9999/events")
+
+            with patch("agent_trace.watch.EventStreamer", return_value=mock_streamer), \
+                 patch("agent_trace.watch._tail_events", self._fake_tail(fake_events)):
+                out = StringIO()
+                watch_session(store, session_id, cfg, out=out, stream_config=stream_cfg)
+
+            self.assertGreaterEqual(len(enqueued), 1)
+            mock_streamer.stop.assert_called_once()
+
+    def test_no_streamer_when_no_stream_config(self) -> None:
+        """watch_session without stream_config does not create an EventStreamer."""
+        import tempfile
+        from agent_trace.store import TraceStore
+        from agent_trace.watch import WatcherConfig, watch_session
+
+        fake_events = [
+            TraceEvent(event_type=EventType.SESSION_END, timestamp=1.0,
+                       session_id="s1", data={}),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            from agent_trace.models import SessionMeta
+            meta = SessionMeta(agent_name="test", command="test")
+            session_path = store.create_session(meta)
+            session_id = session_path.name
+            (store._session_dir(session_id) / "events.ndjson").touch()
+
+            with patch("agent_trace.watch.EventStreamer") as mock_cls, \
+                 patch("agent_trace.watch._tail_events", self._fake_tail(fake_events)):
+                cfg = WatcherConfig()
+                watch_session(store, session_id, cfg, stream_config=None)
+                mock_cls.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements push-based event streaming for `agent-strace watch` (closes #103).

Events are batched and POSTed as NDJSON to a configurable HTTP endpoint in real-time as they arrive during a watched session. HTTP failures are logged to stderr but never interrupt the watch loop.

## Changes

**`src/agent_trace/watch.py`**
- `StreamConfig` dataclass: `url`, `batch_size`, `flush_interval`, `headers`, `event_types` filter
- `EventStreamer` class: daemon thread, thread-safe queue, flushes on batch size or interval, clean stop with 5s join timeout
- `watch_session`: accepts `stream_config`, creates/stops streamer around the tail loop

**`src/agent_trace/cli.py`**
- `--stream-to URL` — HTTP endpoint to POST events to
- `--stream-batch-size N` — max events per POST (default: 10)
- `--stream-flush-interval S` — max seconds between flushes (default: 2.0)

**`tests/test_streaming.py`** — 14 new tests:
- `StreamConfig` defaults and `from_url` factory
- `EventStreamer` unit tests: flush-on-stop, batch-size trigger, interval trigger, event-type filter, empty filter passes all, idempotent stop
- HTTP integration tests: NDJSON payload arrives, `Content-Type` header, 500 response does not crash
- `watch_session` wiring: streamer receives events, no streamer created when `stream_config=None`

**`README.md`** — new "Push-based event streaming" section with usage examples and option table

**`src/agent_trace/__init__.py`** — version bumped to `0.46.0`

## Wire protocol

Each POST body is NDJSON (`Content-Type: application/x-ndjson`):

```
{"event_type":"tool_call","timestamp":1700000001.0,"session_id":"abc123","data":{...}}
{"event_type":"llm_response","timestamp":1700000002.5,"session_id":"abc123","data":{...}}
```
