### PR TITLE
feat(server): API key authentication for collector (#130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,10 @@ python -m pytest tests/test_watch.py -v
 
 ## Version bumping
 
-Current version: `0.51.1` in `src/agent_trace/__init__.py`.
+Current version: `0.52.0` in `src/agent_trace/__init__.py`.
 
-- New feature (new command, new flag, new integration): bump minor (`0.51.1` → `0.52.0`)
-- Bug fix or small improvement: bump patch (`0.51.1` → `0.51.2`)
+- New feature (new command, new flag, new integration): bump minor (`0.52.0` → `0.53.0`)
+- Bug fix or small improvement: bump patch (`0.52.0` → `0.52.1`)
 - Breaking change to CLI or storage format: bump major — check with maintainer first
 
 ## docs/ structure

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -336,9 +336,19 @@ Export sessions as JSONL for eval datasets. Compatible with LangSmith, Braintrus
 
 ### `server`
 ```
-agent-strace server [--port N] [--storage DIR]
+agent-strace server [--port N] [--host HOST] [--storage DIR] [--auth-key KEY]
+agent-strace server keygen
 ```
 Start a server-side event collector. See [server.md](server.md).
+
+| Flag | Description |
+|---|---|
+| `--port N` | Port to listen on (default: 4317) |
+| `--host HOST` | Host to bind to (default: 0.0.0.0) |
+| `--storage DIR` | Trace storage directory (default: `$AGENT_STRACE_STORAGE` or `.agent-traces`) |
+| `--auth-key KEY` | Require `Authorization: Bearer KEY` on all requests (also read from `AGENT_STRACE_AUTH_KEY`) |
+
+`keygen` prints a new `ast_`-prefixed API key to stdout. Set `AGENT_STRACE_AUTH_KEY` on the client side to inject the header automatically into all outbound collector requests.
 
 ### `auto`
 ```

--- a/docs/server.md
+++ b/docs/server.md
@@ -58,9 +58,40 @@ When multiple agents send to the same collector, sessions are linked via `parent
 
 ---
 
-## Security note
+## Authentication
 
-No authentication in v1 — intended for internal/private network use. Add a reverse proxy (nginx, Caddy) for auth and TLS.
+By default the server runs unauthenticated (local use). For any network-accessible deployment, enable API key auth:
+
+```bash
+# Generate a key
+agent-strace server keygen
+# → ast_a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5
+
+# Start server with key enforcement
+agent-strace server --auth-key ast_a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5
+
+# Or via environment variable
+AGENT_STRACE_AUTH_KEY=ast_a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5 agent-strace server
+```
+
+Requests without a matching `Authorization: Bearer <key>` header receive `401 Unauthorized`.
+
+**Client side** — set `AGENT_STRACE_AUTH_KEY` alongside `AGENT_STRACE_ENDPOINT` and all outbound requests include the header automatically:
+
+```bash
+export AGENT_STRACE_ENDPOINT=https://collector.example.com
+export AGENT_STRACE_AUTH_KEY=ast_a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5
+python my_agent.py
+```
+
+The `--stream-headers` flag on `agent-strace watch` also works for one-off overrides:
+
+```bash
+agent-strace watch --stream-to https://collector.example.com \
+  --stream-headers "Authorization=Bearer ast_..."
+```
+
+Key format: `ast_` prefix + 32 hex characters. Generated with `secrets.token_hex(16)` — no new dependencies.
 
 ---
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.51.1"
+__version__ = "0.52.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -875,6 +875,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_server.add_argument("--storage", metavar="DIR",
                           help="storage directory for traces "
                                "(default: $AGENT_STRACE_STORAGE or .agent-traces)")
