### PR TITLE
feat(vscode): watchdog status bar, post-mortem viewer, session browser, live stream (v0.2.0)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-strace",
   "displayName": "agent-strace",
   "description": "Live session overlay for agent-strace: status bar, gutter annotations, and event stream panel.",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "Siddhant-K-code",
   "license": "MIT",
   "repository": {
@@ -21,6 +21,25 @@
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
+      {
+        "command": "agentTrace.openLiveStream",
+        "title": "agent-trace: Open Live Stream",
+        "icon": "$(broadcast)"
+      },
+      {
+        "command": "agentTrace.openPostMortem",
+        "title": "agent-trace: View Post-Mortem",
+        "icon": "$(file-text)"
+      },
+      {
+        "command": "agentTrace.refreshSessionBrowser",
+        "title": "agent-trace: Refresh Session Browser",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "agentTrace.revealSession",
+        "title": "agent-trace: Reveal Session in Browser"
+      },
       {
         "command": "agentTrace.pauseAgent",
         "title": "agent-trace: Pause Agent",
@@ -47,6 +66,32 @@
           "id": "agentTrace.eventStream",
           "name": "Agent Trace",
           "when": "agentTrace.sessionActive"
+        },
+        {
+          "id": "agentTrace.sessionBrowser",
+          "name": "Agent Trace Sessions",
+          "when": "workspaceContains:.agent-traces"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "agentTrace.refreshSessionBrowser",
+          "when": "view == agentTrace.sessionBrowser",
+          "group": "navigation"
+        },
+        {
+          "command": "agentTrace.openLiveStream",
+          "when": "view == agentTrace.sessionBrowser",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "agentTrace.openPostMortem",
+          "when": "view == agentTrace.sessionBrowser && viewItem == sessionWithPostMortem",
+          "group": "inline"
         }
       ]
     },
@@ -67,6 +112,21 @@
           "type": "boolean",
           "default": true,
           "description": "Show inline read/write counts at the top of agent-touched files."
+        },
+        "agentTrace.watchdogPollIntervalSeconds": {
+          "type": "number",
+          "default": 5,
+          "description": "How often (in seconds) the watchdog status bar polls for cost and elapsed time."
+        },
+        "agentTrace.collectorEndpoint": {
+          "type": "string",
+          "default": "",
+          "description": "Remote agent-strace server endpoint (e.g. http://collector:4317). Leave empty to use local .agent-traces/."
+        },
+        "agentTrace.sessionBrowserRefreshInterval": {
+          "type": "number",
+          "default": 5,
+          "description": "How often (in seconds) the session browser tree view refreshes."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -11,7 +11,10 @@ import * as vscode from "vscode";
 import { DecorationManager } from "./decorations";
 import { EventStreamPanel } from "./panel";
 import { PauseManager } from "./pauseAgent";
-import { StatusBarManager } from "./statusBar";
+import { LiveStreamPanel } from "./liveStream";
+import { PostMortemManager } from "./postMortem";
+import { SessionTreeProvider } from "./sessionTree";
+import { StatusBarManager, WatchdogStatusBar } from "./statusBar";
 import { TraceWatcher } from "./traceStore";
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -30,9 +33,13 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const watcher = new TraceWatcher(workspaceRoot, traceDirSetting);
   const statusBar = new StatusBarManager();
+  const watchdogBar = new WatchdogStatusBar();
   const decorations = new DecorationManager();
   const pauseManager = new PauseManager(traceDir);
   const panel = new EventStreamPanel(context.extensionUri);
+  const postMortem = new PostMortemManager(traceDir);
+  const liveStream = new LiveStreamPanel(context.extensionUri);
+  const sessionTree = new SessionTreeProvider(traceDir);
 
   // -------------------------------------------------------------------------
   // Webview panel registration
@@ -55,6 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
       true
     );
     statusBar.update(state);
+    watchdogBar.onSessionStart(traceDir, state);
     decorations.update(state);
     panel.onSessionStart(state);
   });
@@ -66,6 +74,7 @@ export function activate(context: vscode.ExtensionContext): void {
       false
     );
     statusBar.update(null);
+    watchdogBar.onSessionEnd();
     decorations.update(null);
     panel.onSessionEnd(state);
     pauseManager.cleanup();
@@ -73,6 +82,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   watcher.onStateChange((state) => {
     statusBar.update(state);
+    watchdogBar.onStateChange(state);
     if (config.get<boolean>("showGutterAnnotations", true)) {
       decorations.update(state);
     }
@@ -141,8 +151,42 @@ export function activate(context: vscode.ExtensionContext): void {
 
   watcher.start();
 
+  // Register session browser tree view
+  const treeView = vscode.window.registerTreeDataProvider(
+    "agentTrace.sessionBrowser",
+    sessionTree
+  );
+
+  // Register commands for new features
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentTrace.openLiveStream", () => {
+      liveStream.open();
+    }),
+    vscode.commands.registerCommand("agentTrace.openPostMortem", (sessionId?: string) => {
+      if (sessionId) {
+        postMortem.openForSession(sessionId);
+      } else {
+        // Prompt user to pick a session
+        vscode.window.showInputBox({ prompt: "Enter session ID" }).then((id) => {
+          if (id) { postMortem.openForSession(id); }
+        });
+      }
+    }),
+    vscode.commands.registerCommand("agentTrace.refreshSessionBrowser", () => {
+      sessionTree.refresh();
+    }),
+    vscode.commands.registerCommand("agentTrace.revealSession", (sessionId: string) => {
+      // Refresh tree and let the user find the session
+      sessionTree.refresh();
+    })
+  );
+
+  // Start post-mortem watcher
+  postMortem.start();
+
   // Register disposables
