### PR TITLE
feat(compare): add session regression testing command (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,40 @@ Supported models: `sonnet` (default), `opus`, `haiku`, `gpt4`, `gpt4o`. Token co
 
 See [examples/session_analysis.md](examples/session_analysis.md) for a full walkthrough combining `import`, `explain`, and `cost`.
 
+### Session regression testing (compare)
+
+Compare two sessions structurally and get a verdict on whether agent behaviour improved or regressed. Useful when changing models, prompts, or tool implementations.
+
+```bash
+# Compare two existing sessions
+agent-strace compare <session-id-a> <session-id-b>
+
+# Compare the last 2 sessions with a given task tag
+agent-strace compare --tag refactor-auth
+
+# Machine-readable output
+agent-strace compare <session-id-a> <session-id-b> --format json
+```
+
+Example output:
+
+```
+Session Comparison
+─────────────────────────────────────────────────────────────────
+                                 a84664242afa    bf1207728ee6    change
+─────────────────────────────────────────────────────────────────
+  Duration                              18m 00s         12m 00s     -33%
+  Total cost                            $4.2300         $2.8700     -32%
+  Tool calls                                 14              11     -21%
+  Files modified                              2               2    (same)
+  Errors                                      0               0
+─────────────────────────────────────────────────────────────────
+Verdict: bf1207728ee6 was 32% cheaper, 33% faster
+Decision divergence:  2 point(s)
+```
+
+`decision divergence` is the edit distance between the two sessions' decision event sequences — no LLM call required. `--tag` compares the last N sessions whose `agent_name` or `command` contains the tag string.
+
 ### Weekly spend digest (budget-report)
 
 Aggregate cost across sessions for a configurable time window. Shows total spend, top sessions, cost by tool, and savings from watchdog budget ceilings.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -48,6 +48,7 @@ from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
+from .compare import cmd_compare
 from .lint import cmd_lint
 from .retention import cmd_retention
 from .sample import cmd_sample
@@ -882,6 +883,23 @@ def build_parser() -> argparse.ArgumentParser:
     p_sample.add_argument("--seed", type=int, default=None,
                           help="random seed for reproducible random sampling")
 
+    # compare
+    p_compare = sub.add_parser("compare", help="session-to-session regression report")
+    p_compare.add_argument("session_id_a", nargs="?",
+                           help="first session ID (baseline)")
+    p_compare.add_argument("session_id_b", nargs="?",
+                           help="second session ID (candidate)")
+    p_compare.add_argument("--rerun", action="store_true",
+                           help="re-run the original prompt and compare live")
+    p_compare.add_argument("--model", metavar="MODEL",
+                           help="model to use for --rerun")
+    p_compare.add_argument("--tag", metavar="TAG",
+                           help="compare the last N sessions matching this tag")
+    p_compare.add_argument("--last", type=int, default=2, metavar="N",
+                           help="number of tagged sessions to compare (default: 2)")
+    p_compare.add_argument("--format", choices=["text", "json"], default="text",
+                           dest="format", help="output format (default: text)")
+
     # budget-report
     p_budget = sub.add_parser("budget-report", help="weekly spend digest across sessions")
     p_budget.add_argument("--since", metavar="DATE",
@@ -1034,6 +1052,7 @@ def main() -> None:
         "mcp": cmd_mcp,
         "auto": cmd_auto,
         "budget-report": cmd_budget_report,
+        "compare": cmd_compare,
         "lint": cmd_lint,
         "retention": cmd_retention,
         "sample": cmd_sample,

--- a/src/agent_trace/compare.py
+++ b/src/agent_trace/compare.py
@@ -1,0 +1,229 @@
+"""Session-to-session regression testing: agent-strace compare.
+
+Wraps diff.compare_sessions with a first-class CLI workflow for regression
+testing: compare two sessions directly, compare the last N sessions with a
+given tag, or re-run a session's original prompt and compare live.
+
+Decision divergence is computed as edit distance on decision event text —
+no LLM call required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from typing import TextIO
+
+from .diff import compare_sessions, format_compare, CompareReport
+from .models import EventType, SessionMeta
+from .store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Decision divergence (edit distance on decision text)
+# ---------------------------------------------------------------------------
+
+def _decision_texts(store: TraceStore, session_id: str) -> list[str]:
+    """Extract decision event text from a session."""
+    try:
+        events = store.load_events(session_id)
+    except Exception:
+        return []
+    texts: list[str] = []
+    for ev in events:
+        if ev.event_type == EventType.DECISION:
+            text = (
+                ev.data.get("text")
+                or ev.data.get("content")
+                or ev.data.get("reasoning")
+                or ""
+            )
+            if text:
+                texts.append(str(text))
+    return texts
+
+
+def _edit_distance(a: list[str], b: list[str]) -> int:
+    """Levenshtein distance between two lists of strings (token-level)."""
+    m, n = len(a), len(b)
+    if m == 0:
+        return n
+    if n == 0:
+        return m
+    dp = list(range(n + 1))
+    for i in range(1, m + 1):
+        prev = dp[0]
+        dp[0] = i
+        for j in range(1, n + 1):
+            temp = dp[j]
+            if a[i - 1] == b[j - 1]:
+                dp[j] = prev
+            else:
+                dp[j] = 1 + min(prev, dp[j], dp[j - 1])
+            prev = temp
+    return dp[n]
+
+
+def decision_divergence(store: TraceStore, session_a: str, session_b: str) -> int:
+    """Number of decision events where reasoning text differs significantly."""
+    texts_a = _decision_texts(store, session_a)
+    texts_b = _decision_texts(store, session_b)
+    return _edit_distance(texts_a, texts_b)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation of CompareReport
+# ---------------------------------------------------------------------------
+
+def _report_to_dict(report: CompareReport, divergence: int) -> dict:
+    return {
+        "session_a": report.session_a,
+        "session_b": report.session_b,
+        "label_a": report.label_a,
+        "label_b": report.label_b,
+        "duration_a": report.duration_a,
+        "duration_b": report.duration_b,
+        "cost_a": report.cost_a,
+        "cost_b": report.cost_b,
+        "tool_calls_a": report.tool_calls_a,
+        "tool_calls_b": report.tool_calls_b,
+        "files_modified_a": report.files_modified_a,
+        "files_modified_b": report.files_modified_b,
+        "errors_a": report.errors_a,
+        "errors_b": report.errors_b,
+        "redundant_reads_a": report.redundant_reads_a,
+        "redundant_reads_b": report.redundant_reads_b,
+        "decision_divergence": divergence,
+        "divergence_points": [
+            {"step": step, "description_a": da, "description_b": db}
+            for step, da, db in report.divergence_points
+        ],
+        "verdict": report.verdict,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tag-based session lookup
+# ---------------------------------------------------------------------------
+
+def _sessions_by_tag(store: TraceStore, tag: str, last: int = 2) -> list[str]:
+    """Return the last N session IDs whose agent_name or command contains tag."""
+    all_sessions = store.list_sessions()
+    matched = [
+        s for s in all_sessions
+        if tag.lower() in (s.agent_name or "").lower()
+        or tag.lower() in (s.command or "").lower()
+    ]
+    # list_sessions returns newest-first
+    return [s.session_id for s in matched[:last]]
+
+
+# ---------------------------------------------------------------------------
+# --rerun support
+# ---------------------------------------------------------------------------
+
+def _get_user_prompt(store: TraceStore, session_id: str) -> str | None:
+    """Extract the original user prompt from a session's events."""
+    try:
+        events = store.load_events(session_id)
+    except Exception:
+        return None
+    for ev in events:
+        if ev.event_type == EventType.USER_PROMPT:
+            return (
+                ev.data.get("content")
+                or ev.data.get("text")
+                or ev.data.get("prompt")
+                or None
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    fmt = getattr(args, "format", "text")
+    tag = getattr(args, "tag", None)
+    last = getattr(args, "last", 2)
+    rerun = getattr(args, "rerun", False)
+    model = getattr(args, "model", None)
+
+    # Resolve the two session IDs
+    session_a: str | None = None
+    session_b: str | None = None
+
+    if tag:
+        ids = _sessions_by_tag(store, tag, last=last)
+        if len(ids) < 2:
+            sys.stderr.write(
+                f"Need at least 2 sessions tagged {tag!r}, found {len(ids)}.\n"
+            )
+            return 1
+        session_a, session_b = ids[1], ids[0]  # older first, newer second
+
+    else:
+        raw_a = getattr(args, "session_id_a", None)
+        raw_b = getattr(args, "session_id_b", None)
+
+        if not raw_a:
+            sys.stderr.write(
+                "Usage: agent-strace compare <session-id-a> <session-id-b>\n"
+                "       agent-strace compare <session-id> --rerun [--model MODEL]\n"
+                "       agent-strace compare --tag TAG [--last N]\n"
+            )
+            return 1
+
+        full_a = store.find_session(raw_a)
+        if not full_a:
+            sys.stderr.write(f"Session not found: {raw_a}\n")
+            return 1
+        session_a = full_a
+
+        if rerun:
+            # --rerun: re-execute the original prompt and compare live
+            prompt = _get_user_prompt(store, session_a)
+            if not prompt:
+                sys.stderr.write(
+                    f"Session {session_a[:12]} has no stored user_prompt. "
+                    "Cannot --rerun without a recorded prompt.\n"
+                )
+                return 1
+            sys.stderr.write(
+                f"[compare] --rerun is not yet automated. "
+                f"Original prompt for {session_a[:12]}:\n\n{prompt}\n\n"
+                "Run the agent with this prompt, then compare the two sessions manually.\n"
+            )
+            return 1
+
+        if not raw_b:
+            sys.stderr.write("Provide two session IDs or use --tag / --rerun.\n")
+            return 1
+
+        full_b = store.find_session(raw_b)
+        if not full_b:
+            sys.stderr.write(f"Session not found: {raw_b}\n")
+            return 1
+        session_b = full_b
+
+    # Run comparison
+    try:
+        report = compare_sessions(store, session_a, session_b)
+    except Exception as exc:
+        sys.stderr.write(f"[compare] Failed: {exc}\n")
+        return 1
+
+    divergence = decision_divergence(store, session_a, session_b)
+
+    if fmt == "json":
+        sys.stdout.write(json.dumps(_report_to_dict(report, divergence), indent=2) + "\n")
+    else:
+        # Text: use existing format_compare, then append decision divergence
+        format_compare(report, sys.stdout)
+        sys.stdout.write(f"Decision divergence:  {divergence} point(s)\n\n")
+
+    return 0

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,364 @@
+"""Tests for agent-strace compare (Issue #114)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_trace.compare import (
+    cmd_compare,
+    decision_divergence,
+    _decision_texts,
+    _edit_distance,
+    _sessions_by_tag,
+    _get_user_prompt,
+    _report_to_dict,
+)
+from agent_trace.diff import compare_sessions
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> TraceStore:
+    tmp = tempfile.mkdtemp()
+    return TraceStore(Path(tmp))
+
+
+def _add_session(store: TraceStore, agent_name: str = "test",
+                 tool_calls: list[str] | None = None,
+                 decisions: list[str] | None = None,
+                 user_prompt: str | None = None,
+                 write_files: list[str] | None = None) -> str:
+    meta = SessionMeta(agent_name=agent_name, command=agent_name)
+    sp = store.create_session(meta)
+    sid = sp.name
+
+    events: list[TraceEvent] = [
+        TraceEvent(event_type=EventType.SESSION_START, timestamp=1.0,
+                   session_id=sid, data={}),
+    ]
+    if user_prompt:
+        events.append(TraceEvent(event_type=EventType.USER_PROMPT, timestamp=1.1,
+                                 session_id=sid, data={"content": user_prompt}))
+    for tool in (tool_calls or ["Read"]):
+        events.append(TraceEvent(event_type=EventType.TOOL_CALL, timestamp=2.0,
+                                 session_id=sid, data={"tool_name": tool}))
+    for path in (write_files or []):
+        events.append(TraceEvent(event_type=EventType.TOOL_CALL, timestamp=2.5,
+                                 session_id=sid,
+                                 data={"tool_name": "Write",
+                                       "arguments": {"file_path": path}}))
+    for text in (decisions or []):
+        events.append(TraceEvent(event_type=EventType.DECISION, timestamp=3.0,
+                                 session_id=sid, data={"text": text}))
+    events.append(TraceEvent(event_type=EventType.SESSION_END, timestamp=4.0,
+                             session_id=sid, data={}))
+
+    for e in events:
+        store.append_event(sid, e)
+    return sid
+
+
+# ---------------------------------------------------------------------------
+# _edit_distance
+# ---------------------------------------------------------------------------
+
+class TestEditDistance(unittest.TestCase):
+    def test_identical_lists(self):
+        self.assertEqual(_edit_distance(["a", "b"], ["a", "b"]), 0)
+
+    def test_empty_lists(self):
+        self.assertEqual(_edit_distance([], []), 0)
+
+    def test_one_empty(self):
+        self.assertEqual(_edit_distance(["a", "b"], []), 2)
+        self.assertEqual(_edit_distance([], ["a", "b"]), 2)
+
+    def test_single_insertion(self):
+        self.assertEqual(_edit_distance(["a"], ["a", "b"]), 1)
+
+    def test_single_deletion(self):
+        self.assertEqual(_edit_distance(["a", "b"], ["a"]), 1)
+
+    def test_single_substitution(self):
+        self.assertEqual(_edit_distance(["a"], ["b"]), 1)
+
+    def test_completely_different(self):
+        self.assertEqual(_edit_distance(["a", "b", "c"], ["x", "y", "z"]), 3)
+
+
+# ---------------------------------------------------------------------------
+# _decision_texts
+# ---------------------------------------------------------------------------
+
+class TestDecisionTexts(unittest.TestCase):
+    def test_extracts_decision_events(self):
+        store = _make_store()
+        sid = _add_session(store, decisions=["chose A", "chose B"])
+        texts = _decision_texts(store, sid)
+        self.assertEqual(texts, ["chose A", "chose B"])
+
+    def test_empty_when_no_decisions(self):
+        store = _make_store()
+        sid = _add_session(store)
+        texts = _decision_texts(store, sid)
+        self.assertEqual(texts, [])
+
+    def test_missing_session_returns_empty(self):
+        store = _make_store()
+        texts = _decision_texts(store, "nonexistent")
+        self.assertEqual(texts, [])
+
+
+# ---------------------------------------------------------------------------
+# decision_divergence
+# ---------------------------------------------------------------------------
+
+class TestDecisionDivergence(unittest.TestCase):
+    def test_identical_decisions_zero_divergence(self):
+        store = _make_store()
+        sid_a = _add_session(store, decisions=["chose A", "chose B"])
+        sid_b = _add_session(store, decisions=["chose A", "chose B"])
+        self.assertEqual(decision_divergence(store, sid_a, sid_b), 0)
+
+    def test_different_decisions_nonzero(self):
+        store = _make_store()
+        sid_a = _add_session(store, decisions=["chose A", "chose B"])
+        sid_b = _add_session(store, decisions=["chose X", "chose Y"])
+        self.assertGreater(decision_divergence(store, sid_a, sid_b), 0)
+
+    def test_extra_decision_in_b(self):
+        store = _make_store()
+        sid_a = _add_session(store, decisions=["chose A"])
+        sid_b = _add_session(store, decisions=["chose A", "chose B"])
+        self.assertEqual(decision_divergence(store, sid_a, sid_b), 1)
+
+    def test_no_decisions_both_zero(self):
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        self.assertEqual(decision_divergence(store, sid_a, sid_b), 0)
+
+
+# ---------------------------------------------------------------------------
+# _sessions_by_tag
+# ---------------------------------------------------------------------------
+
+class TestSessionsByTag(unittest.TestCase):
+    def test_finds_sessions_by_agent_name(self):
+        store = _make_store()
+        _add_session(store, agent_name="refactor-auth")
+        _add_session(store, agent_name="refactor-auth")
+        _add_session(store, agent_name="add-tests")
+        ids = _sessions_by_tag(store, "refactor-auth", last=2)
+        self.assertEqual(len(ids), 2)
+
+    def test_returns_at_most_last_n(self):
+        store = _make_store()
+        for _ in range(5):
+            _add_session(store, agent_name="my-task")
+        ids = _sessions_by_tag(store, "my-task", last=2)
+        self.assertEqual(len(ids), 2)
+
+    def test_returns_empty_when_no_match(self):
+        store = _make_store()
+        _add_session(store, agent_name="other-task")
+        ids = _sessions_by_tag(store, "nonexistent", last=2)
+        self.assertEqual(ids, [])
+
+    def test_case_insensitive_match(self):
+        store = _make_store()
+        _add_session(store, agent_name="Refactor-Auth")
+        _add_session(store, agent_name="Refactor-Auth")
+        ids = _sessions_by_tag(store, "refactor-auth", last=2)
+        self.assertEqual(len(ids), 2)
+
+
+# ---------------------------------------------------------------------------
+# _get_user_prompt
+# ---------------------------------------------------------------------------
+
+class TestGetUserPrompt(unittest.TestCase):
+    def test_returns_prompt_when_present(self):
+        store = _make_store()
+        sid = _add_session(store, user_prompt="Fix the login bug")
+        prompt = _get_user_prompt(store, sid)
+        self.assertEqual(prompt, "Fix the login bug")
+
+    def test_returns_none_when_absent(self):
+        store = _make_store()
+        sid = _add_session(store)
+        prompt = _get_user_prompt(store, sid)
+        self.assertIsNone(prompt)
+
+
+# ---------------------------------------------------------------------------
+# compare_sessions + _report_to_dict
+# ---------------------------------------------------------------------------
+
+class TestCompareSessionsIntegration(unittest.TestCase):
+    def test_produces_report(self):
+        store = _make_store()
+        sid_a = _add_session(store, tool_calls=["Read", "Write"],
+                             write_files=["a.py"])
+        sid_b = _add_session(store, tool_calls=["Read"],
+                             write_files=["a.py"])
+        report = compare_sessions(store, sid_a, sid_b)
+        self.assertEqual(report.session_a, sid_a)
+        self.assertEqual(report.session_b, sid_b)
+        self.assertIsInstance(report.verdict, str)
+
+    def test_report_to_dict_structure(self):
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        report = compare_sessions(store, sid_a, sid_b)
+        d = _report_to_dict(report, divergence=3)
+        self.assertIn("session_a", d)
+        self.assertIn("session_b", d)
+        self.assertIn("verdict", d)
+        self.assertIn("decision_divergence", d)
+        self.assertEqual(d["decision_divergence"], 3)
+        self.assertIn("divergence_points", d)
+
+    def test_json_serialisable(self):
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        report = compare_sessions(store, sid_a, sid_b)
+        d = _report_to_dict(report, divergence=0)
+        # Must not raise
+        json.dumps(d)
+
+
+# ---------------------------------------------------------------------------
+# cmd_compare CLI
+# ---------------------------------------------------------------------------
+
+class TestCmdCompare(unittest.TestCase):
+    def _args(self, store_dir, sid_a=None, sid_b=None, fmt="text",
+              tag=None, last=2, rerun=False, model=None):
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = store_dir
+        args.session_id_a = sid_a
+        args.session_id_b = sid_b
+        args.format = fmt
+        args.tag = tag
+        args.last = last
+        args.rerun = rerun
+        args.model = model
+        return args
+
+    def test_compare_two_sessions_text(self):
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        args = self._args(store.base_dir, sid_a=sid_a, sid_b=sid_b)
+        result = cmd_compare(args)
+        self.assertEqual(result, 0)
+
+    def test_compare_two_sessions_json(self):
+        import io
+        from unittest.mock import patch
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        args = self._args(store.base_dir, sid_a=sid_a, sid_b=sid_b, fmt="json")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            result = cmd_compare(args)
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertIn("verdict", data)
+        self.assertIn("decision_divergence", data)
+
+    def test_missing_session_a_returns_1(self):
+        store = _make_store()
+        args = self._args(store.base_dir, sid_a="nonexistent", sid_b="also-missing")
+        result = cmd_compare(args)
+        self.assertEqual(result, 1)
+
+    def test_missing_session_b_returns_1(self):
+        store = _make_store()
+        sid_a = _add_session(store)
+        args = self._args(store.base_dir, sid_a=sid_a, sid_b="nonexistent")
+        result = cmd_compare(args)
+        self.assertEqual(result, 1)
+
+    def test_no_args_returns_1(self):
+        store = _make_store()
+        args = self._args(store.base_dir)
+        result = cmd_compare(args)
+        self.assertEqual(result, 1)
+
+    def test_tag_compare(self):
+        store = _make_store()
+        _add_session(store, agent_name="refactor-auth")
+        _add_session(store, agent_name="refactor-auth")
+        args = self._args(store.base_dir, tag="refactor-auth", last=2)
+        result = cmd_compare(args)
+        self.assertEqual(result, 0)
+
+    def test_tag_not_enough_sessions_returns_1(self):
+        store = _make_store()
+        _add_session(store, agent_name="refactor-auth")  # only 1
+        args = self._args(store.base_dir, tag="refactor-auth", last=2)
+        result = cmd_compare(args)
+        self.assertEqual(result, 1)
+
+    def test_rerun_without_prompt_returns_1(self):
+        store = _make_store()
+        sid_a = _add_session(store)  # no user_prompt
+        args = self._args(store.base_dir, sid_a=sid_a, rerun=True)
+        result = cmd_compare(args)
+        self.assertEqual(result, 1)
+
+    def test_rerun_with_prompt_returns_1_with_message(self):
+        """--rerun is not yet automated; returns 1 with instructions."""
+        import io
+        from unittest.mock import patch
+        store = _make_store()
+        sid_a = _add_session(store, user_prompt="Fix the login bug")
+        args = self._args(store.base_dir, sid_a=sid_a, rerun=True)
+        captured = io.StringIO()
+        with patch("sys.stderr", captured):
+            result = cmd_compare(args)
+        self.assertEqual(result, 1)
+        self.assertIn("Fix the login bug", captured.getvalue())
+
+    def test_json_output_includes_divergence(self):
+        import io
+        from unittest.mock import patch
+        store = _make_store()
+        sid_a = _add_session(store, decisions=["chose A"])
+        sid_b = _add_session(store, decisions=["chose B"])
+        args = self._args(store.base_dir, sid_a=sid_a, sid_b=sid_b, fmt="json")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_compare(args)
+        data = json.loads(captured.getvalue())
+        self.assertIn("decision_divergence", data)
+        self.assertGreaterEqual(data["decision_divergence"], 0)
+
+    def test_text_output_includes_divergence_line(self):
+        import io
+        from unittest.mock import patch
+        store = _make_store()
+        sid_a = _add_session(store)
+        sid_b = _add_session(store)
+        args = self._args(store.base_dir, sid_a=sid_a, sid_b=sid_b, fmt="text")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_compare(args)
+        self.assertIn("Decision divergence", captured.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements `agent-strace compare` (closes #114) — session-to-session regression testing.

## What it does

Wraps the existing `diff.compare_sessions` with a first-class CLI workflow. Produces a structured report showing cost, duration, tool call count, files modified, and errors — with a rule-based verdict and a decision divergence score.

## Decision divergence

Computed as Levenshtein edit distance on the two sessions' `DECISION` event text sequences. No LLM call. A score of 0 means identical reasoning paths; higher means more divergence.

## CLI

```bash
agent-strace compare <id-a> <id-b>              # direct comparison
agent-strace compare --tag refactor-auth        # last 2 sessions with tag
agent-strace compare <id-a> <id-b> --format json
```

`--rerun` surfaces the stored `user_prompt` with instructions for manual re-execution. Full automation is deferred (requires agent runner integration).

## Changes

- `src/agent_trace/compare.py` — `decision_divergence()`, `_sessions_by_tag()`, `_get_user_prompt()`, `cmd_compare()`
- `src/agent_trace/cli.py` — `compare` subcommand registered
- `tests/test_compare.py` — 34 tests (edit distance, decision extraction, tag lookup, all CLI paths)
- `README.md` — compare section with example output
- Version bumped to `0.49.0`
