### PR TITLE
feat: watch --policy flag and annotation filters/export

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -144,7 +144,7 @@ Check token usage against model context limit.
 ### `watch`
 ```
 agent-strace watch [session-id] [--timeout DURATION] [--budget $N] [--on-violation ACTION]
-                   [--on-death CMD] [--rules FILE] [--stream-to URL]
+                   [--on-death CMD] [--policy FILE] [--rules FILE] [--stream-to URL]
                    [--stream-batch-size N] [--stream-flush-interval S]
                    [--max-context-pct N] [--dry-run]
 ```
@@ -156,6 +156,7 @@ Live session monitor with kill-switch rules.
 | `--budget $N` | Kill when spend exceeds N dollars |
 | `--on-violation kill\|pause\|alert` | Action when a rule fires |
 | `--on-death CMD` | Command to run after kill (receives `{post_mortem_path}`) |
+| `--policy FILE` | Scope policy file to enforce (default: `.agent-scope.json`) |
 | `--rules FILE` | JSON rules file |
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
 | `--dry-run` | Evaluate rules without acting |
@@ -374,10 +375,26 @@ Visualise the A2A agent call graph. Exports as OTLP spans for Jaeger, Tempo, or 
 
 ### `annotate`
 ```
-agent-strace annotate <session-id> <event-offset> [--note TEXT] [--label TEXT]
-                      [--bookmark] [--list] [--delete ANNOTATION_ID]
+agent-strace annotate <session-id> [--event ID] [--at OFFSET] [--note TEXT] [--label LABEL]
+                      [--author NAME] [--list] [--delete ANNOTATION_ID]
+                      [--filter-label LABEL] [--filter-author AUTHOR] [--since Nd]
+                      [--export-format json]
 ```
 Add notes, labels, and bookmarks to session events. Annotations appear in shared HTML reports.
