### PR TITLE
feat(lint): add agent-strace lint with 7 behaviour rules (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,58 @@ Supported models: `sonnet` (default), `opus`, `haiku`, `gpt4`, `gpt4o`. Token co
 
 See [examples/session_analysis.md](examples/session_analysis.md) for a full walkthrough combining `import`, `explain`, and `cost`.
 
+### Static behaviour analysis (lint)
+
+Analyse a session for known bad patterns — tool loops, reasoning spirals, budget proximity, context saturation, redundant reads, error-retry loops, and sessions that produced no output.
+
+```bash
+# Lint the latest session
+agent-strace lint
+
+# Lint a specific session
+agent-strace lint <session-id>
+
+# Lint all sessions from the last 7 days
+agent-strace lint --all --since 7d
+
+# Machine-readable output for CI
+agent-strace lint <session-id> --format json
+
+# Exit code 1 on any WARN or ERROR (CI gate)
+agent-strace lint <session-id> --strict
+```
+
+Example output:
+
+```
+WARN   tool-loop              "Bash" called 7 times consecutively (events 34–41). Possible loop.
+WARN   reasoning-spiral       4 consecutive LLM calls with no tool call (events 12–15). Agent may be over-reasoning.
+ERROR  budget-proximity       Session reached 94% of a $5.00 budget ceiling. Consider raising or splitting the task.
+INFO   context-saturation     Input tokens exceeded 80% of model context window at event 28.
+INFO   redundant-read         "README.md" read 3 times in this session. Consider caching.
+
+2 error(s), 2 warning(s), 2 info(s). Use --strict for non-zero exit on warnings.
+```
+
+Rules are configurable via `.agent-strace-lint.json`:
+
+```json
+{
+  "tool-loop": { "threshold": 7 },
+  "reasoning-spiral": { "enabled": false }
+}
+```
+
+| Rule | Level | Trigger |
+|---|---|---|
+| `tool-loop` | WARN | Same tool called 5+ times consecutively |
+| `reasoning-spiral` | WARN | 3+ consecutive LLM calls with no tool call |
+| `budget-proximity` | ERROR | Session cost exceeded 90% of watchdog budget ceiling |
+| `context-saturation` | INFO | Input tokens exceeded 80% of model context window |
+| `redundant-read` | INFO | Same file read 3+ times in a session |
+| `error-retry-loop` | WARN | Same tool errored and was retried 3+ times |
+| `no-output` | WARN | Session completed with no write or file-modifying tool calls |
+
 ### Data retention
 
 Enforce configurable retention policies to automatically delete old session data — required for GDPR, SOC 2, and internal data policies.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -47,6 +47,7 @@ from .share import cmd_share
 from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
+from .lint import cmd_lint
 from .retention import cmd_retention
 from .sample import cmd_sample
 from .server import cmd_server
@@ -880,6 +881,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_sample.add_argument("--seed", type=int, default=None,
                           help="random seed for reproducible random sampling")
 
+    # lint
+    p_lint = sub.add_parser("lint", help="analyse a session for bad behaviour patterns")
+    p_lint.add_argument("session_id", nargs="?",
+                        help="session ID to lint (default: latest)")
+    p_lint.add_argument("--all", action="store_true", dest="all",
+                        help="lint all sessions in the store")
+    p_lint.add_argument("--since", metavar="DURATION",
+                        help="with --all, only sessions newer than this (e.g. 7d, 24h)")
+    p_lint.add_argument("--strict", action="store_true",
+                        help="exit with code 1 on any WARN or ERROR (for CI)")
+    p_lint.add_argument("--format", choices=["text", "json"], default="text",
+                        help="output format (default: text)")
+    p_lint.add_argument("--config", metavar="FILE",
+                        help="path to .agent-strace-lint.json config file")
+
     # retention
     p_ret = sub.add_parser("retention", help="manage session data retention")
     ret_sub = p_ret.add_subparsers(dest="retention_command")
@@ -1005,6 +1021,7 @@ def main() -> None:
         "standup": cmd_standup,
         "mcp": cmd_mcp,
         "auto": cmd_auto,
+        "lint": cmd_lint,
         "retention": cmd_retention,
         "sample": cmd_sample,
         "server": cmd_server,

--- a/src/agent_trace/lint.py
+++ b/src/agent_trace/lint.py
@@ -1,0 +1,597 @@
+"""Static behaviour analysis: agent-strace lint.
+
+Analyses a session's event stream and flags known bad patterns — tool loops,
+reasoning spirals, budget proximity, context saturation, redundant reads,
+error-retry loops, and no-output sessions.
+
+Each rule is a pure function:
+    rule(events: list[TraceEvent], config: dict) -> list[LintResult]
+
+Rules are independent — a failure in one never prevents others from running.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, TextIO
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+class LintLevel:
+    INFO = "INFO"
+    WARN = "WARN"
+    ERROR = "ERROR"
+
+
+@dataclass
+class LintResult:
+    rule: str
+    level: str          # INFO | WARN | ERROR
+    message: str
+    line_start: int | None = None   # 1-based event index where the issue starts
+    line_end: int | None = None
+
+
+@dataclass
+class LintReport:
+    session_id: str
+    findings: list[LintResult] = field(default_factory=list)
+
+    @property
+    def errors(self) -> int:
+        return sum(1 for f in self.findings if f.level == LintLevel.ERROR)
+
+    @property
+    def warnings(self) -> int:
+        return sum(1 for f in self.findings if f.level == LintLevel.WARN)
+
+    @property
+    def infos(self) -> int:
+        return sum(1 for f in self.findings if f.level == LintLevel.INFO)
+
+
+# ---------------------------------------------------------------------------
+# Default rule configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_CONFIG: dict = {
+    "tool-loop": {
+        "enabled": True,
+        "level": LintLevel.WARN,
+        "threshold": 5,        # same tool N+ times consecutively
+    },
+    "reasoning-spiral": {
+        "enabled": True,
+        "level": LintLevel.WARN,
+        "threshold": 3,        # N+ consecutive LLM calls with no tool call
+    },
+    "budget-proximity": {
+        "enabled": True,
+        "level": LintLevel.ERROR,
+        "threshold": 0.90,     # fraction of budget ceiling
+    },
+    "context-saturation": {
+        "enabled": True,
+        "level": LintLevel.INFO,
+        "threshold": 0.80,     # fraction of context window
+    },
+    "redundant-read": {
+        "enabled": True,
+        "level": LintLevel.INFO,
+        "threshold": 3,        # same file read N+ times
+    },
+    "error-retry-loop": {
+        "enabled": True,
+        "level": LintLevel.WARN,
+        "threshold": 3,        # same tool errored and retried N+ times
+    },
+    "no-output": {
+        "enabled": True,
+        "level": LintLevel.WARN,
+    },
+}
+
+_WRITE_TOOLS = {"write", "edit", "create", "str_replace", "str_replace_based_edit_tool",
+                "multiedit", "notebook_edit"}
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+def _rule_tool_loop(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Same tool called N+ times consecutively."""
+    threshold = cfg.get("threshold", 5)
+    level = cfg.get("level", LintLevel.WARN)
+    results: list[LintResult] = []
+
+    run_tool: str | None = None
+    run_start = 0
+    run_len = 0
+
+    for i, ev in enumerate(events):
+        if ev.event_type != EventType.TOOL_CALL:
+            if run_len >= threshold:
+                results.append(LintResult(
+                    rule="tool-loop",
+                    level=level,
+                    message=(
+                        f"{run_tool!r} called {run_len} times consecutively "
+                        f"(events {run_start + 1}–{run_start + run_len}). Possible loop."
+                    ),
+                    line_start=run_start + 1,
+                    line_end=run_start + run_len,
+                ))
+            run_tool = None
+            run_len = 0
+            continue
+
+        tool = ev.data.get("tool_name", "")
+        if tool == run_tool:
+            run_len += 1
+        else:
+            if run_len >= threshold:
+                results.append(LintResult(
+                    rule="tool-loop",
+                    level=level,
+                    message=(
+                        f"{run_tool!r} called {run_len} times consecutively "
+                        f"(events {run_start + 1}–{run_start + run_len}). Possible loop."
+                    ),
+                    line_start=run_start + 1,
+                    line_end=run_start + run_len,
+                ))
+            run_tool = tool
+            run_start = i
+            run_len = 1
+
+    # flush trailing run
+    if run_len >= threshold:
+        results.append(LintResult(
+            rule="tool-loop",
+            level=level,
+            message=(
+                f"{run_tool!r} called {run_len} times consecutively "
+                f"(events {run_start + 1}–{run_start + run_len}). Possible loop."
+            ),
+            line_start=run_start + 1,
+            line_end=run_start + run_len,
+        ))
+
+    return results
+
+
+def _rule_reasoning_spiral(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """N+ consecutive LLM calls with no tool call between them."""
+    threshold = cfg.get("threshold", 3)
+    level = cfg.get("level", LintLevel.WARN)
+    results: list[LintResult] = []
+
+    llm_types = {EventType.LLM_REQUEST, EventType.LLM_RESPONSE,
+                 EventType.ASSISTANT_RESPONSE}
+
+    run_start = 0
+    run_len = 0
+
+    for i, ev in enumerate(events):
+        if ev.event_type in llm_types:
+            if run_len == 0:
+                run_start = i
+            run_len += 1
+        elif ev.event_type == EventType.TOOL_CALL:
+            if run_len >= threshold:
+                results.append(LintResult(
+                    rule="reasoning-spiral",
+                    level=level,
+                    message=(
+                        f"{run_len} consecutive LLM calls with no tool call "
+                        f"(events {run_start + 1}–{run_start + run_len}). "
+                        "Agent may be over-reasoning."
+                    ),
+                    line_start=run_start + 1,
+                    line_end=run_start + run_len,
+                ))
+            run_len = 0
+
+    if run_len >= threshold:
+        results.append(LintResult(
+            rule="reasoning-spiral",
+            level=level,
+            message=(
+                f"{run_len} consecutive LLM calls with no tool call "
+                f"(events {run_start + 1}–{run_start + run_len}). "
+                "Agent may be over-reasoning."
+            ),
+            line_start=run_start + 1,
+            line_end=run_start + run_len,
+        ))
+
+    return results
+
+
+def _rule_budget_proximity(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Session cost exceeded N% of watchdog budget ceiling."""
+    threshold = cfg.get("threshold", 0.90)
+    level = cfg.get("level", LintLevel.ERROR)
+
+    # Find budget ceiling from session events (written by watchdog)
+    budget: float | None = None
+    for ev in events:
+        if ev.event_type == EventType.SESSION_START:
+            budget = ev.data.get("budget_dollars") or ev.data.get("max_cost_dollars")
+            if budget:
+                break
+
+    if not budget:
+        return []
+
+    # Estimate cost from token events
+    total_tokens = sum(
+        len(json.dumps(ev.data)) // 4
+        for ev in events
+        if ev.event_type in {EventType.LLM_REQUEST, EventType.LLM_RESPONSE,
+                              EventType.ASSISTANT_RESPONSE, EventType.USER_PROMPT}
+    )
+    # Use sonnet pricing: $3/M input, $15/M output — rough average $9/M
+    estimated_cost = total_tokens * 9.0 / 1_000_000
+
+    if estimated_cost >= budget * threshold:
+        pct = estimated_cost / budget * 100
+        return [LintResult(
+            rule="budget-proximity",
+            level=level,
+            message=(
+                f"Session reached {pct:.0f}% of a ${budget:.2f} budget ceiling "
+                f"(estimated ${estimated_cost:.4f} spent). "
+                "Consider raising or splitting the task."
+            ),
+        )]
+    return []
+
+
+def _rule_context_saturation(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Input tokens exceeded N% of model context window."""
+    threshold = cfg.get("threshold", 0.80)
+    level = cfg.get("level", LintLevel.INFO)
+    # Common context window sizes by model hint
+    context_window = 200_000  # claude default; conservative
+
+    results: list[LintResult] = []
+    cumulative_input = 0
+
+    for i, ev in enumerate(events):
+        if ev.event_type in {EventType.LLM_REQUEST, EventType.USER_PROMPT}:
+            tokens = len(json.dumps(ev.data)) // 4
+            cumulative_input += tokens
+            if cumulative_input >= context_window * threshold:
+                pct = cumulative_input / context_window * 100
+                results.append(LintResult(
+                    rule="context-saturation",
+                    level=level,
+                    message=(
+                        f"Input tokens exceeded {threshold * 100:.0f}% of model context window "
+                        f"at event {i + 1} (~{cumulative_input:,} tokens, "
+                        f"{pct:.0f}% of {context_window:,})."
+                    ),
+                    line_start=i + 1,
+                ))
+                break  # report once
+
+    return results
+
+
+def _rule_redundant_read(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Same file read N+ times in a session."""
+    threshold = cfg.get("threshold", 3)
+    level = cfg.get("level", LintLevel.INFO)
+
+    from collections import Counter
+    read_counts: Counter = Counter()
+
+    for ev in events:
+        if ev.event_type not in {EventType.TOOL_CALL, EventType.FILE_READ}:
+            continue
+        tool = ev.data.get("tool_name", "").lower()
+        if tool in ("read", "read_file", "file_read") or ev.event_type == EventType.FILE_READ:
+            path = (
+                ev.data.get("arguments", {}).get("file_path")
+                or ev.data.get("arguments", {}).get("path")
+                or ev.data.get("path")
+                or ev.data.get("file_path")
+            )
+            if path:
+                read_counts[str(path)] += 1
+
+    results: list[LintResult] = []
+    for path, count in read_counts.items():
+        if count >= threshold:
+            results.append(LintResult(
+                rule="redundant-read",
+                level=level,
+                message=(
+                    f"{path!r} read {count} times in this session. "
+                    "Consider caching or restructuring the prompt."
+                ),
+            ))
+    return results
+
+
+def _rule_error_retry_loop(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Same tool errored and was retried N+ times."""
+    threshold = cfg.get("threshold", 3)
+    level = cfg.get("level", LintLevel.WARN)
+
+    from collections import Counter
+    error_counts: Counter = Counter()
+    last_tool: str | None = None
+
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            last_tool = ev.data.get("tool_name", "")
+        elif ev.event_type == EventType.ERROR:
+            if last_tool:
+                error_counts[last_tool] += 1
+        elif ev.event_type == EventType.TOOL_RESULT:
+            # tool_result with is_error flag
+            if ev.data.get("is_error") and last_tool:
+                error_counts[last_tool] += 1
+
+    results: list[LintResult] = []
+    for tool, count in error_counts.items():
+        if count >= threshold:
+            results.append(LintResult(
+                rule="error-retry-loop",
+                level=level,
+                message=(
+                    f"{tool!r} errored and was retried {count} times. "
+                    "Check tool implementation or input validation."
+                ),
+            ))
+    return results
+
+
+def _rule_no_output(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
+    """Session completed with no write or file-modifying tool calls."""
+    level = cfg.get("level", LintLevel.WARN)
+
+    has_session_end = any(e.event_type == EventType.SESSION_END for e in events)
+    if not has_session_end:
+        return []  # session still in progress
+
+    has_write = any(
+        e.event_type == EventType.TOOL_CALL
+        and e.data.get("tool_name", "").lower() in _WRITE_TOOLS
+        for e in events
+    )
+    has_file_write = any(e.event_type == EventType.FILE_WRITE for e in events)
+
+    if not has_write and not has_file_write:
+        return [LintResult(
+            rule="no-output",
+            level=level,
+            message=(
+                "Session completed with no Write or file-modifying tool calls. "
+                "Agent may have only read/reasoned without producing output."
+            ),
+        )]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Rule registry
+# ---------------------------------------------------------------------------
+
+_RULES: dict[str, Callable[[list[TraceEvent], dict], list[LintResult]]] = {
+    "tool-loop": _rule_tool_loop,
+    "reasoning-spiral": _rule_reasoning_spiral,
+    "budget-proximity": _rule_budget_proximity,
+    "context-saturation": _rule_context_saturation,
+    "redundant-read": _rule_redundant_read,
+    "error-retry-loop": _rule_error_retry_loop,
+    "no-output": _rule_no_output,
+}
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def _load_config(config_path: str | None) -> dict:
+    """Load rule config from file, merging with defaults."""
+    config = {k: dict(v) for k, v in DEFAULT_CONFIG.items()}
+
+    if not config_path:
+        # Look for .agent-strace-lint.json in cwd
+        default = Path(".agent-strace-lint.json")
+        if default.exists():
+            config_path = str(default)
+
+    if config_path:
+        try:
+            overrides = json.loads(Path(config_path).read_text())
+            for rule_name, rule_cfg in overrides.items():
+                if rule_name in config:
+                    config[rule_name].update(rule_cfg)
+                else:
+                    config[rule_name] = rule_cfg
+        except Exception as exc:
+            sys.stderr.write(f"[lint] Warning: could not load config {config_path}: {exc}\n")
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Core lint function
+# ---------------------------------------------------------------------------
+
+def lint_session(
+    store: TraceStore,
+    session_id: str,
+    config: dict | None = None,
+) -> LintReport:
+    """Run all enabled rules against a session. Returns a LintReport."""
+    if config is None:
+        config = DEFAULT_CONFIG
+
+    events = store.load_events(session_id)
+    report = LintReport(session_id=session_id)
+
+    for rule_name, rule_fn in _RULES.items():
+        rule_cfg = config.get(rule_name, {})
+        if not rule_cfg.get("enabled", True):
+            continue
+        try:
+            findings = rule_fn(events, rule_cfg)
+            report.findings.extend(findings)
+        except Exception as exc:
+            sys.stderr.write(f"[lint] Rule {rule_name!r} failed: {exc}\n")
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+_LEVEL_ORDER = {LintLevel.ERROR: 0, LintLevel.WARN: 1, LintLevel.INFO: 2}
+
+
+def format_report(report: LintReport, out: TextIO = sys.stdout) -> None:
+    """Print a lint report in human-readable form."""
+    if not report.findings:
+        out.write(f"✓  No issues found in session {report.session_id[:12]}\n")
+        return
+
+    # Sort: ERROR first, then WARN, then INFO
+    sorted_findings = sorted(report.findings, key=lambda f: _LEVEL_ORDER.get(f.level, 99))
+
+    for f in sorted_findings:
+        loc = ""
+        if f.line_start is not None:
+            loc = f" (event {f.line_start}" + (f"–{f.line_end}" if f.line_end and f.line_end != f.line_start else "") + ")"
+        out.write(f"{f.level:<5}  {f.rule:<22}  {f.message}{loc}\n")
+
+    out.write(
+        f"\n{report.errors} error(s), {report.warnings} warning(s), "
+        f"{report.infos} info(s)."
+    )
+    if report.errors == 0 and report.warnings == 0:
+        out.write(" Exit code: 0\n")
+    else:
+        out.write(" Use --strict for non-zero exit on warnings.\n")
+
+
+def format_report_json(report: LintReport) -> str:
+    return json.dumps({
+        "session_id": report.session_id,
+        "errors": report.errors,
+        "warnings": report.warnings,
+        "infos": report.infos,
+        "findings": [
+            {
+                "rule": f.rule,
+                "level": f.level,
+                "message": f.message,
+                "line_start": f.line_start,
+                "line_end": f.line_end,
+            }
+            for f in report.findings
+        ],
+    }, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_lint(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    config = _load_config(getattr(args, "config", None))
+    strict = getattr(args, "strict", False)
+    fmt = getattr(args, "format", "text")
+    lint_all = getattr(args, "all", False)
+    since_str = getattr(args, "since", None)
+
+    # Resolve session IDs
+    session_ids: list[str] = []
+
+    if lint_all:
+        sessions = store.list_sessions()
+        if since_str:
+            import time as _time
+            cutoff = _parse_since(since_str)
+            sessions = [s for s in sessions if s.started_at >= cutoff]
+        session_ids = [s.session_id for s in sessions]
+        if not session_ids:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+    else:
+        raw_id = getattr(args, "session_id", None)
+        if not raw_id:
+            latest = store.get_latest_session_id()
+            if not latest:
+                sys.stderr.write("No sessions found.\n")
+                return 1
+            raw_id = latest
+        full_id = store.find_session(raw_id)
+        if not full_id:
+            sys.stderr.write(f"Session not found: {raw_id}\n")
+            return 1
+        session_ids = [full_id]
+
+    reports: list[LintReport] = []
+    for sid in session_ids:
+        reports.append(lint_session(store, sid, config))
+
+    if fmt == "json":
+        if len(reports) == 1:
+            sys.stdout.write(format_report_json(reports[0]) + "\n")
+        else:
+            sys.stdout.write(json.dumps([
+                json.loads(format_report_json(r)) for r in reports
+            ], indent=2) + "\n")
+    else:
+        for report in reports:
+            if len(reports) > 1:
+                sys.stdout.write(f"\n── Session {report.session_id[:12]} ──\n")
+            format_report(report, sys.stdout)
+
+    # Exit code
+    total_errors = sum(r.errors for r in reports)
+    total_warnings = sum(r.warnings for r in reports)
+
+    if strict and (total_errors > 0 or total_warnings > 0):
+        return 1
+    if total_errors > 0:
+        return 1
+    return 0
+
+
+def _parse_since(s: str) -> float:
+    """Parse a duration string like '7d', '24h' into a Unix timestamp cutoff."""
+    import time as _time
+    s = s.strip()
+    multipliers = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+    if s[-1] in multipliers:
+        try:
+            return _time.time() - float(s[:-1]) * multipliers[s[-1]]
+        except ValueError:
+            pass
+    # Try ISO date
+    try:
+        import datetime
+        dt = datetime.datetime.fromisoformat(s)
+        return dt.timestamp()
+    except ValueError:
+        pass
+    raise ValueError(f"Cannot parse --since value: {s!r}")

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,589 @@
+"""Tests for agent-strace lint (Issue #116)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_trace.lint import (
+    DEFAULT_CONFIG,
+    LintLevel,
+    LintReport,
+    LintResult,
+    _rule_budget_proximity,
+    _rule_context_saturation,
+    _rule_error_retry_loop,
+    _rule_no_output,
+    _rule_reasoning_spiral,
+    _rule_redundant_read,
+    _rule_tool_loop,
+    _load_config,
+    lint_session,
+    format_report,
+    format_report_json,
+    cmd_lint,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ev(event_type: EventType, **data) -> TraceEvent:
+    return TraceEvent(event_type=event_type, timestamp=1.0, session_id="s1", data=data)
+
+
+def _tool_call(tool: str, **kwargs) -> TraceEvent:
+    return _ev(EventType.TOOL_CALL, tool_name=tool, arguments=kwargs)
+
+
+def _llm_response() -> TraceEvent:
+    return _ev(EventType.LLM_RESPONSE, content="thinking...")
+
+
+def _llm_request() -> TraceEvent:
+    return _ev(EventType.LLM_REQUEST, prompt="do something")
+
+
+def _error(msg: str = "fail") -> TraceEvent:
+    return _ev(EventType.ERROR, message=msg)
+
+
+def _tool_result(is_error: bool = False) -> TraceEvent:
+    return _ev(EventType.TOOL_RESULT, is_error=is_error)
+
+
+def _session_end() -> TraceEvent:
+    return _ev(EventType.SESSION_END)
+
+
+def _make_store_with_events(events: list[TraceEvent]) -> tuple[TraceStore, str]:
+    tmp = tempfile.mkdtemp()
+    store = TraceStore(Path(tmp))
+    meta = SessionMeta(agent_name="test", command="test")
+    session_path = store.create_session(meta)
+    session_id = session_path.name
+    for e in events:
+        e.session_id = session_id
+        store.append_event(session_id, e)
+    return store, session_id
+
+
+# ---------------------------------------------------------------------------
+# Rule: tool-loop
+# ---------------------------------------------------------------------------
+
+class TestRuleToolLoop(unittest.TestCase):
+    def _cfg(self, threshold=5):
+        return {"enabled": True, "level": LintLevel.WARN, "threshold": threshold}
+
+    def test_triggers_on_consecutive_calls(self):
+        events = [_tool_call("Bash")] * 6
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].rule, "tool-loop")
+        self.assertEqual(results[0].level, LintLevel.WARN)
+        self.assertIn("Bash", results[0].message)
+        self.assertIn("6", results[0].message)
+
+    def test_no_trigger_below_threshold(self):
+        events = [_tool_call("Bash")] * 4
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(results, [])
+
+    def test_resets_on_different_tool(self):
+        events = [_tool_call("Bash")] * 4 + [_tool_call("Read")] + [_tool_call("Bash")] * 4
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(results, [])
+
+    def test_triggers_exactly_at_threshold(self):
+        events = [_tool_call("Write")] * 5
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(len(results), 1)
+
+    def test_non_tool_call_breaks_run(self):
+        events = [_tool_call("Bash")] * 3 + [_llm_response()] + [_tool_call("Bash")] * 3
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(results, [])
+
+    def test_line_numbers_set(self):
+        events = [_tool_call("Bash")] * 6
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(results[0].line_start, 1)
+        self.assertEqual(results[0].line_end, 6)
+
+    def test_multiple_runs_reported(self):
+        events = [_tool_call("Bash")] * 6 + [_llm_response()] + [_tool_call("Read")] * 6
+        results = _rule_tool_loop(events, self._cfg(threshold=5))
+        self.assertEqual(len(results), 2)
+
+
+# ---------------------------------------------------------------------------
+# Rule: reasoning-spiral
+# ---------------------------------------------------------------------------
+
+class TestRuleReasoningSpiral(unittest.TestCase):
+    def _cfg(self, threshold=3):
+        return {"enabled": True, "level": LintLevel.WARN, "threshold": threshold}
+
+    def test_triggers_on_consecutive_llm_calls(self):
+        events = [_llm_request(), _llm_response(), _llm_request(), _llm_response()]
+        results = _rule_reasoning_spiral(events, self._cfg(threshold=3))
+        self.assertEqual(len(results), 1)
+        self.assertIn("4", results[0].message)
+
+    def test_no_trigger_below_threshold(self):
+        events = [_llm_request(), _llm_response()]
+        results = _rule_reasoning_spiral(events, self._cfg(threshold=3))
+        self.assertEqual(results, [])
+
+    def test_tool_call_resets_run(self):
+        # 2 LLM calls, then a tool call, then 2 more — neither run reaches threshold=3
+        events = [_llm_request(), _llm_response(),
+                  _tool_call("Bash"),
+                  _llm_request(), _llm_response()]
+        results = _rule_reasoning_spiral(events, self._cfg(threshold=3))
+        self.assertEqual(results, [])
+
+    def test_triggers_at_end_of_stream(self):
+        events = [_llm_request()] * 4
+        results = _rule_reasoning_spiral(events, self._cfg(threshold=3))
+        self.assertEqual(len(results), 1)
+
+
+# ---------------------------------------------------------------------------
+# Rule: budget-proximity
+# ---------------------------------------------------------------------------
+
+class TestRuleBudgetProximity(unittest.TestCase):
+    def _cfg(self, threshold=0.90):
+        return {"enabled": True, "level": LintLevel.ERROR, "threshold": threshold}
+
+    def test_no_trigger_without_budget(self):
+        events = [_llm_request()] * 10
+        results = _rule_budget_proximity(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_triggers_when_near_budget(self):
+        # SESSION_START with a tiny budget so estimated cost exceeds 90%
+        start = TraceEvent(
+            event_type=EventType.SESSION_START,
+            timestamp=1.0,
+            session_id="s1",
+            data={"budget_dollars": 0.000001},  # tiny budget
+        )
+        # Add many LLM events to push estimated cost over threshold
+        events = [start] + [_llm_request()] * 100
+        results = _rule_budget_proximity(events, self._cfg())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].level, LintLevel.ERROR)
+
+    def test_no_trigger_well_below_budget(self):
+        start = TraceEvent(
+            event_type=EventType.SESSION_START,
+            timestamp=1.0,
+            session_id="s1",
+            data={"budget_dollars": 1000.0},  # huge budget
+        )
+        events = [start, _llm_request()]
+        results = _rule_budget_proximity(events, self._cfg())
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Rule: context-saturation
+# ---------------------------------------------------------------------------
+
+class TestRuleContextSaturation(unittest.TestCase):
+    def _cfg(self, threshold=0.80):
+        return {"enabled": True, "level": LintLevel.INFO, "threshold": threshold}
+
+    def test_no_trigger_on_small_session(self):
+        events = [_llm_request()] * 5
+        results = _rule_context_saturation(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_triggers_on_large_input(self):
+        # Create a very large LLM request to exceed 80% of 200k context
+        big_data = "x" * (200_000 * 4 * 4)  # way over threshold
+        ev = TraceEvent(
+            event_type=EventType.LLM_REQUEST,
+            timestamp=1.0,
+            session_id="s1",
+            data={"prompt": big_data},
+        )
+        results = _rule_context_saturation([ev], self._cfg())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].level, LintLevel.INFO)
+
+    def test_reports_only_once(self):
+        big_data = "x" * (200_000 * 4 * 4)
+        events = [
+            TraceEvent(event_type=EventType.LLM_REQUEST, timestamp=1.0,
+                       session_id="s1", data={"prompt": big_data}),
+            TraceEvent(event_type=EventType.LLM_REQUEST, timestamp=2.0,
+                       session_id="s1", data={"prompt": big_data}),
+        ]
+        results = _rule_context_saturation(events, self._cfg())
+        self.assertEqual(len(results), 1)
+
+
+# ---------------------------------------------------------------------------
+# Rule: redundant-read
+# ---------------------------------------------------------------------------
+
+class TestRuleRedundantRead(unittest.TestCase):
+    def _cfg(self, threshold=3):
+        return {"enabled": True, "level": LintLevel.INFO, "threshold": threshold}
+
+    def test_triggers_on_repeated_reads(self):
+        events = [
+            _tool_call("Read", file_path="README.md"),
+            _tool_call("Read", file_path="README.md"),
+            _tool_call("Read", file_path="README.md"),
+        ]
+        results = _rule_redundant_read(events, self._cfg())
+        self.assertEqual(len(results), 1)
+        self.assertIn("README.md", results[0].message)
+        self.assertIn("3", results[0].message)
+
+    def test_no_trigger_below_threshold(self):
+        events = [
+            _tool_call("Read", file_path="README.md"),
+            _tool_call("Read", file_path="README.md"),
+        ]
+        results = _rule_redundant_read(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_different_files_not_counted_together(self):
+        events = [
+            _tool_call("Read", file_path="a.py"),
+            _tool_call("Read", file_path="b.py"),
+            _tool_call("Read", file_path="c.py"),
+        ]
+        results = _rule_redundant_read(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_multiple_files_each_reported(self):
+        events = (
+            [_tool_call("Read", file_path="a.py")] * 3
+            + [_tool_call("Read", file_path="b.py")] * 3
+        )
+        results = _rule_redundant_read(events, self._cfg())
+        self.assertEqual(len(results), 2)
+
+
+# ---------------------------------------------------------------------------
+# Rule: error-retry-loop
+# ---------------------------------------------------------------------------
+
+class TestRuleErrorRetryLoop(unittest.TestCase):
+    def _cfg(self, threshold=3):
+        return {"enabled": True, "level": LintLevel.WARN, "threshold": threshold}
+
+    def test_triggers_on_repeated_errors(self):
+        events = [
+            _tool_call("Bash"),
+            _error("exit 1"),
+            _tool_call("Bash"),
+            _error("exit 1"),
+            _tool_call("Bash"),
+            _error("exit 1"),
+        ]
+        results = _rule_error_retry_loop(events, self._cfg())
+        self.assertEqual(len(results), 1)
+        self.assertIn("Bash", results[0].message)
+
+    def test_no_trigger_below_threshold(self):
+        events = [
+            _tool_call("Bash"),
+            _error("exit 1"),
+            _tool_call("Bash"),
+            _error("exit 1"),
+        ]
+        results = _rule_error_retry_loop(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_tool_result_is_error_counts(self):
+        events = [
+            _tool_call("Write"),
+            _tool_result(is_error=True),
+            _tool_call("Write"),
+            _tool_result(is_error=True),
+            _tool_call("Write"),
+            _tool_result(is_error=True),
+        ]
+        results = _rule_error_retry_loop(events, self._cfg())
+        self.assertEqual(len(results), 1)
+
+    def test_different_tools_counted_separately(self):
+        events = [
+            _tool_call("Bash"), _error(),
+            _tool_call("Read"), _error(),
+            _tool_call("Write"), _error(),
+        ]
+        results = _rule_error_retry_loop(events, self._cfg())
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Rule: no-output
+# ---------------------------------------------------------------------------
+
+class TestRuleNoOutput(unittest.TestCase):
+    def _cfg(self):
+        return {"enabled": True, "level": LintLevel.WARN}
+
+    def test_triggers_when_no_writes(self):
+        events = [_tool_call("Read", file_path="a.py"), _session_end()]
+        results = _rule_no_output(events, self._cfg())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].level, LintLevel.WARN)
+
+    def test_no_trigger_with_write_tool(self):
+        events = [_tool_call("Write", file_path="out.py"), _session_end()]
+        results = _rule_no_output(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_no_trigger_with_edit_tool(self):
+        events = [_tool_call("edit", file_path="a.py"), _session_end()]
+        results = _rule_no_output(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_no_trigger_without_session_end(self):
+        # Session still in progress — don't flag
+        events = [_tool_call("Read", file_path="a.py")]
+        results = _rule_no_output(events, self._cfg())
+        self.assertEqual(results, [])
+
+    def test_file_write_event_counts(self):
+        events = [
+            _ev(EventType.FILE_WRITE, path="out.txt"),
+            _session_end(),
+        ]
+        results = _rule_no_output(events, self._cfg())
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestLoadConfig(unittest.TestCase):
+    def test_defaults_returned_when_no_file(self):
+        config = _load_config(None)
+        self.assertIn("tool-loop", config)
+        self.assertTrue(config["tool-loop"]["enabled"])
+
+    def test_override_from_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"tool-loop": {"threshold": 99}}, f)
+            path = f.name
+        config = _load_config(path)
+        self.assertEqual(config["tool-loop"]["threshold"], 99)
+        # Other defaults preserved
+        self.assertTrue(config["tool-loop"]["enabled"])
+
+    def test_disable_rule_via_config(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"tool-loop": {"enabled": False}}, f)
+            path = f.name
+        config = _load_config(path)
+        self.assertFalse(config["tool-loop"]["enabled"])
+
+    def test_bad_config_file_falls_back_to_defaults(self):
+        config = _load_config("/nonexistent/path.json")
+        self.assertIn("tool-loop", config)
+
+
+# ---------------------------------------------------------------------------
+# lint_session integration
+# ---------------------------------------------------------------------------
+
+class TestLintSession(unittest.TestCase):
+    def test_clean_session_no_findings(self):
+        events = [
+            _tool_call("Read", file_path="a.py"),
+            _tool_call("Write", file_path="b.py"),
+            _session_end(),
+        ]
+        store, sid = _make_store_with_events(events)
+        report = lint_session(store, sid)
+        self.assertIsInstance(report, LintReport)
+        self.assertEqual(report.session_id, sid)
+        # no-output should not fire (Write present), no loops
+        self.assertEqual(report.errors, 0)
+        self.assertEqual(report.warnings, 0)
+
+    def test_tool_loop_detected(self):
+        events = [_tool_call("Bash")] * 7 + [_session_end()]
+        store, sid = _make_store_with_events(events)
+        report = lint_session(store, sid)
+        rules_fired = {f.rule for f in report.findings}
+        self.assertIn("tool-loop", rules_fired)
+
+    def test_no_output_detected(self):
+        events = [_tool_call("Read", file_path="a.py"), _session_end()]
+        store, sid = _make_store_with_events(events)
+        report = lint_session(store, sid)
+        rules_fired = {f.rule for f in report.findings}
+        self.assertIn("no-output", rules_fired)
+
+    def test_disabled_rule_not_run(self):
+        events = [_tool_call("Bash")] * 7 + [_session_end()]
+        store, sid = _make_store_with_events(events)
+        config = {k: dict(v) for k, v in DEFAULT_CONFIG.items()}
+        config["tool-loop"]["enabled"] = False
+        report = lint_session(store, sid, config=config)
+        rules_fired = {f.rule for f in report.findings}
+        self.assertNotIn("tool-loop", rules_fired)
+
+    def test_rule_failure_does_not_prevent_others(self):
+        """A rule that raises must not stop other rules from running."""
+        from agent_trace import lint as lint_mod
+        original = lint_mod._RULES.get("tool-loop")
+        try:
+            lint_mod._RULES["tool-loop"] = lambda events, cfg: (_ for _ in ()).throw(RuntimeError("boom"))
+            events = [_tool_call("Read", file_path="a.py"), _session_end()]
+            store, sid = _make_store_with_events(events)
+            report = lint_session(store, sid)
+            # no-output should still fire
+            rules_fired = {f.rule for f in report.findings}
+            self.assertIn("no-output", rules_fired)
+        finally:
+            if original:
+                lint_mod._RULES["tool-loop"] = original
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatReport(unittest.TestCase):
+    def test_clean_report_message(self):
+        import io
+        report = LintReport(session_id="abc123", findings=[])
+        out = io.StringIO()
+        format_report(report, out)
+        self.assertIn("No issues found", out.getvalue())
+
+    def test_findings_printed(self):
+        import io
+        report = LintReport(session_id="abc123", findings=[
+            LintResult(rule="tool-loop", level=LintLevel.WARN, message="Bash looped"),
+            LintResult(rule="no-output", level=LintLevel.WARN, message="No writes"),
+        ])
+        out = io.StringIO()
+        format_report(report, out)
+        text = out.getvalue()
+        self.assertIn("tool-loop", text)
+        self.assertIn("no-output", text)
+        self.assertIn("WARN", text)
+
+    def test_json_format(self):
+        report = LintReport(session_id="abc123", findings=[
+            LintResult(rule="tool-loop", level=LintLevel.ERROR, message="loop"),
+        ])
+        data = json.loads(format_report_json(report))
+        self.assertEqual(data["session_id"], "abc123")
+        self.assertEqual(data["errors"], 1)
+        self.assertEqual(len(data["findings"]), 1)
+        self.assertEqual(data["findings"][0]["rule"], "tool-loop")
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_lint
+# ---------------------------------------------------------------------------
+
+class TestCmdLint(unittest.TestCase):
+    def _make_args(self, store_dir, session_id=None, strict=False,
+                   fmt="text", lint_all=False, since=None, config=None):
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = store_dir
+        args.session_id = session_id
+        args.strict = strict
+        args.format = fmt
+        args.all = lint_all
+        args.since = since
+        args.config = config
+        return args
+
+    def test_returns_0_on_clean_session(self):
+        events = [_tool_call("Write", file_path="a.py"), _session_end()]
+        store, sid = _make_store_with_events(events)
+        args = self._make_args(store.base_dir, session_id=sid)
+        result = cmd_lint(args)
+        self.assertEqual(result, 0)
+
+    def test_returns_1_on_error_finding(self):
+        # Budget proximity triggers ERROR when budget is tiny
+        start = TraceEvent(
+            event_type=EventType.SESSION_START,
+            timestamp=1.0,
+            session_id="s1",
+            data={"budget_dollars": 0.000001},
+        )
+        events = [start] + [_llm_request()] * 100 + [_session_end()]
+        store, sid = _make_store_with_events(events)
+        args = self._make_args(store.base_dir, session_id=sid)
+        result = cmd_lint(args)
+        self.assertEqual(result, 1)
+
+    def test_strict_returns_1_on_warning(self):
+        events = [_tool_call("Bash")] * 7 + [_session_end()]
+        store, sid = _make_store_with_events(events)
+        args = self._make_args(store.base_dir, session_id=sid, strict=True)
+        result = cmd_lint(args)
+        self.assertEqual(result, 1)
+
+    def test_non_strict_returns_0_on_warning_only(self):
+        # Only warnings (tool-loop), no errors
+        events = [_tool_call("Bash")] * 7 + [_tool_call("Write", file_path="a.py"), _session_end()]
+        store, sid = _make_store_with_events(events)
+        args = self._make_args(store.base_dir, session_id=sid, strict=False)
+        result = cmd_lint(args)
+        self.assertEqual(result, 0)
+
+    def test_json_format_output(self):
+        import io
+        from unittest.mock import patch
+        events = [_tool_call("Bash")] * 7 + [_session_end()]
+        store, sid = _make_store_with_events(events)
+        args = self._make_args(store.base_dir, session_id=sid, fmt="json")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_lint(args)
+        data = json.loads(captured.getvalue())
+        self.assertIn("findings", data)
+        self.assertIn("session_id", data)
+
+    def test_all_flag_lints_multiple_sessions(self):
+        tmp = tempfile.mkdtemp()
+        store = TraceStore(Path(tmp))
+        for _ in range(3):
+            meta = SessionMeta(agent_name="test", command="test")
+            sp = store.create_session(meta)
+            sid = sp.name
+            e = TraceEvent(event_type=EventType.SESSION_END, timestamp=1.0,
+                           session_id=sid, data={})
+            store.append_event(sid, e)
+        args = self._make_args(store.base_dir, lint_all=True)
+        result = cmd_lint(args)
+        self.assertIn(result, (0, 1))  # just verify it runs without crash
+
+    def test_missing_session_returns_1(self):
+        import tempfile
+        tmp = tempfile.mkdtemp()
+        store = TraceStore(Path(tmp))
+        args = self._make_args(store.base_dir, session_id="nonexistent")
+        result = cmd_lint(args)
+        self.assertEqual(result, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements `agent-strace lint` (closes #116) — static behaviour analysis for agent sessions.

## What it does

Analyses a session's event stream and flags known bad patterns. Each rule is a pure function `(events, config) -> list[LintResult]`. Rules are independent — a failure in one never prevents others from running.

## Rules

| Rule | Level | Trigger |
|---|---|---|
| `tool-loop` | WARN | Same tool called 5+ times consecutively |
| `reasoning-spiral` | WARN | 3+ consecutive LLM calls with no tool call |
| `budget-proximity` | ERROR | Session cost exceeded 90% of watchdog budget ceiling |
| `context-saturation` | INFO | Input tokens exceeded 80% of model context window |
| `redundant-read` | INFO | Same file read 3+ times in a session |
| `error-retry-loop` | WARN | Same tool errored and retried 3+ times |
| `no-output` | WARN | Session completed with no write/file-modifying tool calls |

## CLI

```bash
agent-strace lint <session-id>
agent-strace lint --all --since 7d
agent-strace lint <session-id> --format json
agent-strace lint <session-id> --strict   # exit 1 on WARN or ERROR
```

## Changes

- `src/agent_trace/lint.py` — rule engine, 7 rules, config loading, formatting, CLI handler
- `src/agent_trace/cli.py` — `lint` subcommand registered
- `tests/test_lint.py` — 49 tests (each rule: trigger, non-trigger, edge case; config; CLI)
- `README.md` — lint section with example output, rule table, config format
- Version bumped to `0.47.0`
