### PR TITLE
feat(budget-report): add weekly spend digest command (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,48 @@ Supported models: `sonnet` (default), `opus`, `haiku`, `gpt4`, `gpt4o`. Token co
 
 See [examples/session_analysis.md](examples/session_analysis.md) for a full walkthrough combining `import`, `explain`, and `cost`.
 
+### Weekly spend digest (budget-report)
+
+Aggregate cost across sessions for a configurable time window. Shows total spend, top sessions, cost by tool, and savings from watchdog budget ceilings.
+
+```bash
+# Last 7 days (default)
+agent-strace budget-report
+
+# Custom window
+agent-strace budget-report --since 2026-05-01 --until 2026-05-23
+
+# Markdown output (paste into Slack or email)
+agent-strace budget-report --format markdown
+
+# Machine-readable JSON
+agent-strace budget-report --format json
+```
+
+Example output:
+
+```
+Budget Report — May 16 to May 23, 2026
+
+Total spend:        $47.23  (↑ 12% vs prior period)
+Sessions:           34      (↑ 3 vs prior period)
+Avg cost/session:   $1.39
+
+Top 5 most expensive sessions:
+  1. a84664242afa  $8.43  refactor-auth                   2026-05-21
+  2. bf1207728ee6  $6.21  add-test-coverage               2026-05-22
+  3. c91ab3312fde  $4.87  fix-login-bug  ⚠ watchdog       2026-05-20
+
+Cost by tool (estimated):
+  Bash                  $18.43  (39%)
+  Read                  $12.11  (26%)
+  Write                  $9.87  (21%)
+
+Sessions terminated by watchdog:  3  ($14.21 saved by budget ceiling)
+```
+
+Week-over-week delta is shown when prior-period data exists. The `--format markdown` output is designed to paste directly into Slack without editing.
+
 ### Static behaviour analysis (lint)
 
 Analyse a session for known bad patterns — tool loops, reasoning spirals, budget proximity, context saturation, redundant reads, error-retry loops, and sessions that produced no output.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/src/agent_trace/budget_report.py
+++ b/src/agent_trace/budget_report.py
@@ -1,0 +1,395 @@
+"""Weekly spend digest: agent-strace budget-report.
+
+Aggregates cost across sessions for a configurable time window and produces
+a human-readable or markdown-formatted spend summary. Reads watchdog
+post-mortem files to calculate budget-ceiling savings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time as _time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .cost import estimate_cost, DEFAULT_MODEL
+from .models import EventType, SessionMeta
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionSpend:
+    session_id: str
+    agent_name: str
+    started_at: float
+    cost: float
+    tool_breakdown: dict[str, float]   # tool_name -> estimated cost share
+    watchdog_terminated: bool = False
+    watchdog_budget: float | None = None   # budget ceiling at time of kill
+
+
+@dataclass
+class BudgetReport:
+    window_start: float
+    window_end: float
+    sessions: list[SessionSpend]
+    # Prior-window data for week-over-week comparison (may be empty)
+    prior_sessions: list[SessionSpend] = field(default_factory=list)
+
+    @property
+    def total_cost(self) -> float:
+        return sum(s.cost for s in self.sessions)
+
+    @property
+    def prior_total_cost(self) -> float:
+        return sum(s.cost for s in self.prior_sessions)
+
+    @property
+    def session_count(self) -> int:
+        return len(self.sessions)
+
+    @property
+    def prior_session_count(self) -> int:
+        return len(self.prior_sessions)
+
+    @property
+    def avg_cost(self) -> float:
+        return self.total_cost / max(1, self.session_count)
+
+    @property
+    def watchdog_terminated_sessions(self) -> list[SessionSpend]:
+        return [s for s in self.sessions if s.watchdog_terminated]
+
+    @property
+    def watchdog_savings(self) -> float:
+        """Estimated savings from watchdog budget ceilings."""
+        total = 0.0
+        for s in self.watchdog_terminated_sessions:
+            if s.watchdog_budget is not None and s.cost < s.watchdog_budget:
+                total += s.watchdog_budget - s.cost
+        return total
+
+    @property
+    def tool_totals(self) -> dict[str, float]:
+        """Aggregate cost by tool across all sessions."""
+        totals: dict[str, float] = {}
+        for s in self.sessions:
+            for tool, cost in s.tool_breakdown.items():
+                totals[tool] = totals.get(tool, 0.0) + cost
+        return dict(sorted(totals.items(), key=lambda x: x[1], reverse=True))
+
+    @property
+    def top_sessions(self) -> list[SessionSpend]:
+        return sorted(self.sessions, key=lambda s: s.cost, reverse=True)[:5]
+
+
+# ---------------------------------------------------------------------------
+# Post-mortem reading
+# ---------------------------------------------------------------------------
+
+def _read_postmortem(store: TraceStore, session_id: str) -> dict | None:
+    """Read watchdog post-mortem JSON for a session, or None if absent."""
+    pm_path = store._session_dir(session_id) / "watchdog-postmortem.json"
+    if not pm_path.exists():
+        return None
+    try:
+        return json.loads(pm_path.read_text())
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tool cost breakdown
+# ---------------------------------------------------------------------------
+
+_TOOL_COST_FRACTION = 0.30  # rough: ~30% of session cost attributable to tool calls
+
+
+def _tool_breakdown(store: TraceStore, session_id: str, total_cost: float) -> dict[str, float]:
+    """Estimate cost share per tool based on event count."""
+    try:
+        events = store.load_events(session_id)
+    except Exception:
+        return {}
+
+    tool_counts: dict[str, int] = {}
+    for ev in events:
+        if ev.event_type == EventType.TOOL_CALL:
+            tool = ev.data.get("tool_name", "unknown")
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+
+    total_calls = sum(tool_counts.values())
+    if not total_calls:
+        return {}
+
+    tool_cost_pool = total_cost * _TOOL_COST_FRACTION
+    return {
+        tool: (count / total_calls) * tool_cost_pool
+        for tool, count in tool_counts.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core report builder
+# ---------------------------------------------------------------------------
+
+def build_report(
+    store: TraceStore,
+    window_start: float,
+    window_end: float,
+    include_prior: bool = True,
+) -> BudgetReport:
+    """Build a BudgetReport for the given time window."""
+    all_sessions = store.list_sessions()
+
+    window_sessions: list[SessionSpend] = []
+    prior_sessions: list[SessionSpend] = []
+
+    window_size = window_end - window_start
+    prior_start = window_start - window_size
+    prior_end = window_start
+
+    for meta in all_sessions:
+        in_window = window_start <= meta.started_at < window_end
+        in_prior = include_prior and (prior_start <= meta.started_at < prior_end)
+
+        if not in_window and not in_prior:
+            continue
+
+        # Estimate cost
+        try:
+            cost_result = estimate_cost(store, meta.session_id)
+            cost = cost_result.total_cost
+        except Exception:
+            cost = 0.0
+
+        # Check for watchdog termination
+        pm = _read_postmortem(store, meta.session_id)
+        watchdog_terminated = pm is not None
+        watchdog_budget: float | None = None
+        if pm:
+            # Extract budget from post-mortem or session meta
+            watchdog_budget = pm.get("budget_at_death") or pm.get("max_cost_dollars")
+
+        breakdown = _tool_breakdown(store, meta.session_id, cost)
+
+        spend = SessionSpend(
+            session_id=meta.session_id,
+            agent_name=meta.agent_name or meta.command or "",
+            started_at=meta.started_at,
+            cost=cost,
+            tool_breakdown=breakdown,
+            watchdog_terminated=watchdog_terminated,
+            watchdog_budget=watchdog_budget,
+        )
+
+        if in_window:
+            window_sessions.append(spend)
+        elif in_prior:
+            prior_sessions.append(spend)
+
+    return BudgetReport(
+        window_start=window_start,
+        window_end=window_end,
+        sessions=window_sessions,
+        prior_sessions=prior_sessions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_date(ts: float) -> str:
+    import datetime
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+
+def _fmt_delta(current: float, prior: float, higher_is_worse: bool = True) -> str:
+    """Format a week-over-week delta string."""
+    if prior == 0:
+        return ""
+    pct = (current - prior) / prior * 100
+    if abs(pct) < 1:
+        return "(≈ same)"
+    arrow = "↑" if pct > 0 else "↓"
+    direction = "worse" if (pct > 0) == higher_is_worse else "better"
+    return f"({arrow} {abs(pct):.0f}% vs prior period)"
+
+
+def format_report_text(report: BudgetReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    start = _fmt_date(report.window_start)
+    end = _fmt_date(report.window_end)
+    w(f"Budget Report — {start} to {end}\n\n")
+
+    if not report.sessions:
+        w("No sessions in this period.\n")
+        return
+
+    has_prior = bool(report.prior_sessions)
+
+    # Summary
+    cost_delta = _fmt_delta(report.total_cost, report.prior_total_cost) if has_prior else ""
+    count_delta = _fmt_delta(report.session_count, report.prior_session_count) if has_prior else ""
+
+    w(f"Total spend:        ${report.total_cost:.2f}  {cost_delta}\n")
+    w(f"Sessions:           {report.session_count}      {count_delta}\n")
+    w(f"Avg cost/session:   ${report.avg_cost:.2f}\n")
+    w("\n")
+
+    # Top sessions
+    top = report.top_sessions
+    w(f"Top {len(top)} most expensive sessions:\n")
+    for i, s in enumerate(top, 1):
+        tag = "  ⚠ watchdog" if s.watchdog_terminated else ""
+        name = (s.agent_name or s.session_id[:12])[:30]
+        w(f"  {i}. {s.session_id[:12]}  ${s.cost:.2f}  {name:<30}  {_fmt_date(s.started_at)}{tag}\n")
+    w("\n")
+
+    # Cost by tool
+    tool_totals = report.tool_totals
+    if tool_totals:
+        w("Cost by tool (estimated):\n")
+        total_tool_cost = sum(tool_totals.values()) or 1e-9
+        for tool, cost in list(tool_totals.items())[:8]:
+            pct = cost / report.total_cost * 100
+            w(f"  {tool:<20}  ${cost:.2f}  ({pct:.0f}%)\n")
+        w("\n")
+
+    # Watchdog savings
+    terminated = report.watchdog_terminated_sessions
+    if terminated:
+        w(f"Sessions terminated by watchdog:  {len(terminated)}")
+        savings = report.watchdog_savings
+        if savings > 0:
+            w(f"  (${savings:.2f} saved by budget ceiling)")
+        w("\n")
+
+
+def format_report_markdown(report: BudgetReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    start = _fmt_date(report.window_start)
+    end = _fmt_date(report.window_end)
+    w(f"## Budget Report — {start} to {end}\n\n")
+
+    if not report.sessions:
+        w("_No sessions in this period._\n")
+        return
+
+    has_prior = bool(report.prior_sessions)
+    cost_delta = _fmt_delta(report.total_cost, report.prior_total_cost) if has_prior else ""
+    count_delta = _fmt_delta(report.session_count, report.prior_session_count) if has_prior else ""
+
+    w(f"**Total spend:** ${report.total_cost:.2f} {cost_delta}  \n")
+    w(f"**Sessions:** {report.session_count} {count_delta}  \n")
+    w(f"**Avg cost/session:** ${report.avg_cost:.2f}\n\n")
+
+    # Top sessions table
+    w(f"### Top {len(report.top_sessions)} sessions\n\n")
+    w("| # | Session | Cost | Name | Date |\n")
+    w("|---|---------|------|------|------|\n")
+    for i, s in enumerate(report.top_sessions, 1):
+        tag = " ⚠" if s.watchdog_terminated else ""
+        name = (s.agent_name or s.session_id[:12])[:30]
+        w(f"| {i} | `{s.session_id[:12]}` | ${s.cost:.2f}{tag} | {name} | {_fmt_date(s.started_at)} |\n")
+    w("\n")
+
+    # Cost by tool
+    tool_totals = report.tool_totals
+    if tool_totals:
+        w("### Cost by tool\n\n")
+        w("| Tool | Cost | % |\n")
+        w("|------|------|---|\n")
+        for tool, cost in list(tool_totals.items())[:8]:
+            pct = cost / report.total_cost * 100
+            w(f"| {tool} | ${cost:.2f} | {pct:.0f}% |\n")
+        w("\n")
+
+    # Watchdog
+    terminated = report.watchdog_terminated_sessions
+    if terminated:
+        savings = report.watchdog_savings
+        savings_str = f" (${savings:.2f} saved by budget ceiling)" if savings > 0 else ""
+        w(f"**Sessions terminated by watchdog:** {len(terminated)}{savings_str}\n")
+
+
+def format_report_json(report: BudgetReport) -> str:
+    return json.dumps({
+        "window_start": report.window_start,
+        "window_end": report.window_end,
+        "total_cost": report.total_cost,
+        "session_count": report.session_count,
+        "avg_cost": report.avg_cost,
+        "prior_total_cost": report.prior_total_cost,
+        "prior_session_count": report.prior_session_count,
+        "watchdog_terminated": len(report.watchdog_terminated_sessions),
+        "watchdog_savings": report.watchdog_savings,
+        "top_sessions": [
+            {
+                "session_id": s.session_id,
+                "agent_name": s.agent_name,
+                "started_at": s.started_at,
+                "cost": s.cost,
+                "watchdog_terminated": s.watchdog_terminated,
+            }
+            for s in report.top_sessions
+        ],
+        "tool_totals": report.tool_totals,
+    }, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Date parsing helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date(s: str) -> float:
+    """Parse ISO date string or relative duration (7d, 24h) to Unix timestamp."""
+    s = s.strip()
+    multipliers = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+    if s and s[-1] in multipliers:
+        try:
+            return _time.time() - float(s[:-1]) * multipliers[s[-1]]
+        except ValueError:
+            pass
+    import datetime
+    try:
+        dt = datetime.datetime.fromisoformat(s)
+        return dt.timestamp()
+    except ValueError:
+        raise ValueError(f"Cannot parse date: {s!r}. Use ISO format (2026-05-01) or duration (7d).")
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_budget_report(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    fmt = getattr(args, "format", "text")
+
+    # Time window
+    since_str = getattr(args, "since", None)
+    until_str = getattr(args, "until", None)
+
+    now = _time.time()
+    window_end = _parse_date(until_str) if until_str else now
+    window_start = _parse_date(since_str) if since_str else (window_end - 7 * 86400)
+
+    report = build_report(store, window_start, window_end)
+
+    if fmt == "json":
+        sys.stdout.write(format_report_json(report) + "\n")
+    elif fmt == "markdown":
+        format_report_markdown(report, sys.stdout)
+    else:
+        format_report_text(report, sys.stdout)
+
+    return 0

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -47,6 +47,7 @@ from .share import cmd_share
 from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
+from .budget_report import cmd_budget_report
 from .lint import cmd_lint
 from .retention import cmd_retention
 from .sample import cmd_sample
@@ -881,6 +882,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_sample.add_argument("--seed", type=int, default=None,
                           help="random seed for reproducible random sampling")
 
+    # budget-report
+    p_budget = sub.add_parser("budget-report", help="weekly spend digest across sessions")
+    p_budget.add_argument("--since", metavar="DATE",
+                          help="start of window (ISO date or duration like 7d; default: 7 days ago)")
+    p_budget.add_argument("--until", metavar="DATE",
+                          help="end of window (ISO date; default: now)")
+    p_budget.add_argument("--format", choices=["text", "markdown", "json"], default="text",
+                          dest="format", help="output format (default: text)")
+    p_budget.add_argument("--endpoint", metavar="URL",
+                          help="remote collector endpoint (not yet implemented)")
+
     # lint
     p_lint = sub.add_parser("lint", help="analyse a session for bad behaviour patterns")
     p_lint.add_argument("session_id", nargs="?",
@@ -1021,6 +1033,7 @@ def main() -> None:
         "standup": cmd_standup,
         "mcp": cmd_mcp,
         "auto": cmd_auto,
+        "budget-report": cmd_budget_report,
         "lint": cmd_lint,
         "retention": cmd_retention,
         "sample": cmd_sample,

--- a/tests/test_budget_report.py
+++ b/tests/test_budget_report.py
@@ -1,0 +1,395 @@
+"""Tests for agent-strace budget-report (Issue #115)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from agent_trace.budget_report import (
+    BudgetReport,
+    SessionSpend,
+    build_report,
+    format_report_json,
+    format_report_markdown,
+    format_report_text,
+    cmd_budget_report,
+    _parse_date,
+    _read_postmortem,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmp = tempfile.mkdtemp()
+    return TraceStore(Path(tmp)), tmp
+
+
+def _add_session(store: TraceStore, started_at: float, agent_name: str = "test",
+                 tool_calls: list[str] | None = None,
+                 with_postmortem: bool = False,
+                 budget: float | None = None) -> str:
+    meta = SessionMeta(agent_name=agent_name, command="test")
+    meta.started_at = started_at
+    sp = store.create_session(meta)
+    sid = sp.name
+    # Fix the started_at in meta.json (create_session uses default_factory)
+    meta2 = store.load_meta(sid)
+    meta2.started_at = started_at
+    store.update_meta(meta2)
+
+    # Add some events
+    events = [
+        TraceEvent(event_type=EventType.SESSION_START, timestamp=started_at,
+                   session_id=sid, data={}),
+    ]
+    for tool in (tool_calls or ["Read", "Write"]):
+        events.append(TraceEvent(event_type=EventType.TOOL_CALL, timestamp=started_at + 1,
+                                 session_id=sid, data={"tool_name": tool}))
+    events.append(TraceEvent(event_type=EventType.SESSION_END, timestamp=started_at + 60,
+                             session_id=sid, data={}))
+    for e in events:
+        store.append_event(sid, e)
+
+    if with_postmortem:
+        pm = {
+            "session_id": sid,
+            "reason": "budget_exceeded",
+            "elapsed_seconds": 60.0,
+            "cost_at_death": 4.50,
+            "max_cost_dollars": budget or 5.0,
+        }
+        (store._session_dir(sid) / "watchdog-postmortem.json").write_text(json.dumps(pm))
+
+    return sid
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+class TestParseDate(unittest.TestCase):
+    def test_iso_date(self):
+        ts = _parse_date("2026-01-01")
+        self.assertIsInstance(ts, float)
+        self.assertGreater(ts, 0)
+
+    def test_days_duration(self):
+        before = time.time()
+        ts = _parse_date("7d")
+        after = time.time()
+        self.assertAlmostEqual(ts, before - 7 * 86400, delta=5)
+
+    def test_hours_duration(self):
+        ts = _parse_date("24h")
+        self.assertAlmostEqual(ts, time.time() - 24 * 3600, delta=5)
+
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_date("not-a-date")
+
+
+# ---------------------------------------------------------------------------
+# _read_postmortem
+# ---------------------------------------------------------------------------
+
+class TestReadPostmortem(unittest.TestCase):
+    def test_returns_none_when_absent(self):
+        store, _ = _make_store()
+        meta = SessionMeta(agent_name="t", command="t")
+        sp = store.create_session(meta)
+        sid = sp.name
+        self.assertIsNone(_read_postmortem(store, sid))
+
+    def test_returns_dict_when_present(self):
+        store, _ = _make_store()
+        meta = SessionMeta(agent_name="t", command="t")
+        sp = store.create_session(meta)
+        sid = sp.name
+        pm = {"reason": "budget_exceeded", "cost_at_death": 3.0}
+        (store._session_dir(sid) / "watchdog-postmortem.json").write_text(json.dumps(pm))
+        result = _read_postmortem(store, sid)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["reason"], "budget_exceeded")
+
+    def test_returns_none_on_corrupt_json(self):
+        store, _ = _make_store()
+        meta = SessionMeta(agent_name="t", command="t")
+        sp = store.create_session(meta)
+        sid = sp.name
+        (store._session_dir(sid) / "watchdog-postmortem.json").write_text("not json{{{")
+        self.assertIsNone(_read_postmortem(store, sid))
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+class TestBuildReport(unittest.TestCase):
+    def test_empty_store(self):
+        store, _ = _make_store()
+        now = time.time()
+        report = build_report(store, now - 7 * 86400, now)
+        self.assertEqual(report.session_count, 0)
+        self.assertEqual(report.total_cost, 0.0)
+
+    def test_sessions_in_window_included(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3 * 86400)  # 3 days ago — in window
+        _add_session(store, now - 10 * 86400)  # 10 days ago — outside window
+        report = build_report(store, now - 7 * 86400, now)
+        self.assertEqual(report.session_count, 1)
+
+    def test_sessions_outside_window_excluded(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 10 * 86400)
+        report = build_report(store, now - 7 * 86400, now)
+        self.assertEqual(report.session_count, 0)
+
+    def test_prior_window_populated(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3 * 86400)   # current window
+        _add_session(store, now - 10 * 86400)  # prior window (7–14 days ago)
+        report = build_report(store, now - 7 * 86400, now, include_prior=True)
+        self.assertEqual(report.session_count, 1)
+        self.assertEqual(report.prior_session_count, 1)
+
+    def test_watchdog_terminated_detected(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400, with_postmortem=True, budget=5.0)
+        report = build_report(store, now - 7 * 86400, now)
+        self.assertEqual(len(report.watchdog_terminated_sessions), 1)
+
+    def test_watchdog_savings_calculated(self):
+        store, _ = _make_store()
+        now = time.time()
+        # Post-mortem says cost_at_death=4.50, budget=5.0 → savings=0.50
+        _add_session(store, now - 1 * 86400, with_postmortem=True, budget=5.0)
+        report = build_report(store, now - 7 * 86400, now)
+        # Savings = budget - actual_cost (actual cost from estimate_cost, not pm)
+        # Just verify it's non-negative
+        self.assertGreaterEqual(report.watchdog_savings, 0.0)
+
+    def test_tool_totals_aggregated(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400, tool_calls=["Bash", "Bash", "Read"])
+        report = build_report(store, now - 7 * 86400, now)
+        # Tool totals should have Bash and Read
+        totals = report.tool_totals
+        self.assertIn("Bash", totals)
+        self.assertIn("Read", totals)
+
+    def test_top_sessions_sorted_by_cost(self):
+        store, _ = _make_store()
+        now = time.time()
+        for i in range(6):
+            _add_session(store, now - i * 3600)
+        report = build_report(store, now - 7 * 86400, now)
+        top = report.top_sessions
+        self.assertLessEqual(len(top), 5)
+        # Verify descending order
+        for i in range(len(top) - 1):
+            self.assertGreaterEqual(top[i].cost, top[i + 1].cost)
+
+    def test_multiple_sessions_cost_summed(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        _add_session(store, now - 2 * 86400)
+        _add_session(store, now - 3 * 86400)
+        report = build_report(store, now - 7 * 86400, now)
+        self.assertEqual(report.session_count, 3)
+        self.assertAlmostEqual(report.total_cost, sum(s.cost for s in report.sessions))
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatReportText(unittest.TestCase):
+    def _make_report(self, n_sessions=2, with_watchdog=False):
+        store, _ = _make_store()
+        now = time.time()
+        for i in range(n_sessions):
+            # Use (i+1)*3600 so all sessions are strictly before window_end=now
+            _add_session(store, now - (i + 1) * 3600,
+                         with_postmortem=(with_watchdog and i == 0), budget=5.0)
+        return build_report(store, now - 7 * 86400, now)
+
+    def test_empty_report(self):
+        import io
+        store, _ = _make_store()
+        now = time.time()
+        report = build_report(store, now - 7 * 86400, now)
+        out = io.StringIO()
+        format_report_text(report, out)
+        self.assertIn("No sessions", out.getvalue())
+
+    def test_contains_total_spend(self):
+        import io
+        report = self._make_report(2)
+        out = io.StringIO()
+        format_report_text(report, out)
+        self.assertIn("Total spend", out.getvalue())
+
+    def test_contains_session_count(self):
+        import io
+        report = self._make_report(3)
+        out = io.StringIO()
+        format_report_text(report, out)
+        self.assertIn("Sessions:", out.getvalue())
+
+    def test_watchdog_line_shown(self):
+        import io
+        report = self._make_report(2, with_watchdog=True)
+        out = io.StringIO()
+        format_report_text(report, out)
+        self.assertIn("watchdog", out.getvalue())
+
+    def test_week_over_week_delta_shown(self):
+        import io
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3 * 86400)   # current
+        _add_session(store, now - 10 * 86400)  # prior
+        report = build_report(store, now - 7 * 86400, now)
+        out = io.StringIO()
+        format_report_text(report, out)
+        text = out.getvalue()
+        # Delta indicator should appear
+        self.assertTrue("↑" in text or "↓" in text or "≈" in text)
+
+
+class TestFormatReportMarkdown(unittest.TestCase):
+    def test_markdown_headers(self):
+        import io
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        report = build_report(store, now - 7 * 86400, now)
+        out = io.StringIO()
+        format_report_markdown(report, out)
+        text = out.getvalue()
+        self.assertIn("## Budget Report", text)
+        self.assertIn("### Top", text)
+
+    def test_markdown_table_format(self):
+        import io
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        report = build_report(store, now - 7 * 86400, now)
+        out = io.StringIO()
+        format_report_markdown(report, out)
+        text = out.getvalue()
+        self.assertIn("|", text)  # table rows
+
+    def test_markdown_empty(self):
+        import io
+        store, _ = _make_store()
+        now = time.time()
+        report = build_report(store, now - 7 * 86400, now)
+        out = io.StringIO()
+        format_report_markdown(report, out)
+        self.assertIn("No sessions", out.getvalue())
+
+
+class TestFormatReportJson(unittest.TestCase):
+    def test_json_structure(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        report = build_report(store, now - 7 * 86400, now)
+        data = json.loads(format_report_json(report))
+        self.assertIn("total_cost", data)
+        self.assertIn("session_count", data)
+        self.assertIn("top_sessions", data)
+        self.assertIn("tool_totals", data)
+        self.assertIn("watchdog_savings", data)
+
+    def test_json_empty_report(self):
+        store, _ = _make_store()
+        now = time.time()
+        report = build_report(store, now - 7 * 86400, now)
+        data = json.loads(format_report_json(report))
+        self.assertEqual(data["session_count"], 0)
+        self.assertEqual(data["total_cost"], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_budget_report
+# ---------------------------------------------------------------------------
+
+class TestCmdBudgetReport(unittest.TestCase):
+    def _args(self, store_dir, fmt="text", since=None, until=None):
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = store_dir
+        args.format = fmt
+        args.since = since
+        args.until = until
+        args.endpoint = None
+        return args
+
+    def test_returns_0_on_empty_store(self):
+        store, _ = _make_store()
+        args = self._args(store.base_dir)
+        result = cmd_budget_report(args)
+        self.assertEqual(result, 0)
+
+    def test_returns_0_with_sessions(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        args = self._args(store.base_dir)
+        result = cmd_budget_report(args)
+        self.assertEqual(result, 0)
+
+    def test_json_format(self):
+        import io
+        from unittest.mock import patch
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        args = self._args(store.base_dir, fmt="json")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_budget_report(args)
+        data = json.loads(captured.getvalue())
+        self.assertIn("total_cost", data)
+
+    def test_markdown_format(self):
+        import io
+        from unittest.mock import patch
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 1 * 86400)
+        args = self._args(store.base_dir, fmt="markdown")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_budget_report(args)
+        self.assertIn("## Budget Report", captured.getvalue())
+
+    def test_custom_since_until(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3 * 86400)
+        args = self._args(store.base_dir, since="7d", until="1d")
+        result = cmd_budget_report(args)
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements `agent-strace budget-report` (closes #115) — a cross-session spend digest for a configurable time window.

## What it does

- Aggregates cost across all sessions in the window using existing `cost.py` logic
- Shows total spend, session count, avg cost with week-over-week delta (when prior-period data exists)
- Top 5 most expensive sessions with watchdog-terminated indicator
- Cost breakdown by tool (estimated from tool call frequency)
- Watchdog savings: reads `watchdog-postmortem.json` files to show dollar value of budget ceilings

## CLI

```bash
agent-strace budget-report                          # last 7 days
agent-strace budget-report --since 2026-05-01       # custom start
agent-strace budget-report --format markdown        # Slack-ready output
agent-strace budget-report --format json            # machine-readable
```

## Changes

- `src/agent_trace/budget_report.py` — `build_report()`, three formatters, `cmd_budget_report`
- `src/agent_trace/cli.py` — `budget-report` subcommand registered
- `tests/test_budget_report.py` — 31 tests (windowing, watchdog detection, all formats, CLI)
- `README.md` — budget-report section with example output
- Version bumped to `0.48.0`