+
+| Flag | Description |
+|---|---|
+| `--event ID` | Event ID to annotate |
+| `--at OFFSET` | Time offset to annotate (e.g. `2m14s`, `1:30`) |
+| `--note TEXT` | Text note to attach |
+| `--label LABEL` | Label chip (`root-cause`, `decision`, `retry`, `fix`, `question`) |
+| `--author NAME` | Author name or email |
+| `--list` | List all annotations for the session |
+| `--delete ID` | Delete an annotation by ID |
+| `--filter-label LABEL` | Filter `--list` by label |
+| `--filter-author AUTHOR` | Filter `--list` by author |
+| `--since Nd` | Filter `--list` to annotations created in the last N days |
+| `--export-format json` | Output `--list` as JSON instead of terminal text |
 
 ### `retention`
 ```

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.53.0"
+__version__ = "0.54.0"

--- a/src/agent_trace/annotate.py
+++ b/src/agent_trace/annotate.py
@@ -181,6 +181,23 @@ def _find_event_by_offset(
 # Formatting
 # ---------------------------------------------------------------------------
 
+def filter_annotations(
+    annotations: list[Annotation],
+    label: str = "",
+    author: str = "",
+    since: float = 0.0,
+) -> list[Annotation]:
+    """Filter annotations by label, author, and/or minimum created_at timestamp."""
+    result = annotations
+    if label:
+        result = [a for a in result if a.label == label]
+    if author:
+        result = [a for a in result if a.author == author]
+    if since:
+        result = [a for a in result if a.created_at >= since]
+    return result
+
+
 def format_annotations(
     annotations: list[Annotation],
     out: TextIO = sys.stdout,
@@ -220,10 +237,32 @@ def cmd_annotate(args: argparse.Namespace) -> int:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
 
-    # --list
+    # --list (with optional filters)
     if getattr(args, "list", False):
         annotations = load_annotations(store, full_id)
-        format_annotations(annotations)
+
+        # Apply filters
+        filter_label = getattr(args, "filter_label", "") or ""
+        filter_author = getattr(args, "filter_author", "") or ""
+        since_str = getattr(args, "since", "") or ""
+        since_ts = 0.0
+        if since_str:
+            import re as _re
+            m = _re.fullmatch(r"(\d+)d", since_str.strip())
+            if m:
+                since_ts = time.time() - int(m.group(1)) * 86400
+            else:
+                sys.stderr.write(f"Invalid --since value: {since_str!r} (use e.g. 7d)\n")
+                return 1
+        annotations = filter_annotations(annotations, label=filter_label,
+                                         author=filter_author, since=since_ts)
+
+        export_fmt = getattr(args, "export_format", "") or ""
+        if export_fmt == "json":
+            import dataclasses as _dc
+            sys.stdout.write(json.dumps([_dc.asdict(a) for a in annotations], indent=2) + "\n")
+        else:
+            format_annotations(annotations)
         return 0
 
     # --delete

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -694,6 +694,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument("--config", help="path to .agent-watch.json config file")
     p_watch.add_argument("--max-context-pct", type=int, default=90, dest="max_context_pct",
                          help="alert when context window is this %% full (default: 90)")
+    p_watch.add_argument("--policy", metavar="POLICY_FILE",
+                         help="path to scope policy file (default: .agent-scope.json)")
     p_watch.add_argument("--rules", metavar="RULES_FILE",
                          help="YAML/JSON rules file for rule-based kill switch (nanny mode)")
     p_watch.add_argument("--dry-run", action="store_true", dest="dry_run",
@@ -740,6 +742,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_ann.add_argument("--author", help="author name or email")
     p_ann.add_argument("--list", action="store_true", help="list all annotations for the session")
     p_ann.add_argument("--delete", metavar="ANNOTATION_ID", help="delete an annotation by ID")
+    p_ann.add_argument("--filter-label", dest="filter_label", metavar="LABEL",
+                       help="filter listed annotations by label")
+    p_ann.add_argument("--filter-author", dest="filter_author", metavar="AUTHOR",
+                       help="filter listed annotations by author")
+    p_ann.add_argument("--since", metavar="Nd",
+                       help="filter listed annotations created in the last N days (e.g. 7d)")
+    p_ann.add_argument("--export-format", dest="export_format", choices=["json"],
+                       help="output format for --list (default: terminal)")
 
     # token-budget
     p_tb = sub.add_parser("token-budget", help="show context window usage for a session")

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -1021,6 +1021,7 @@ def cmd_watch(args: argparse.Namespace) -> int:
             on_violation=getattr(args, "on_violation", "terminal"),
             webhook_url=getattr(args, "webhook", "") or "",
             on_death_cmd=getattr(args, "on_death", "") or "",
+            scope_policy=getattr(args, "policy", None) or ".agent-scope.json",
         )
 
     # Load nanny rules if --rules provided

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -13,6 +13,7 @@ from agent_trace.annotate import (
     _parse_offset,
     add_annotation,
     delete_annotation,
+    filter_annotations,
     format_annotations,
     load_annotations,
 )
@@ -113,6 +114,65 @@ class TestFormatAnnotations(unittest.TestCase):
         output = buf.getvalue()
         self.assertIn("root cause", output)
         self.assertIn("root-cause", output)
+
+
+class TestFilterAnnotations(unittest.TestCase):
+    def _make_annotations(self):
+        import time
+        now = time.time()
+        return [
+            Annotation(event_id="e1", label="root-cause", author="alice", note="a", created_at=now - 86400 * 10),
+            Annotation(event_id="e2", label="decision",   author="bob",   note="b", created_at=now - 86400 * 3),
+            Annotation(event_id="e3", label="root-cause", author="bob",   note="c", created_at=now - 86400 * 1),
+        ]
+
+    def test_filter_by_label(self):
+        anns = self._make_annotations()
+        result = filter_annotations(anns, label="root-cause")
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(a.label == "root-cause" for a in result))
+
+    def test_filter_by_author(self):
+        anns = self._make_annotations()
+        result = filter_annotations(anns, author="bob")
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(a.author == "bob" for a in result))
+
+    def test_filter_by_since(self):
+        import time
+        anns = self._make_annotations()
+        since = time.time() - 86400 * 5  # last 5 days
+        result = filter_annotations(anns, since=since)
+        self.assertEqual(len(result), 2)
+
+    def test_filter_combined(self):
+        import time
+        anns = self._make_annotations()
+        since = time.time() - 86400 * 5
+        result = filter_annotations(anns, label="root-cause", author="bob", since=since)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].event_id, "e3")
+
+    def test_no_filter_returns_all(self):
+        anns = self._make_annotations()
+        result = filter_annotations(anns)
+        self.assertEqual(len(result), 3)
+
+
+class TestWatchPolicyFlag(unittest.TestCase):
+    """Verify --policy is wired into WatcherConfig."""
+
+    def test_policy_path_passed_to_config(self):
+        import argparse
+        from agent_trace.watch import WatcherConfig
+        # Simulate what cmd_watch does when --policy is provided
+        config = WatcherConfig(scope_policy="/tmp/my-policy.json")
+        self.assertEqual(config.scope_policy, "/tmp/my-policy.json")
+
+    def test_default_policy_path(self):
+        from agent_trace.watch import WatcherConfig
+        config = WatcherConfig()
+        self.assertEqual(config.scope_policy, ".agent-scope.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #133
Closes #140

## What changed

**`watch --policy FILE`** (`#133`)
Previously the only way to specify a scope policy file was via a full `--config .agent-watch.json`. Now you can pass it directly:
```bash
agent-strace watch --policy .agent-scope.json
```
The flag wires into `WatcherConfig.scope_policy`, which the existing `ScopeWatcher` already reads.

**Annotation filters and JSON export** (`#140`)
`agent-strace annotate --list` now supports:
```bash
# filter by label
agent-strace annotate <sid> --list --filter-label root-cause

# filter by author
agent-strace annotate <sid> --list --filter-author alice

# filter to last 7 days
agent-strace annotate <sid> --list --since 7d

# export as JSON (e.g. for CI or downstream tooling)
agent-strace annotate <sid> --list --export-format json
```

42/42 tests passing.