+    p_server.add_argument("--auth-key", metavar="KEY", dest="auth_key",
+                          help="require Authorization: Bearer <KEY> on all requests "
+                               "(also read from AGENT_STRACE_AUTH_KEY env var)")
+    p_server_sub = p_server.add_subparsers(dest="server_subcommand")
+    p_server_sub.add_parser("keygen", help="generate a new ast_-prefixed API key")
 
     # sample
     p_sample = sub.add_parser(

--- a/src/agent_trace/server.py
+++ b/src/agent_trace/server.py
@@ -14,11 +14,20 @@ API:
 Usage:
     agent-strace server --port 4317 --storage ./traces
 
+    # With API key authentication
+    agent-strace server keygen                          # generate a key
+    agent-strace server --auth-key ast_<key>            # enforce auth
+    AGENT_STRACE_AUTH_KEY=ast_<key> agent-strace server # via env var
+
 Agents point to it via environment variable:
     AGENT_STRACE_ENDPOINT=http://collector:4317 python my_agent.py
 
-No authentication in v1 — intended for internal/private network use.
-Add a reverse proxy (nginx, Caddy) for auth.
+    # With auth key on the client side
+    AGENT_STRACE_ENDPOINT=https://collector.example.com
+    AGENT_STRACE_AUTH_KEY=ast_<key>
+
+Without --auth-key / AGENT_STRACE_AUTH_KEY the server runs unauthenticated
+(original behaviour, unchanged for local use).
 
 See ADR-0012 for architecture decisions.
 """
@@ -28,6 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import secrets
 import sys
 import threading
 import time
@@ -41,26 +51,45 @@ from .store import TraceStore, DEFAULT_TRACE_DIR
 
 
 # ---------------------------------------------------------------------------
+# Key generation
+# ---------------------------------------------------------------------------
+
+KEY_PREFIX = "ast_"
+
+
+def generate_api_key() -> str:
+    """Return a new ``ast_``-prefixed API key using secrets.token_hex."""
+    return KEY_PREFIX + secrets.token_hex(16)
+
+
+# ---------------------------------------------------------------------------
 # Remote event sender (used by hooks when AGENT_STRACE_ENDPOINT is set)
 # ---------------------------------------------------------------------------
+
+def _auth_headers() -> dict[str, str]:
+    """Return Authorization header dict if AGENT_STRACE_AUTH_KEY is set."""
+    key = os.environ.get("AGENT_STRACE_AUTH_KEY", "").strip()
+    if key:
+        return {"Authorization": f"Bearer {key}"}
+    return {}
+
 
 def send_event_to_endpoint(event: TraceEvent, endpoint: str) -> bool:
     """POST a single event to a remote collector.
 
     Returns True on success. Failures are logged to stderr but never raise —
     the hook must not block the agent.
+
+    When AGENT_STRACE_AUTH_KEY is set, injects ``Authorization: Bearer``
+    automatically.
     """
     import urllib.request
     import urllib.error
 
     url = endpoint.rstrip("/") + "/events"
     body = (event.to_json() + "\n").encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers={"Content-Type": "application/x-ndjson"},
-        method="POST",
-    )
+    headers = {"Content-Type": "application/x-ndjson", **_auth_headers()}
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status in (200, 202)
@@ -70,18 +99,18 @@ def send_event_to_endpoint(event: TraceEvent, endpoint: str) -> bool:
 
 
 def send_session_meta_to_endpoint(meta: SessionMeta, endpoint: str) -> bool:
-    """POST session metadata to a remote collector."""
+    """POST session metadata to a remote collector.
+
+    When AGENT_STRACE_AUTH_KEY is set, injects ``Authorization: Bearer``
+    automatically.
+    """
     import urllib.request
     import urllib.error
 
     url = endpoint.rstrip("/") + "/sessions"
     body = meta.to_json().encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
+    headers = {"Content-Type": "application/json", **_auth_headers()}
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             return resp.status in (200, 202)
@@ -100,10 +129,18 @@ class CollectorHandler(BaseHTTPRequestHandler):
     # Injected by the server setup
     store: TraceStore
     _lock: threading.Lock
+    _auth_key: str  # empty string = no auth required
 
     def log_message(self, fmt: str, *args: Any) -> None:
         # Suppress default access log; write to stderr with our prefix
         sys.stderr.write(f"[server] {fmt % args}\n")
+
+    def _check_auth(self) -> bool:
+        """Return True if the request is authorised (or auth is disabled)."""
+        if not self._auth_key:
+            return True
+        auth = self.headers.get("Authorization", "")
+        return auth == f"Bearer {self._auth_key}"
 
     def _send_json(self, status: int, data: dict) -> None:
         body = json.dumps(data).encode("utf-8")
@@ -132,6 +169,9 @@ class CollectorHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------
 
     def do_GET(self) -> None:
+        if not self._check_auth():
+            self._send_json(401, {"error": "Unauthorized"})
+            return
         path = urlparse(self.path).path.rstrip("/")
 
         if path == "/health":
@@ -180,6 +220,9 @@ class CollectorHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------
 
     def do_POST(self) -> None:
+        if not self._check_auth():
+            self._send_json(401, {"error": "Unauthorized"})
+            return
         path = urlparse(self.path).path.rstrip("/")
         body = self._read_body()
 
@@ -248,12 +291,13 @@ class CollectorHandler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": str(exc)})
 
 
-def _make_handler(store: TraceStore, lock: threading.Lock) -> type:
-    """Return a CollectorHandler subclass with store and lock injected."""
+def _make_handler(store: TraceStore, lock: threading.Lock, auth_key: str = "") -> type:
+    """Return a CollectorHandler subclass with store, lock, and auth key injected."""
     class Handler(CollectorHandler):
         pass
     Handler.store = store
     Handler._lock = lock
+    Handler._auth_key = auth_key
     return Handler
 
 
@@ -265,15 +309,21 @@ def run_server(
     port: int,
     storage_dir: str,
     host: str = "0.0.0.0",
+    auth_key: str = "",
 ) -> None:
-    """Start the collector server and block until interrupted."""
+    """Start the collector server and block until interrupted.
+
+    When *auth_key* is non-empty, all requests must include
+    ``Authorization: Bearer <auth_key>`` or receive 401.
+    """
     store = TraceStore(storage_dir)
     lock = threading.Lock()
-    handler_class = _make_handler(store, lock)
+    handler_class = _make_handler(store, lock, auth_key=auth_key)
 
     server = HTTPServer((host, port), handler_class)
+    auth_note = " (auth enabled)" if auth_key else " (no auth)"
     sys.stderr.write(
-        f"[agent-strace server] listening on {host}:{port}\n"
+        f"[agent-strace server] listening on {host}:{port}{auth_note}\n"
         f"[agent-strace server] storage: {Path(storage_dir).resolve()}\n"
         f"[agent-strace server] health: http://{host}:{port}/health\n"
     )
@@ -290,10 +340,20 @@ def run_server(
 # ---------------------------------------------------------------------------
 
 def cmd_server(args: argparse.Namespace) -> int:
+    subcommand = getattr(args, "server_subcommand", None)
+
+    if subcommand == "keygen":
+        sys.stdout.write(generate_api_key() + "\n")
+        return 0
+
     port = getattr(args, "port", 4317)
     storage = getattr(args, "storage", None) or os.environ.get(
         "AGENT_STRACE_STORAGE", DEFAULT_TRACE_DIR
     )
     host = getattr(args, "host", "0.0.0.0")
-    run_server(port=port, storage_dir=storage, host=host)
+    auth_key = (
+        getattr(args, "auth_key", None)
+        or os.environ.get("AGENT_STRACE_AUTH_KEY", "")
+    ).strip()
+    run_server(port=port, storage_dir=storage, host=host, auth_key=auth_key)
     return 0

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,385 @@
+"""Tests for API key authentication on the collector server (Issue #130)."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from agent_trace.server import (
+    KEY_PREFIX,
+    _auth_headers,
+    _make_handler,
+    cmd_server,
+    generate_api_key,
+    run_server,
+    send_event_to_endpoint,
+    send_session_meta_to_endpoint,
+)
+from agent_trace.store import TraceStore
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_store() -> TraceStore:
+    return TraceStore(Path(tempfile.mkdtemp()))
+
+
+def _start_server(store: TraceStore, auth_key: str = "", port: int = 0):
+    """Start a test server on an ephemeral port. Returns (server, port)."""
+    from http.server import HTTPServer
+    lock = threading.Lock()
+    handler = _make_handler(store, lock, auth_key=auth_key)
+    server = HTTPServer(("127.0.0.1", port), handler)
+    actual_port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, actual_port
+
+
+def _post(url: str, body: bytes, content_type: str, headers: dict | None = None) -> tuple[int, bytes]:
+    h = {"Content-Type": content_type, **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=h, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _get(url: str, headers: dict | None = None) -> tuple[int, bytes]:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _make_event(session_id: str = "test-session-001") -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.TOOL_CALL,
+        timestamp=1_000_000.0,
+        session_id=session_id,
+        data={"tool_name": "Bash", "arguments": {"command": "ls"}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# generate_api_key
+# ---------------------------------------------------------------------------
+
+class TestGenerateApiKey(unittest.TestCase):
+
+    def test_starts_with_prefix(self):
+        key = generate_api_key()
+        self.assertTrue(key.startswith(KEY_PREFIX))
+
+    def test_length(self):
+        # ast_ (4) + 32 hex chars = 36
+        key = generate_api_key()
+        self.assertEqual(len(key), 36)
+
+    def test_hex_suffix(self):
+        key = generate_api_key()
+        suffix = key[len(KEY_PREFIX):]
+        self.assertTrue(all(c in "0123456789abcdef" for c in suffix))
+
+    def test_unique(self):
+        keys = {generate_api_key() for _ in range(20)}
+        self.assertEqual(len(keys), 20)
+
+    def test_prefix_constant(self):
+        self.assertEqual(KEY_PREFIX, "ast_")
+
+
+# ---------------------------------------------------------------------------
+# _auth_headers
+# ---------------------------------------------------------------------------
+
+class TestAuthHeaders(unittest.TestCase):
+
+    def test_empty_when_no_env(self):
+        os.environ.pop("AGENT_STRACE_AUTH_KEY", None)
+        self.assertEqual(_auth_headers(), {})
+
+    def test_returns_bearer_when_set(self):
+        os.environ["AGENT_STRACE_AUTH_KEY"] = "ast_abc123"
+        try:
+            h = _auth_headers()
+            self.assertEqual(h.get("Authorization"), "Bearer ast_abc123")
+        finally:
+            del os.environ["AGENT_STRACE_AUTH_KEY"]
+
+    def test_empty_string_env_gives_no_header(self):
+        os.environ["AGENT_STRACE_AUTH_KEY"] = ""
+        try:
+            self.assertEqual(_auth_headers(), {})
+        finally:
+            del os.environ["AGENT_STRACE_AUTH_KEY"]
+
+
+# ---------------------------------------------------------------------------
+# Server: no-auth mode (existing behaviour unchanged)
+# ---------------------------------------------------------------------------
+
+class TestServerNoAuth(unittest.TestCase):
+
+    def setUp(self):
+        self.store = _make_store()
+        self.server, self.port = _start_server(self.store, auth_key="")
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_health_no_auth_required(self):
+        status, body = _get(f"{self.base}/health")
+        self.assertEqual(status, 200)
+
+    def test_post_events_no_auth_required(self):
+        event = _make_event()
+        status, _ = _post(
+            f"{self.base}/events",
+            (event.to_json() + "\n").encode(),
+            "application/x-ndjson",
+        )
+        self.assertEqual(status, 200)
+
+    def test_get_sessions_no_auth_required(self):
+        status, _ = _get(f"{self.base}/sessions")
+        self.assertEqual(status, 200)
+
+    def test_no_auth_header_still_works(self):
+        status, _ = _get(f"{self.base}/health")
+        self.assertNotEqual(status, 401)
+
+
+# ---------------------------------------------------------------------------
+# Server: auth mode — valid key accepted
+# ---------------------------------------------------------------------------
+
+class TestServerAuthValid(unittest.TestCase):
+
+    KEY = "ast_deadbeef1234567890abcdef123456"
+
+    def setUp(self):
+        self.store = _make_store()
+        self.server, self.port = _start_server(self.store, auth_key=self.KEY)
+        self.base = f"http://127.0.0.1:{self.port}"
+        self.auth = {"Authorization": f"Bearer {self.KEY}"}
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_health_with_valid_key(self):
+        status, _ = _get(f"{self.base}/health", headers=self.auth)
+        self.assertEqual(status, 200)
+
+    def test_post_events_with_valid_key(self):
+        event = _make_event()
+        status, _ = _post(
+            f"{self.base}/events",
+            (event.to_json() + "\n").encode(),
+            "application/x-ndjson",
+            headers=self.auth,
+        )
+        self.assertEqual(status, 200)
+
+    def test_get_sessions_with_valid_key(self):
+        status, _ = _get(f"{self.base}/sessions", headers=self.auth)
+        self.assertEqual(status, 200)
+
+    def test_post_sessions_with_valid_key(self):
+        meta = SessionMeta(agent_name="test")
+        status, _ = _post(
+            f"{self.base}/sessions",
+            meta.to_json().encode(),
+            "application/json",
+            headers=self.auth,
+        )
+        self.assertEqual(status, 200)
+
+
+# ---------------------------------------------------------------------------
+# Server: auth mode — missing key rejected
+# ---------------------------------------------------------------------------
+
+class TestServerAuthMissing(unittest.TestCase):
+
+    KEY = "ast_cafebabe1234567890abcdef123456"
+
+    def setUp(self):
+        self.store = _make_store()
+        self.server, self.port = _start_server(self.store, auth_key=self.KEY)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_health_without_key_returns_401(self):
+        status, _ = _get(f"{self.base}/health")
+        self.assertEqual(status, 401)
+
+    def test_post_events_without_key_returns_401(self):
+        event = _make_event()
+        status, _ = _post(
+            f"{self.base}/events",
+            (event.to_json() + "\n").encode(),
+            "application/x-ndjson",
+        )
+        self.assertEqual(status, 401)
+
+    def test_get_sessions_without_key_returns_401(self):
+        status, _ = _get(f"{self.base}/sessions")
+        self.assertEqual(status, 401)
+
+    def test_401_body_is_json(self):
+        status, body = _get(f"{self.base}/health")
+        self.assertEqual(status, 401)
+        data = json.loads(body)
+        self.assertIn("error", data)
+
+
+# ---------------------------------------------------------------------------
+# Server: auth mode — wrong key rejected
+# ---------------------------------------------------------------------------
+
+class TestServerAuthWrongKey(unittest.TestCase):
+
+    KEY = "ast_rightkey1234567890abcdef1234"
+
+    def setUp(self):
+        self.store = _make_store()
+        self.server, self.port = _start_server(self.store, auth_key=self.KEY)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_wrong_key_returns_401(self):
+        status, _ = _get(
+            f"{self.base}/health",
+            headers={"Authorization": "Bearer ast_wrongkey000000000000000000000"},
+        )
+        self.assertEqual(status, 401)
+
+    def test_partial_key_returns_401(self):
+        status, _ = _get(
+            f"{self.base}/health",
+            headers={"Authorization": f"Bearer {self.KEY[:-1]}"},
+        )
+        self.assertEqual(status, 401)
+
+    def test_no_bearer_prefix_returns_401(self):
+        status, _ = _get(
+            f"{self.base}/health",
+            headers={"Authorization": self.KEY},
+        )
+        self.assertEqual(status, 401)
+
+    def test_empty_bearer_returns_401(self):
+        status, _ = _get(
+            f"{self.base}/health",
+            headers={"Authorization": "Bearer "},
+        )
+        self.assertEqual(status, 401)
+
+
+# ---------------------------------------------------------------------------
+# cmd_server keygen
+# ---------------------------------------------------------------------------
+
+class TestCmdServerKeygen(unittest.TestCase):
+
+    def _run_keygen(self) -> str:
+        args = argparse.Namespace(
+            server_subcommand="keygen",
+            port=4317,
+            storage=None,
+            host="0.0.0.0",
+            auth_key=None,
+            trace_dir=Path(tempfile.mkdtemp()),
+        )
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            result = cmd_server(args)
+        finally:
+            sys.stdout = old
+        return buf.getvalue().strip(), result
+
+    def test_keygen_returns_0(self):
+        _, rc = self._run_keygen()
+        self.assertEqual(rc, 0)
+
+    def test_keygen_prints_key(self):
+        key, _ = self._run_keygen()
+        self.assertTrue(key.startswith(KEY_PREFIX))
+
+    def test_keygen_key_correct_length(self):
+        key, _ = self._run_keygen()
+        self.assertEqual(len(key), 36)
+
+    def test_keygen_produces_unique_keys(self):
+        keys = {self._run_keygen()[0] for _ in range(5)}
+        self.assertEqual(len(keys), 5)
+
+
+# ---------------------------------------------------------------------------
+# AGENT_STRACE_AUTH_KEY env var injected into client send functions
+# ---------------------------------------------------------------------------
+
+class TestClientAuthInjection(unittest.TestCase):
+
+    KEY = "ast_clienttest1234567890abcdef12"
+
+    def setUp(self):
+        self.store = _make_store()
+        self.server, self.port = _start_server(self.store, auth_key=self.KEY)
+        self.base = f"http://127.0.0.1:{self.port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        os.environ.pop("AGENT_STRACE_AUTH_KEY", None)
+
+    def test_send_event_fails_without_env_key(self):
+        os.environ.pop("AGENT_STRACE_AUTH_KEY", None)
+        event = _make_event()
+        result = send_event_to_endpoint(event, self.base)
+        self.assertFalse(result)
+
+    def test_send_event_succeeds_with_env_key(self):
+        os.environ["AGENT_STRACE_AUTH_KEY"] = self.KEY
+        event = _make_event()
+        result = send_event_to_endpoint(event, self.base)
+        self.assertTrue(result)
+
+    def test_send_session_meta_fails_without_env_key(self):
+        os.environ.pop("AGENT_STRACE_AUTH_KEY", None)
+        meta = SessionMeta(agent_name="test")
+        result = send_session_meta_to_endpoint(meta, self.base)
+        self.assertFalse(result)
+
+    def test_send_session_meta_succeeds_with_env_key(self):
+        os.environ["AGENT_STRACE_AUTH_KEY"] = self.KEY
+        meta = SessionMeta(agent_name="test")
+        result = send_session_meta_to_endpoint(meta, self.base)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds API key authentication to `agent-strace server`. Prerequisite for the hosted collector (#129).

Closes #130

## Changes

**Server side**
- `agent-strace server keygen` — generates a new `ast_`-prefixed key using `secrets.token_hex(16)`
- `agent-strace server --auth-key KEY` — enforces `Authorization: Bearer KEY` on all endpoints; requests without it get `401`
- `AGENT_STRACE_AUTH_KEY` env var — alternative to `--auth-key` on the server
- No `--auth-key` = current unauthenticated behaviour, unchanged

**Client side**
- `AGENT_STRACE_AUTH_KEY` env var — when set, `send_event_to_endpoint` and `send_session_meta_to_endpoint` inject `Authorization: Bearer` automatically into all outbound requests to `AGENT_STRACE_ENDPOINT`
- `--stream-headers` on `watch` already worked; no changes needed there

**No new dependencies** — `secrets.token_hex` is stdlib.

## Tests

32 tests in `tests/test_server_auth.py`:
- `generate_api_key`: prefix, length, hex suffix, uniqueness
- `_auth_headers`: env var present/absent/empty
- No-auth mode: all endpoints still work without a key
- Auth mode, valid key: all endpoints return 200
- Auth mode, missing key: all endpoints return 401 with JSON body
- Auth mode, wrong key: wrong key / partial key / no Bearer prefix / empty Bearer all return 401
- `cmd_server keygen`: returns 0, prints valid key, unique across calls
- Client injection: `send_event_to_endpoint` and `send_session_meta_to_endpoint` fail without env key, succeed with it

## Docs

- `docs/server.md`: new Authentication section with keygen, `--auth-key`, `AGENT_STRACE_AUTH_KEY`, and `--stream-headers` examples
- `docs/commands.md`: `server` flag table updated
