### PR TITLE
docs(server): add hosted collector section (#129)

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -6,6 +6,27 @@ See [ADR-0012](../ADRs/0012-server-side-event-collector.md) for design rationale
 
 ---
 
+## Hosted collector
+
+> **Status: planned.** A managed `collector.agent-strace.dev` endpoint is on the roadmap. When available, it will implement the same API as `agent-strace server` — no client changes required.
+>
+> Track progress and sign up for early access: [agent-strace/collector](https://github.com/Siddhant-K-code/agent-strace-collector) *(infrastructure repo, separate from this package)*
+
+Once live, the only change needed is the endpoint:
+
+```bash
+# Self-hosted (today)
+AGENT_STRACE_ENDPOINT=http://localhost:4317 python my_agent.py
+
+# Hosted (when available — no other changes)
+AGENT_STRACE_ENDPOINT=https://collector.agent-strace.dev python my_agent.py
+AGENT_STRACE_AUTH_KEY=ast_<your-key>
+```
+
+The hosted endpoint will implement the same API documented below, with API key auth (see [Authentication](#authentication)) and a free tier for individual developers.
+
+---
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## What

Adds a "Hosted collector" section to `docs/server.md` for issue #129.

Refs #129

## Changes

- `docs/server.md`: new section at the top describing the planned `collector.agent-strace.dev` endpoint
  - Marked as **planned / not yet live**
  - Links to a separate infrastructure repo (`agent-strace/agent-strace-collector`) for the deployment work
  - Shows the one-line client change needed when it is available (`AGENT_STRACE_ENDPOINT` + `AGENT_STRACE_AUTH_KEY`)
  - No code changes — the client is already fully ready

## Note

The infrastructure work (persistent HTTP service, storage, domain, free tier) belongs in a separate repo. See comment on #129.