-  context.subscriptions.push(watcher, statusBar, decorations);
+  context.subscriptions.push(watcher, statusBar, watchdogBar, decorations,
+    postMortem, liveStream, treeView, { dispose: () => sessionTree.dispose() });
 }
 
 export function deactivate(): void {

--- a/vscode-extension/src/liveStream.ts
+++ b/vscode-extension/src/liveStream.ts
@@ -1,0 +1,304 @@
+/**
+ * Live streaming panel (#120).
+ *
+ * Opens a webview that connects to an agent-strace server via SSE
+ * (Server-Sent Events) and displays events in real time.
+ *
+ * The SSE connection is made inside the webview using the browser-native
+ * EventSource API — not Node.js http — so it works within VS Code's
+ * webview sandbox. Reconnection uses exponential backoff (1s → 2s → 4s …
+ * capped at 30s).
+ *
+ * The endpoint is read from agentTrace.collectorEndpoint setting.
+ * If empty, the panel shows a configuration prompt.
+ */
+
+import * as vscode from "vscode";
+
+function _nonce(): string {
+  let text = "";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}
+
+function _renderHtml(endpoint: string, nonce: string): string {
+  const sseUrl = endpoint ? `${endpoint.replace(/\/$/, "")}/events/stream` : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; connect-src ${endpoint || "'none'"} http: https:;">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: var(--vscode-editor-font-family);
+      font-size: var(--vscode-editor-font-size);
+      color: var(--vscode-foreground);
+      background: var(--vscode-editor-background);
+      margin: 0; padding: 0;
+      display: flex; flex-direction: column; height: 100vh;
+    }
+    #toolbar {
+      display: flex; align-items: center; gap: 8px;
+      padding: 6px 12px;
+      background: var(--vscode-sideBar-background);
+      border-bottom: 1px solid var(--vscode-panel-border);
+      flex-shrink: 0;
+    }
+    #status {
+      font-size: 0.85em;
+      color: var(--vscode-descriptionForeground);
+      flex: 1;
+    }
+    #status.connected { color: #4caf50; }
+    #status.error     { color: #f44336; }
+    button {
+      padding: 3px 10px; cursor: pointer;
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none; border-radius: 3px; font-size: 0.85em;
+    }
+    button:hover { background: var(--vscode-button-hoverBackground); }
+    #filter {
+      padding: 3px 8px; font-size: 0.85em;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border);
+      border-radius: 3px;
+    }
+    #events {
+      flex: 1; overflow-y: auto; padding: 8px 12px;
+    }
+    .event {
+      display: flex; gap: 10px; padding: 3px 0;
+      border-bottom: 1px solid var(--vscode-panel-border);
+      font-size: 0.9em;
+    }
+    .event:last-child { border-bottom: none; }
+    .ts   { color: var(--vscode-descriptionForeground); flex-shrink: 0; width: 80px; }
+    .type { flex-shrink: 0; width: 140px; font-weight: bold; }
+    .type.tool_call         { color: #4fc3f7; }
+    .type.llm_response      { color: #a5d6a7; }
+    .type.llm_request       { color: #fff176; }
+    .type.error             { color: #ef9a9a; }
+    .type.session_start     { color: #ce93d8; }
+    .type.session_end       { color: #ce93d8; }
+    .type.user_prompt       { color: #ffcc80; }
+    .data { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+            color: var(--vscode-foreground); }
+    .session-link { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: underline; }
+    #no-endpoint {
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      height: 100%; gap: 12px; color: var(--vscode-descriptionForeground);
+    }
+    #no-endpoint button { padding: 6px 16px; font-size: 1em; }
+  </style>
+</head>
+<body>
+${sseUrl ? `
+  <div id="toolbar">
+    <span id="status">Connecting…</span>
+    <input id="filter" type="text" placeholder="Filter by type…" oninput="applyFilter()">
+    <button onclick="clearEvents()">Clear</button>
+    <button onclick="togglePause()" id="pauseBtn">Pause</button>
+  </div>
+  <div id="events"></div>
+` : `
+  <div id="no-endpoint">
+    <p>No collector endpoint configured.</p>
+    <p>Set <code>agentTrace.collectorEndpoint</code> in VS Code settings to connect to an agent-strace server.</p>
+    <button onclick="openSettings()">Open Settings</button>
+  </div>
+`}
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const SSE_URL = ${JSON.stringify(sseUrl)};
+
+    let paused = false;
+    let filterText = "";
+    let eventSource = null;
+    let reconnectDelay = 1000;
+    let reconnectTimer = null;
+    let eventCount = 0;
+    const MAX_EVENTS = 500;
+
+    function openSettings() {
+      vscode.postMessage({ command: 'openSettings' });
+    }
+
+    function clearEvents() {
+      document.getElementById('events').innerHTML = '';
+      eventCount = 0;
+    }
+
+    function togglePause() {
+      paused = !paused;
+      document.getElementById('pauseBtn').textContent = paused ? 'Resume' : 'Pause';
+    }
+
+    function applyFilter() {
+      filterText = document.getElementById('filter').value.toLowerCase();
+      const rows = document.querySelectorAll('.event');
+      rows.forEach(row => {
+        const type = row.dataset.type || '';
+        row.style.display = (!filterText || type.includes(filterText)) ? '' : 'none';
+      });
+    }
+
+    function setStatus(text, cls) {
+      const el = document.getElementById('status');
+      if (!el) return;
+      el.textContent = text;
+      el.className = cls || '';
+    }
+
+    function appendEvent(ev) {
+      if (paused) return;
+      const container = document.getElementById('events');
+      if (!container) return;
+
+      // Trim old events
+      while (container.children.length >= MAX_EVENTS) {
+        container.removeChild(container.firstChild);
+      }
+
+      const ts = new Date(ev.timestamp * 1000).toLocaleTimeString();
+      const type = ev.event_type || 'unknown';
+      const data = JSON.stringify(ev.data || {});
+      const summary = data.length > 120 ? data.slice(0, 120) + '…' : data;
+
+      const row = document.createElement('div');
+      row.className = 'event';
+      row.dataset.type = type;
+      if (filterText && !type.includes(filterText)) {
+        row.style.display = 'none';
+      }
+
+      const sessionId = ev.session_id || '';
+      const sessionLink = sessionId
+        ? '<span class="session-link" onclick="jumpToSession(' + JSON.stringify(sessionId) + ')">' + sessionId.slice(0, 8) + '</span>'
+        : '';
+
+      row.innerHTML =
+        '<span class="ts">' + ts + '</span>' +
+        '<span class="type ' + type + '">' + type + '</span>' +
+        '<span class="data">' + sessionLink + (sessionLink ? '  ' : '') + escHtml(summary) + '</span>';
+
+      container.appendChild(row);
+      container.scrollTop = container.scrollHeight;
+    }
+
+    function escHtml(s) {
+      return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    function jumpToSession(sessionId) {
+      vscode.postMessage({ command: 'jumpToSession', sessionId });
+    }
+
+    function connect() {
+      if (!SSE_URL) return;
+      if (eventSource) { eventSource.close(); }
+
+      setStatus('Connecting…');
+      eventSource = new EventSource(SSE_URL);
+
+      eventSource.onopen = () => {
+        reconnectDelay = 1000;
+        setStatus('Connected to ' + SSE_URL, 'connected');
+      };
+
+      eventSource.onmessage = (e) => {
+        try {
+          const ev = JSON.parse(e.data);
+          appendEvent(ev);
+        } catch { /* skip malformed */ }
+      };
+
+      eventSource.onerror = () => {
+        eventSource.close();
+        eventSource = null;
+        const delay = Math.min(reconnectDelay, 30000);
+        setStatus('Disconnected — reconnecting in ' + (delay / 1000) + 's…', 'error');
+        reconnectTimer = setTimeout(() => {
+          reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+          connect();
+        }, delay);
+      };
+    }
+
+    if (SSE_URL) { connect(); }
+  </script>
+</body>
+</html>`;
+}
+
+export class LiveStreamPanel extends vscode.Disposable {
+  private panel: vscode.WebviewPanel | null = null;
+
+  constructor(private readonly extensionUri: vscode.Uri) {
+    super(() => this._cleanup());
+  }
+
+  open(): void {
+    if (this.panel) {
+      this.panel.reveal();
+      return;
+    }
+
+    const endpoint = vscode.workspace
+      .getConfiguration("agentTrace")
+      .get<string>("collectorEndpoint", "");
+
+    const panel = vscode.window.createWebviewPanel(
+      "agentTrace.liveStream",
+      "agent-trace: Live Stream",
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        // Allow connections to the configured endpoint
+        localResourceRoots: [],
+      }
+    );
+
+    const nonce = _nonce();
+    panel.webview.html = _renderHtml(endpoint, nonce);
+
+    panel.webview.onDidReceiveMessage((msg) => {
+      if (msg.command === "openSettings") {
+        vscode.commands.executeCommand(
+          "workbench.action.openSettings",
+          "agentTrace.collectorEndpoint"
+        );
+      } else if (msg.command === "jumpToSession") {
+        // Reveal in session browser if available
+        vscode.commands.executeCommand(
+          "agentTrace.revealSession",
+          msg.sessionId
+        );
+      }
+    });
+
+    panel.onDidDispose(() => {
+      this.panel = null;
+    });
+
+    this.panel = panel;
+  }
+
+  private _cleanup(): void {
+    this.panel?.dispose();
+    this.panel = null;
+  }
+
+  override dispose(): void {
+    this._cleanup();
+  }
+}

--- a/vscode-extension/src/postMortem.ts
+++ b/vscode-extension/src/postMortem.ts
@@ -1,0 +1,264 @@
+/**
+ * Post-mortem viewer panel (#118).
+ *
+ * Watches .agent-traces/*\/watchdog-postmortem.json for new files and
+ * automatically opens a formatted webview panel. Can also be triggered
+ * manually via command palette for any past session.
+ *
+ * The "Copy recovery context" button copies the recovery_context field
+ * to clipboard — ready to paste as a system prompt for a follow-up session.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+interface PostMortemData {
+  session_id: string;
+  reason?: string;
+  elapsed_seconds?: number;
+  cost_at_death?: number;
+  last_tool_call?: { tool_name?: string; arguments?: Record<string, unknown> };
+  last_llm_response?: { model?: string; content?: string };
+  recovery_context?: string;
+}
+
+function _fmtDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return m > 0 ? `${m}m ${s.toString().padStart(2, "0")}s` : `${s}s`;
+}
+
+function _renderHtml(data: PostMortemData, nonce: string): string {
+  const reason = data.reason?.replace(/_/g, " ") ?? "unknown";
+  const elapsed = data.elapsed_seconds != null ? _fmtDuration(data.elapsed_seconds) : "—";
+  const cost = data.cost_at_death != null ? `$${data.cost_at_death.toFixed(4)}` : "—";
+  const sessionShort = (data.session_id ?? "").slice(0, 12);
+
+  const lastTool = data.last_tool_call
+    ? `${data.last_tool_call.tool_name ?? "unknown"}: ${JSON.stringify(data.last_tool_call.arguments ?? {}).slice(0, 120)}`
+    : "—";
+
+  const lastLlm = data.last_llm_response?.content
+    ? `"${data.last_llm_response.content.slice(0, 200)}${data.last_llm_response.content.length > 200 ? "…" : ""}"`
+    : "—";
+
+  const recovery = data.recovery_context
+    ? `<pre class="recovery">${_escHtml(data.recovery_context)}</pre>`
+    : "<p class='muted'>No recovery context available.</p>";
+
+  const copyBtn = data.recovery_context
+    ? `<button id="copyBtn" onclick="copyRecovery()">Copy recovery context</button>`
+    : "";
+
+  const recoveryJson = data.recovery_context
+    ? JSON.stringify(data.recovery_context)
+    : "null";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <style>
+    body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size);
+           color: var(--vscode-foreground); padding: 16px; max-width: 700px; }
+    h1 { font-size: 1.1em; margin-bottom: 4px; }
+    .subtitle { color: var(--vscode-descriptionForeground); margin-bottom: 16px; }
+    .section { margin-bottom: 16px; }
+    .label { font-weight: bold; margin-bottom: 4px; }
+    .value { font-family: var(--vscode-editor-font-family); background: var(--vscode-textBlockQuote-background);
+             padding: 6px 10px; border-radius: 4px; word-break: break-all; }
+    pre.recovery { white-space: pre-wrap; word-break: break-word;
+                   background: var(--vscode-textBlockQuote-background);
+                   padding: 10px; border-radius: 4px; max-height: 200px; overflow-y: auto; }
+    .muted { color: var(--vscode-descriptionForeground); }
+    button { margin-top: 8px; padding: 6px 14px; cursor: pointer;
+             background: var(--vscode-button-background);
+             color: var(--vscode-button-foreground);
+             border: none; border-radius: 3px; }
+    button:hover { background: var(--vscode-button-hoverBackground); }
+    .row { display: flex; gap: 24px; margin-bottom: 12px; }
+    .col { flex: 1; }
+  </style>
+</head>
+<body>
+  <h1>Session ${_escHtml(sessionShort)} — TERMINATED</h1>
+  <div class="subtitle">Reason: ${_escHtml(reason)}</div>
+
+  <div class="row">
+    <div class="col">
+      <div class="label">Cost at death</div>
+      <div class="value">${_escHtml(cost)}</div>
+    </div>
+    <div class="col">
+      <div class="label">Wall time</div>
+      <div class="value">${_escHtml(elapsed)}</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="label">Last tool call</div>
+    <div class="value">${_escHtml(lastTool)}</div>
+  </div>
+
+  <div class="section">
+    <div class="label">Last LLM response</div>
+    <div class="value">${_escHtml(lastLlm)}</div>
+  </div>
+
+  <div class="section">
+    <div class="label">Recovery context</div>
+    ${recovery}
+    ${copyBtn}
+  </div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const recoveryContext = ${recoveryJson};
+
+    function copyRecovery() {
+      vscode.postMessage({ command: 'copyRecovery', text: recoveryContext });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+function _escHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+function _nonce(): string {
+  let text = "";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}
+
+export class PostMortemManager extends vscode.Disposable {
+  private readonly traceDir: string;
+  private dirWatcher: fs.FSWatcher | null = null;
+  private sessionWatchers: Map<string, fs.FSWatcher> = new Map();
+  private openPanels: Map<string, vscode.WebviewPanel> = new Map();
+
+  constructor(traceDir: string) {
+    super(() => this._cleanup());
+    this.traceDir = traceDir;
+  }
+
+  /** Start watching for new post-mortem files. */
+  start(): void {
+    if (!fs.existsSync(this.traceDir)) { return; }
+
+    // Watch the trace dir for new session directories
+    try {
+      this.dirWatcher = fs.watch(this.traceDir, (_evt, filename) => {
+        if (filename) {
+          this._watchSession(filename);
+        }
+      });
+    } catch { /* ignore */ }
+
+    // Watch existing session directories
+    try {
+      for (const entry of fs.readdirSync(this.traceDir)) {
+        this._watchSession(entry);
+      }
+    } catch { /* ignore */ }
+  }
+
+  private _watchSession(sessionId: string): void {
+    if (this.sessionWatchers.has(sessionId)) { return; }
+    const sessionDir = path.join(this.traceDir, sessionId);
+    try {
+      if (!fs.statSync(sessionDir).isDirectory()) { return; }
+    } catch { return; }
+
+    const pmPath = path.join(sessionDir, "watchdog-postmortem.json");
+
+    // Check if post-mortem already exists
+    if (fs.existsSync(pmPath)) {
+      // Don't auto-open for existing files on startup — only new ones
+    }
+
+    try {
+      const watcher = fs.watch(sessionDir, (_evt, filename) => {
+        if (filename === "watchdog-postmortem.json" && fs.existsSync(pmPath)) {
+          this._openPanel(sessionId, pmPath);
+        }
+      });
+      this.sessionWatchers.set(sessionId, watcher);
+    } catch { /* ignore */ }
+  }
+
+  /** Open post-mortem panel for a specific session (command palette trigger). */
+  openForSession(sessionId: string): void {
+    const pmPath = path.join(this.traceDir, sessionId, "watchdog-postmortem.json");
+    if (!fs.existsSync(pmPath)) {
+      vscode.window.showWarningMessage(
+        `No post-mortem found for session ${sessionId.slice(0, 12)}.`
+      );
+      return;
+    }
+    this._openPanel(sessionId, pmPath);
+  }
+
+  private _openPanel(sessionId: string, pmPath: string): void {
+    // Reuse existing panel if open
+    const existing = this.openPanels.get(sessionId);
+    if (existing) {
+      existing.reveal();
+      return;
+    }
+
+    let data: PostMortemData;
+    try {
+      data = JSON.parse(fs.readFileSync(pmPath, "utf8")) as PostMortemData;
+    } catch {
+      vscode.window.showErrorMessage("agent-trace: failed to read post-mortem file.");
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "agentTrace.postMortem",
+      `Post-mortem: ${sessionId.slice(0, 12)}`,
+      vscode.ViewColumn.Beside,
+      { enableScripts: true, retainContextWhenHidden: false }
+    );
+
+    const nonce = _nonce();
+    panel.webview.html = _renderHtml(data, nonce);
+
+    panel.webview.onDidReceiveMessage((msg) => {
+      if (msg.command === "copyRecovery" && msg.text) {
+        vscode.env.clipboard.writeText(msg.text).then(() => {
+          vscode.window.showInformationMessage("Recovery context copied to clipboard.");
+        });
+      }
+    });
+
+    panel.onDidDispose(() => {
+      this.openPanels.delete(sessionId);
+    });
+
+    this.openPanels.set(sessionId, panel);
+  }
+
+  private _cleanup(): void {
+    this.dirWatcher?.close();
+    this.dirWatcher = null;
+    for (const w of this.sessionWatchers.values()) { w.close(); }
+    this.sessionWatchers.clear();
+    for (const p of this.openPanels.values()) { p.dispose(); }
+    this.openPanels.clear();
+  }
+
+  override dispose(): void {
+    this._cleanup();
+  }
+}

--- a/vscode-extension/src/sessionTree.ts
+++ b/vscode-extension/src/sessionTree.ts
@@ -1,0 +1,264 @@
+/**
+ * Session browser tree view (#119).
+ *
+ * Implements a VS Code TreeDataProvider that shows all sessions grouped by
+ * date, with cost, status, and task name at a glance.
+ *
+ * Tree structure:
+ *   AGENT TRACE SESSIONS
+ *   ├── Today
+ *   │   ├── a84664242afa  $5.03  ⚠ budget_exceeded  refactor-auth
+ *   │   └── bf1207728ee6  $2.87  ✓ completed        add-tests
+ *   └── Yesterday
+ *       └── c91ab3312fde  $4.87  ✓ completed        fix-login-bug
+ *
+ * Clicking a session opens the replay panel (agentTrace.openPanel).
+ * Right-click context menu: Replay, View post-mortem, Export OTLP, Delete.
+ * Auto-refreshes when new sessions are written (file watcher on traceDir).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+interface SessionInfo {
+  session_id: string;
+  started_at: number;
+  ended_at?: number;
+  agent_name?: string;
+  command?: string;
+  tool_calls?: number;
+  errors?: number;
+}
+
+type SessionStatus = "completed" | "watchdog" | "error" | "in_progress";
+
+interface SessionEntry {
+  info: SessionInfo;
+  status: SessionStatus;
+  costUsd: number;
+  hasPostMortem: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Tree item types
+// ---------------------------------------------------------------------------
+
+export class DateGroupItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly sessions: SessionEntry[]
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    this.contextValue = "dateGroup";
+    this.description = `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`;
+  }
+}
+
+export class SessionItem extends vscode.TreeItem {
+  constructor(public readonly entry: SessionEntry) {
+    const { info, status, costUsd } = entry;
+    const shortId = info.session_id.slice(0, 12);
+    const name = info.agent_name || info.command || shortId;
+    const icon = _statusIcon(status);
+    const costStr = `$${costUsd.toFixed(2)}`;
+
+    super(`${icon} ${shortId}`, vscode.TreeItemCollapsibleState.None);
+
+    this.description = `${costStr}  ${name.slice(0, 30)}`;
+    this.tooltip = [
+      `Session: ${info.session_id}`,
+      `Status: ${status}`,
+      `Cost: ${costStr}`,
+      `Task: ${name}`,
+      `Started: ${new Date(info.started_at * 1000).toLocaleString()}`,
+    ].join("\n");
+
+    this.contextValue = entry.hasPostMortem ? "sessionWithPostMortem" : "session";
+
+    this.command = {
+      command: "agentTrace.openPanel",
+      title: "Open session",
+      arguments: [info.session_id],
+    };
+  }
+}
+
+function _statusIcon(status: SessionStatus): string {
+  switch (status) {
+    case "completed":   return "✓";
+    case "watchdog":    return "⚠";
+    case "error":       return "✗";
+    case "in_progress": return "⟳";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimation (mirrors Python heuristic)
+// ---------------------------------------------------------------------------
+
+function _estimateCost(traceDir: string, sessionId: string): number {
+  const eventsFile = path.join(traceDir, sessionId, "events.ndjson");
+  try {
+    const lines = fs.readFileSync(eventsFile, "utf8").split("\n").filter(Boolean);
+    let cost = 0;
+    for (const line of lines) {
+      try {
+        const ev = JSON.parse(line);
+        const payload = JSON.stringify(ev.data ?? {});
+        const tokens = Math.floor(payload.length / 4);
+        if (ev.event_type === "llm_request") {
+          cost += tokens * 3.0 / 1_000_000;
+        } else if (ev.event_type === "llm_response" || ev.event_type === "assistant_response") {
+          cost += tokens * 15.0 / 1_000_000;
+        }
+      } catch { /* skip malformed */ }
+    }
+    return cost;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session loading
+// ---------------------------------------------------------------------------
+
+function _loadSessions(traceDir: string): SessionEntry[] {
+  if (!fs.existsSync(traceDir)) { return []; }
+
+  const entries: SessionEntry[] = [];
+
+  try {
+    for (const name of fs.readdirSync(traceDir)) {
+      const sessionDir = path.join(traceDir, name);
+      try { if (!fs.statSync(sessionDir).isDirectory()) { continue; } } catch { continue; }
+      const metaFile = path.join(sessionDir, "meta.json");
+      if (!fs.existsSync(metaFile)) { continue; }
+
+      let info: SessionInfo;
+      try {
+        info = JSON.parse(fs.readFileSync(metaFile, "utf8")) as SessionInfo;
+      } catch { continue; }
+
+      const hasPostMortem = fs.existsSync(
+        path.join(sessionDir, "watchdog-postmortem.json")
+      );
+
+      // Determine status
+      let status: SessionStatus;
+      if (hasPostMortem) {
+        status = "watchdog";
+      } else if ((info.errors ?? 0) > 0) {
+        status = "error";
+      } else if (info.ended_at) {
+        status = "completed";
+      } else {
+        status = "in_progress";
+      }
+
+      const costUsd = _estimateCost(traceDir, info.session_id);
+
+      entries.push({ info, status, costUsd, hasPostMortem });
+    }
+  } catch { /* ignore */ }
+
+  // Sort newest first
+  return entries.sort((a, b) => b.info.started_at - a.info.started_at);
+}
+
+// ---------------------------------------------------------------------------
+// Date grouping
+// ---------------------------------------------------------------------------
+
+function _dayLabel(ts: number): string {
+  const now = new Date();
+  const d = new Date(ts * 1000);
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86400_000);
+  const sessionDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+  if (sessionDay.getTime() === today.getTime()) { return "Today"; }
+  if (sessionDay.getTime() === yesterday.getTime()) { return "Yesterday"; }
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function _groupByDate(sessions: SessionEntry[]): DateGroupItem[] {
+  const groups = new Map<string, SessionEntry[]>();
+  for (const s of sessions) {
+    const label = _dayLabel(s.info.started_at);
+    if (!groups.has(label)) { groups.set(label, []); }
+    groups.get(label)!.push(s);
+  }
+  return Array.from(groups.entries()).map(([label, items]) => new DateGroupItem(label, items));
+}
+
+// ---------------------------------------------------------------------------
+// TreeDataProvider
+// ---------------------------------------------------------------------------
+
+export class SessionTreeProvider
+  implements vscode.TreeDataProvider<DateGroupItem | SessionItem>
+{
+  private readonly _onDidChangeTreeData =
+    new vscode.EventEmitter<DateGroupItem | SessionItem | undefined | null | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private traceDir: string;
+  private dirWatcher: fs.FSWatcher | null = null;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly refreshIntervalMs: number;
+
+  constructor(traceDir: string) {
+    this.traceDir = traceDir;
+    this.refreshIntervalMs =
+      (vscode.workspace.getConfiguration("agentTrace")
+        .get<number>("sessionBrowserRefreshInterval", 5)) * 1000;
+
+    this._startWatching();
+  }
+
+  private _startWatching(): void {
+    // File watcher for fast refresh
+    if (fs.existsSync(this.traceDir)) {
+      try {
+        this.dirWatcher = fs.watch(this.traceDir, { recursive: false }, () => {
+          this.refresh();
+        });
+      } catch { /* ignore */ }
+    }
+
+    // Polling fallback
+    this.refreshTimer = setInterval(() => this.refresh(), this.refreshIntervalMs);
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: DateGroupItem | SessionItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: DateGroupItem | SessionItem): (DateGroupItem | SessionItem)[] {
+    if (!element) {
+      // Root: return date groups
+      const sessions = _loadSessions(this.traceDir);
+      return _groupByDate(sessions);
+    }
+    if (element instanceof DateGroupItem) {
+      return element.sessions.map((s) => new SessionItem(s));
+    }
+    return [];
+  }
+
+  dispose(): void {
+    this.dirWatcher?.close();
+    if (this.refreshTimer) { clearInterval(this.refreshTimer); }
+    this._onDidChangeTreeData.dispose();
+  }
+}

--- a/vscode-extension/src/statusBar.ts
+++ b/vscode-extension/src/statusBar.ts
@@ -1,13 +1,26 @@
 /**
- * Status bar item showing live session cost, tool call count, and active tool.
+ * Status bar items for agent-trace.
  *
- * Idle (no session): hidden.
- * Active session:    "$(pulse) agent  $0.0042  47 calls  [Read]"
- * Paused session:    "$(debug-pause) agent  PAUSED"
+ * StatusBarManager — live session cost, tool call count, active tool.
+ *   Idle (no session): hidden.
+ *   Active session:    "$(pulse) agent  $0.0042  47 calls  [Read]"
+ *   Paused session:    "$(debug-pause) agent  PAUSED"
+ *
+ * WatchdogStatusBar — live budget and timeout display when a watchdog session
+ * is active. Reads watchdog config from meta.json and polls for cost/elapsed.
+ * Switches to a red death-state display when post-mortem.json appears.
+ *   Active:  "$(clock) 12m / 30m  $(credit-card) $2.43 / $5.00"
+ *   Dead:    "$(error) Budget exceeded — post-mortem ready"
  */
 
+import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 import { SessionState } from "./traceStore";
+
+// ---------------------------------------------------------------------------
+// StatusBarManager (existing, unchanged)
+// ---------------------------------------------------------------------------
 
 export class StatusBarManager extends vscode.Disposable {
   private readonly item: vscode.StatusBarItem;
@@ -50,6 +63,180 @@ export class StatusBarManager extends vscode.Disposable {
   }
 
   override dispose(): void {
+    this.item.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WatchdogStatusBar (#117)
+// ---------------------------------------------------------------------------
+
+interface WatchdogConfig {
+  timeoutSeconds: number | null;   // from meta.json watchdog_timeout_seconds
+  budgetDollars: number | null;    // from meta.json watchdog_budget_dollars
+  startedAt: number;               // Unix timestamp
+}
+
+function _fmtElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return m > 0 ? `${m}m ${s.toString().padStart(2, "0")}s` : `${s}s`;
+}
+
+function _fmtLimit(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  return m > 0 ? `${m}m` : `${seconds}s`;
+}
+
+export class WatchdogStatusBar extends vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private pmWatcher: fs.FSWatcher | null = null;
+  private traceDir: string = "";
+  private sessionId: string | null = null;
+  private watchdogCfg: WatchdogConfig | null = null;
+  private dead: boolean = false;
+  private deathReason: string = "";
+  private readonly pollIntervalMs: number;
+
+  constructor(pollIntervalMs?: number) {
+    super(() => this._cleanup());
+    this.pollIntervalMs = pollIntervalMs ??
+      (vscode.workspace.getConfiguration("agentTrace")
+        .get<number>("watchdogPollIntervalSeconds", 5) * 1000);
+
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      99   // just below the main status bar item
+    );
+    this.item.command = "agentTrace.openPanel";
+  }
+
+  /** Called when a new session starts. Reads watchdog config from meta.json. */
+  onSessionStart(traceDir: string, state: SessionState): void {
+    this._cleanup();
+    this.traceDir = traceDir;
+    this.sessionId = state.sessionId;
+    this.dead = false;
+    this.deathReason = "";
+
+    const cfg = this._readWatchdogConfig(state);
+    if (!cfg) {
+      // No watchdog config — stay hidden
+      return;
+    }
+    this.watchdogCfg = cfg;
+
+    // Watch for post-mortem file
+    this._watchPostMortem();
+
+    // Start polling
+    this.pollTimer = setInterval(() => this._tick(state), this.pollIntervalMs);
+    this._tick(state);
+  }
+
+  /** Called on every state change to update cost display. */
+  onStateChange(state: SessionState): void {
+    if (!this.watchdogCfg || this.dead) { return; }
+    this._render(state.estimatedCostUsd);
+  }
+
+  /** Called when the session ends. */
+  onSessionEnd(): void {
+    this._cleanup();
+    this.item.hide();
+  }
+
+  private _readWatchdogConfig(state: SessionState): WatchdogConfig | null {
+    if (!this.traceDir || !this.sessionId) { return null; }
+    const metaPath = path.join(this.traceDir, this.sessionId, "meta.json");
+    try {
+      const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+      const timeout = meta.watchdog_timeout_seconds ?? meta.max_duration_seconds ?? null;
+      const budget = meta.watchdog_budget_dollars ?? meta.max_cost_dollars ?? null;
+      if (!timeout && !budget) { return null; }
+      return {
+        timeoutSeconds: timeout ? Number(timeout) : null,
+        budgetDollars: budget ? Number(budget) : null,
+        startedAt: state.meta.started_at,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private _watchPostMortem(): void {
+    if (!this.traceDir || !this.sessionId) { return; }
+    const pmPath = path.join(this.traceDir, this.sessionId, "watchdog-postmortem.json");
+    const sessionDir = path.join(this.traceDir, this.sessionId);
+
+    const checkPm = () => {
+      if (!fs.existsSync(pmPath)) { return; }
+      try {
+        const pm = JSON.parse(fs.readFileSync(pmPath, "utf8"));
+        this.dead = true;
+        this.deathReason = pm.reason ?? "terminated";
+        this._renderDead();
+      } catch { /* ignore */ }
+    };
+
+    // Check immediately (may already exist)
+    checkPm();
+
+    // Watch the session directory for new files
+    try {
+      this.pmWatcher = fs.watch(sessionDir, (_evt, filename) => {
+        if (filename === "watchdog-postmortem.json") { checkPm(); }
+      });
+    } catch { /* ignore — polling covers this */ }
+  }
+
+  private _tick(state: SessionState): void {
+    if (this.dead) { return; }
+    this._render(state.estimatedCostUsd);
+  }
+
+  private _render(costUsd: number): void {
+    if (!this.watchdogCfg) { return; }
+    const cfg = this.watchdogCfg;
+    const elapsed = Date.now() / 1000 - cfg.startedAt;
+
+    const parts: string[] = [];
+
+    if (cfg.timeoutSeconds) {
+      parts.push(`$(clock) ${_fmtElapsed(elapsed)} / ${_fmtLimit(cfg.timeoutSeconds)}`);
+    }
+    if (cfg.budgetDollars) {
+      parts.push(`$(credit-card) $${costUsd.toFixed(2)} / $${cfg.budgetDollars.toFixed(2)}`);
+    }
+
+    this.item.text = parts.join("  ");
+    this.item.backgroundColor = undefined;
+    this.item.tooltip = "agent-trace watchdog — click to open session";
+    this.item.show();
+  }
+
+  private _renderDead(): void {
+    const label = this.deathReason.replace(/_/g, " ");
+    this.item.text = `$(error) ${label} — post-mortem ready`;
+    this.item.backgroundColor = new vscode.ThemeColor("statusBarItem.errorBackground");
+    this.item.tooltip = "agent-trace: watchdog terminated session — click to view post-mortem";
+    this.item.show();
+  }
+
+  private _cleanup(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.pmWatcher?.close();
+    this.pmWatcher = null;
+    this.watchdogCfg = null;
+    this.sessionId = null;
+  }
+
+  override dispose(): void {
+    this._cleanup();
     this.item.dispose();
   }
 }


### PR DESCRIPTION
## Summary

Implements all four VS Code extension issues in a single PR. Extension version bumped from `0.1.2` → `0.2.0`.

---

### #117 — Watchdog status bar (`statusBar.ts`)

A second status bar item appears when a watchdog session is active, showing live elapsed time and cost against the configured ceiling:

```
$(clock) 12m 34s / 30m   $(credit-card) $2.43 / $5.00
```

When `watchdog-postmortem.json` appears, it switches to a red error state:

```
$(error) budget exceeded — post-mortem ready
```

- Reads `watchdog_timeout_seconds` / `watchdog_budget_dollars` from `meta.json`
- Configurable poll interval via `agentTrace.watchdogPollIntervalSeconds` (default: 5s)
- Disposed cleanly on session end and extension deactivation

---

### #118 — Post-mortem viewer (`postMortem.ts`)

Watches all session directories for new `watchdog-postmortem.json` files and auto-opens a formatted webview panel. Shows:
- Reason, cost at death, wall time
- Last tool call and last LLM response
- Recovery context with **Copy recovery context** button (copies to clipboard, ready to paste as a follow-up system prompt)

Also accessible via command palette: `agent-trace: View Post-Mortem`.

---

### #119 — Session browser (`sessionTree.ts`)

A `TreeDataProvider` in the Explorer sidebar showing all sessions grouped by date:

```
AGENT TRACE SESSIONS
├── Today
│   ├── ⚠ a84664242afa  $5.03  refactor-auth
│   └── ✓ bf1207728ee6  $2.87  add-tests
└── Yesterday
    └── ✓ c91ab3312fde  $4.87  fix-login-bug
```

- Status icons: ✓ completed, ⚠ watchdog-terminated, ✗ error, ⟳ in-progress
- Click to open session in event stream panel
- Right-click watchdog sessions → View Post-Mortem
- Auto-refreshes via `fs.watch` + configurable polling (`agentTrace.sessionBrowserRefreshInterval`)

---

### #120 — Live streaming panel (`liveStream.ts`)

A webview connecting to `agent-strace server` via SSE (`EventSource` API — browser-native, not Node.js `http`):

- Real-time event feed with type-coloured rows
- Filter by event type, pause/resume, clear
- Max 500 events in DOM (oldest trimmed)
- Exponential backoff reconnection: 1s → 2s → 4s … capped at 30s
- "Jump to session" link in each row
- Shows configuration prompt when `agentTrace.collectorEndpoint` is unset

---

### New settings

| Setting | Default | Description |
|---|---|---|
| `agentTrace.watchdogPollIntervalSeconds` | `5` | Watchdog status bar poll interval |
| `agentTrace.collectorEndpoint` | `""` | Remote agent-strace server URL |
| `agentTrace.sessionBrowserRefreshInterval` | `5` | Session browser refresh interval |
