### PR TITLE
feat(v0.6.0): live OTLP streaming, baseline anomaly detection, machine identity

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.57.0"
+__version__ = "0.60.0"

--- a/src/agent_trace/baseline.py
+++ b/src/agent_trace/baseline.py
@@ -1,0 +1,314 @@
+"""Per-session baseline and anomaly detection.
+
+Builds a statistical baseline (mean, stddev) from historical sessions and
+flags individual sessions that deviate beyond a configurable sigma threshold.
+
+Usage:
+    # Build / update baseline from recent sessions
+    agent-strace baseline update [--since 30d] [--output .agent-traces/baseline.json]
+
+    # Check a single session against the baseline
+    agent-strace baseline check [session-id] [--baseline FILE] [--sigma 2.0]
+
+    # Show baseline stats
+    agent-strace baseline show [--baseline FILE]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+DEFAULT_BASELINE_PATH = ".agent-traces/baseline.json"
+DEFAULT_SIGMA = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Stats helpers
+# ---------------------------------------------------------------------------
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _stddev(values: list[float], mean: float) -> float:
+    if len(values) < 2:
+        return 0.0
+    variance = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def _z_score(value: float, mean: float, stddev: float) -> float:
+    """Return z-score; 0 when stddev is 0 (no variance in baseline)."""
+    if stddev == 0:
+        return 0.0
+    return abs(value - mean) / stddev
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MetricStats:
+    mean: float = 0.0
+    stddev: float = 0.0
+    min: float = 0.0
+    max: float = 0.0
+    count: int = 0
+
+
+@dataclass
+class BaselineProfile:
+    """Statistical profile built from N historical sessions."""
+    created_at: float = field(default_factory=time.time)
+    session_count: int = 0
+    cost_usd: MetricStats = field(default_factory=MetricStats)
+    tool_calls: MetricStats = field(default_factory=MetricStats)
+    duration_ms: MetricStats = field(default_factory=MetricStats)
+    error_rate: MetricStats = field(default_factory=MetricStats)   # errors / tool_calls
+    llm_requests: MetricStats = field(default_factory=MetricStats)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "BaselineProfile":
+        d = json.loads(text)
+        profile = cls()
+        profile.created_at = d.get("created_at", 0.0)
+        profile.session_count = d.get("session_count", 0)
+        for metric in ("cost_usd", "tool_calls", "duration_ms", "error_rate", "llm_requests"):
+            raw = d.get(metric, {})
+            setattr(profile, metric, MetricStats(**{
+                k: raw.get(k, 0.0) if k != "count" else raw.get(k, 0)
+                for k in ("mean", "stddev", "min", "max", "count")
+            }))
+        return profile
+
+
+@dataclass
+class AnomalyResult:
+    session_id: str
+    anomalous: bool
+    deviations: dict[str, float] = field(default_factory=dict)   # metric → z-score
+    sigma_threshold: float = DEFAULT_SIGMA
+
+    def format(self, out: TextIO = sys.stdout) -> None:
+        status = "ANOMALOUS" if self.anomalous else "OK"
+        out.write(f"\nBaseline check: {self.session_id[:12]}  [{status}]\n\n")
+        if not self.deviations:
+            out.write("  No metrics to compare.\n")
+            return
+        out.write(f"  {'Metric':<18} {'z-score':>8}  {'Status'}\n")
+        out.write(f"  {'-'*18} {'-'*8}  {'-'*10}\n")
+        for metric, z in sorted(self.deviations.items()):
+            flag = "⚠ ANOMALY" if z > self.sigma_threshold else "ok"
+            out.write(f"  {metric:<18} {z:>8.2f}  {flag}\n")
+        out.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Building a baseline
+# ---------------------------------------------------------------------------
+
+def _session_metrics(store: TraceStore, session_id: str) -> dict[str, float] | None:
+    """Extract scalar metrics from a single session. Returns None if unusable."""
+    try:
+        meta = store.load_meta(session_id)
+    except Exception:
+        return None
+    if not meta or not meta.ended_at:
+        return None
+    try:
+        events = store.load_events(session_id)
+    except Exception:
+        events = []
+    errors = sum(1 for e in events if e.event_type == EventType.ERROR)
+    tool_calls = max(meta.tool_calls, 1)
+
+    # Compute cost from token events if available (lazy import to avoid circular deps)
+    cost_usd = 0.0
+    try:
+        from .cost import compute_cost
+        cost_usd = compute_cost(events) or 0.0
+    except Exception:
+        pass
+
+    return {
+        "cost_usd": cost_usd,
+        "tool_calls": float(meta.tool_calls),
+        "duration_ms": meta.total_duration_ms or 0.0,
+        "error_rate": errors / tool_calls,
+        "llm_requests": float(meta.llm_requests),
+    }
+
+
+def build_baseline(store: TraceStore, since_days: float = 30.0) -> BaselineProfile:
+    """Build a baseline profile from sessions completed in the last *since_days* days."""
+    cutoff = time.time() - since_days * 86400
+    session_ids = store.list_sessions()
+
+    samples: dict[str, list[float]] = {
+        "cost_usd": [], "tool_calls": [], "duration_ms": [],
+        "error_rate": [], "llm_requests": [],
+    }
+
+    for meta in session_ids:
+        try:
+            if not meta or not meta.ended_at or meta.started_at < cutoff:
+                continue
+            m = _session_metrics(store, meta.session_id)
+            if m is None:
+                continue
+            for key, val in m.items():
+                samples[key].append(val)
+        except Exception:
+            continue
+
+    profile = BaselineProfile(session_count=len(samples["cost_usd"]))
+    for metric, values in samples.items():
+        if not values:
+            continue
+        mean = _mean(values)
+        sd = _stddev(values, mean)
+        stats = MetricStats(
+            mean=mean,
+            stddev=sd,
+            min=min(values),
+            max=max(values),
+            count=len(values),
+        )
+        setattr(profile, metric, stats)
+
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Checking a session against the baseline
+# ---------------------------------------------------------------------------
+
+def check_session(
+    store: TraceStore,
+    session_id: str,
+    profile: BaselineProfile,
+    sigma: float = DEFAULT_SIGMA,
+) -> AnomalyResult:
+    """Compare a session's metrics against the baseline profile."""
+    metrics = _session_metrics(store, session_id)
+    if metrics is None:
+        return AnomalyResult(session_id=session_id, anomalous=False,
+                             sigma_threshold=sigma)
+
+    deviations: dict[str, float] = {}
+    for metric, value in metrics.items():
+        stats: MetricStats = getattr(profile, metric)
+        if stats.count < 3:
+            continue  # not enough data to be meaningful
+        z = _z_score(value, stats.mean, stats.stddev)
+        deviations[metric] = z
+
+    anomalous = any(z > sigma for z in deviations.values())
+    return AnomalyResult(
+        session_id=session_id,
+        anomalous=anomalous,
+        deviations=deviations,
+        sigma_threshold=sigma,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def save_baseline(profile: BaselineProfile, path: str = DEFAULT_BASELINE_PATH) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(profile.to_json())
+
+
+def load_baseline(path: str = DEFAULT_BASELINE_PATH) -> BaselineProfile | None:
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        return BaselineProfile.from_json(p.read_text())
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_baseline(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    sub = getattr(args, "baseline_cmd", None)
+
+    if sub == "update":
+        since_days = float(getattr(args, "since_days", 30))
+        output = getattr(args, "output", DEFAULT_BASELINE_PATH)
+        profile = build_baseline(store, since_days=since_days)
+        save_baseline(profile, output)
+        sys.stdout.write(
+            f"Baseline updated: {profile.session_count} sessions, "
+            f"saved to {output}\n"
+        )
+        return 0
+
+    elif sub == "check":
+        session_id = getattr(args, "session_id", None)
+        if not session_id:
+            session_id = store.get_latest_session_id()
+        if not session_id:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+        full_id = store.find_session(session_id)
+        if not full_id:
+            sys.stderr.write(f"Session not found: {session_id}\n")
+            return 1
+
+        baseline_path = getattr(args, "baseline_path", DEFAULT_BASELINE_PATH)
+        sigma = float(getattr(args, "sigma", DEFAULT_SIGMA))
+        profile = load_baseline(baseline_path)
+        if not profile:
+            sys.stderr.write(f"No baseline found at {baseline_path}. "
+                             f"Run: agent-strace baseline update\n")
+            return 1
+
+        result = check_session(store, full_id, profile, sigma=sigma)
+        result.format()
+        return 1 if result.anomalous else 0
+
+    elif sub == "show":
+        baseline_path = getattr(args, "baseline_path", DEFAULT_BASELINE_PATH)
+        profile = load_baseline(baseline_path)
+        if not profile:
+            sys.stderr.write(f"No baseline found at {baseline_path}\n")
+            return 1
+        ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(profile.created_at))
+        sys.stdout.write(f"\nBaseline ({profile.session_count} sessions, built {ts})\n\n")
+        sys.stdout.write(f"  {'Metric':<18} {'Mean':>10} {'Stddev':>10} {'Min':>10} {'Max':>10}\n")
+        sys.stdout.write(f"  {'-'*18} {'-'*10} {'-'*10} {'-'*10} {'-'*10}\n")
+        for metric in ("cost_usd", "tool_calls", "duration_ms", "error_rate", "llm_requests"):
+            s: MetricStats = getattr(profile, metric)
+            sys.stdout.write(
+                f"  {metric:<18} {s.mean:>10.3f} {s.stddev:>10.3f} "
+                f"{s.min:>10.3f} {s.max:>10.3f}\n"
+            )
+        sys.stdout.write("\n")
+        return 0
+
+    else:
+        sys.stderr.write("Usage: agent-strace baseline <update|check|show>\n")
+        return 1

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -25,7 +25,9 @@ from .http_proxy import HTTPProxyServer
 from .a2a import cmd_a2a_tree
 from .mcp_server import cmd_mcp
 from .annotate import cmd_annotate
+from .baseline import cmd_baseline
 from .drift import cmd_drift
+from .identity import cmd_identity
 from .langfuse_export import cmd_export_scores
 from .oncall import cmd_oncall
 from .optimize import cmd_optimize
@@ -700,6 +702,8 @@ def build_parser() -> argparse.ArgumentParser:
                          help="YAML/JSON rules file for rule-based kill switch (nanny mode)")
     p_watch.add_argument("--dry-run", action="store_true", dest="dry_run",
                          help="evaluate rules without taking action (for testing)")
+    p_watch.add_argument("--stream-otlp", dest="stream_otlp", action="store_true",
+                         help="stream events as OTLP JSON spans instead of raw NDJSON")
     p_watch.add_argument("--stream-to", dest="stream_to", metavar="URL",
                          help="push events in real-time to this HTTP endpoint as NDJSON")
     p_watch.add_argument("--stream-batch-size", dest="stream_batch_size", type=int, default=10,
@@ -801,6 +805,43 @@ def build_parser() -> argparse.ArgumentParser:
     p_fresh.add_argument("--since", default="", help="check changes since this date (YYYY-MM-DD)")
     p_fresh.add_argument("--scope", default="", help="file glob to limit scope")
     p_fresh.add_argument("--repo", default=".", help="path to git repository (default: .)")
+
+    # baseline (statistical baseline and anomaly detection)
+    p_baseline = sub.add_parser("baseline", help="build and check statistical session baselines")
+    baseline_sub = p_baseline.add_subparsers(dest="baseline_cmd")
+
+    p_bl_update = baseline_sub.add_parser("update", help="build baseline from recent sessions")
+    p_bl_update.add_argument("--since", type=float, default=30.0, dest="since_days",
+                             metavar="DAYS", help="sessions from the last N days (default: 30)")
+    p_bl_update.add_argument("--output", default=".agent-traces/baseline.json",
+                             help="output path (default: .agent-traces/baseline.json)")
+
+    p_bl_check = baseline_sub.add_parser("check", help="check a session against the baseline")
+    p_bl_check.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_bl_check.add_argument("--baseline", dest="baseline_path",
+                            default=".agent-traces/baseline.json",
+                            help="baseline file (default: .agent-traces/baseline.json)")
+    p_bl_check.add_argument("--sigma", type=float, default=2.0,
+                            help="anomaly threshold in standard deviations (default: 2.0)")
+
+    p_bl_show = baseline_sub.add_parser("show", help="show baseline statistics")
+    p_bl_show.add_argument("--baseline", dest="baseline_path",
+                           default=".agent-traces/baseline.json",
+                           help="baseline file (default: .agent-traces/baseline.json)")
+
+    # identity (per-agent machine identity and session signing)
+    p_identity = sub.add_parser("identity", help="manage agent machine identity and sign sessions")
+    identity_sub = p_identity.add_subparsers(dest="identity_cmd")
+
+    identity_sub.add_parser("show", help="show or create the machine identity")
+
+    p_id_sign = identity_sub.add_parser("sign", help="sign a session with the machine identity")
+    p_id_sign.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_id_sign.add_argument("--agent-name", dest="agent_name", default="",
+                           help="agent name to embed in the identity")
+
+    p_id_verify = identity_sub.add_parser("verify", help="verify a session's signature")
+    p_id_verify.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
 
     # drift (behavioral drift detection)
     p_drift = sub.add_parser("drift", help="detect behavioral drift across sessions")
@@ -1099,7 +1140,9 @@ def main() -> None:
         "curve": cmd_curve,
         "inflation": cmd_inflation,
         "a2a-tree": cmd_a2a_tree,
+        "baseline": cmd_baseline,
         "drift": cmd_drift,
+        "identity": cmd_identity,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/identity.py
+++ b/src/agent_trace/identity.py
@@ -1,0 +1,290 @@
+"""Per-agent machine identity with HMAC-signed session tokens.
+
+Generates a stable machine identity (UUID stored in ~/.agent-trace/identity.json)
+and signs session metadata with HMAC-SHA256 so that a remote collector or reviewer
+can verify that a trace came from a specific named agent instance.
+
+Usage:
+    # Generate or show the current machine identity
+    agent-strace identity show
+
+    # Sign a session (adds HMAC signature to session meta)
+    agent-strace identity sign [session-id]
+
+    # Verify a session's signature
+    agent-strace identity verify [session-id]
+
+The identity key is stored at ~/.agent-trace/identity.json (user-scoped).
+Override with AGENT_TRACE_IDENTITY_FILE env var.
+
+Zero runtime dependencies — stdlib hmac / hashlib / uuid only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .store import TraceStore
+
+
+DEFAULT_IDENTITY_DIR = Path.home() / ".agent-trace"
+_IDENTITY_FILE_ENV = "AGENT_TRACE_IDENTITY_FILE"
+
+
+# ---------------------------------------------------------------------------
+# Identity schema
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentIdentity:
+    """Stable per-machine identity for an agent instance."""
+    identity_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    agent_name: str = ""
+    created_at: float = field(default_factory=time.time)
+    # HMAC key stored as hex; never transmitted in signatures
+    _key_hex: str = field(default_factory=lambda: uuid.uuid4().hex + uuid.uuid4().hex)
+
+    def to_public_dict(self) -> dict:
+        """Return the public portion (no key)."""
+        return {
+            "identity_id": self.identity_id,
+            "agent_name": self.agent_name,
+            "created_at": self.created_at,
+        }
+
+    def to_json(self) -> str:
+        d = asdict(self)
+        d["key_hex"] = d.pop("_key_hex")
+        return json.dumps(d, indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "AgentIdentity":
+        d = json.loads(text)
+        key = d.pop("key_hex", d.pop("_key_hex", uuid.uuid4().hex * 2))
+        obj = cls(
+            identity_id=d.get("identity_id", uuid.uuid4().hex),
+            agent_name=d.get("agent_name", ""),
+            created_at=d.get("created_at", time.time()),
+        )
+        obj._key_hex = key
+        return obj
+
+    @property
+    def key_bytes(self) -> bytes:
+        return bytes.fromhex(self._key_hex)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def _identity_path() -> Path:
+    env = os.environ.get(_IDENTITY_FILE_ENV, "")
+    if env:
+        return Path(env)
+    return DEFAULT_IDENTITY_DIR / "identity.json"
+
+
+def load_or_create_identity(agent_name: str = "") -> AgentIdentity:
+    """Load the machine identity, creating one if it doesn't exist."""
+    path = _identity_path()
+    if path.exists():
+        try:
+            identity = AgentIdentity.from_json(path.read_text())
+            if agent_name and not identity.agent_name:
+                identity.agent_name = agent_name
+            return identity
+        except Exception:
+            pass
+    identity = AgentIdentity(agent_name=agent_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(identity.to_json())
+    return identity
+
+
+def load_identity() -> AgentIdentity | None:
+    """Load existing identity; return None if not found."""
+    path = _identity_path()
+    if not path.exists():
+        return None
+    try:
+        return AgentIdentity.from_json(path.read_text())
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Signing and verification
+# ---------------------------------------------------------------------------
+
+def _sign_payload(identity: AgentIdentity, payload: dict) -> str:
+    """Return HMAC-SHA256 hex digest of the canonical JSON payload."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hmac.new(
+        identity.key_bytes,
+        canonical.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _sig_path(store: TraceStore, session_id: str) -> Path:
+    """Return the path to the identity sidecar file for a session."""
+    return store.base_dir / session_id / "identity.json"
+
+
+def _load_sig(store: TraceStore, session_id: str) -> dict | None:
+    p = _sig_path(store, session_id)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
+def _save_sig(store: TraceStore, session_id: str, sig_data: dict) -> None:
+    p = _sig_path(store, session_id)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(sig_data, indent=2))
+
+
+def sign_session(store: TraceStore, session_id: str,
+                 identity: AgentIdentity) -> bool:
+    """Add an HMAC signature sidecar to a session. Returns True on success."""
+    try:
+        meta = store.load_meta(session_id)
+    except Exception:
+        return False
+    if not meta:
+        return False
+
+    payload = {
+        "session_id": meta.session_id,
+        "agent_name": meta.agent_name,
+        "started_at": meta.started_at,
+        "ended_at": meta.ended_at,
+        "tool_calls": meta.tool_calls,
+        "errors": meta.errors,
+    }
+    sig = _sign_payload(identity, payload)
+    _save_sig(store, session_id, {
+        "identity_id": identity.identity_id,
+        "agent_name": identity.agent_name,
+        "signature": sig,
+        "signed_at": time.time(),
+    })
+    return True
+
+
+def verify_session(store: TraceStore, session_id: str,
+                   identity: AgentIdentity) -> tuple[bool, str]:
+    """Verify a session's HMAC signature. Returns (ok, reason)."""
+    try:
+        meta = store.load_meta(session_id)
+    except Exception:
+        return False, "session not found"
+    if not meta:
+        return False, "session not found"
+
+    stored = _load_sig(store, session_id)
+    if not stored:
+        return False, "no signature on session"
+
+    if stored.get("identity_id") != identity.identity_id:
+        return False, (
+            f"identity mismatch: session signed by {stored.get('identity_id')}, "
+            f"verifying with {identity.identity_id}"
+        )
+
+    payload = {
+        "session_id": meta.session_id,
+        "agent_name": meta.agent_name,
+        "started_at": meta.started_at,
+        "ended_at": meta.ended_at,
+        "tool_calls": meta.tool_calls,
+        "errors": meta.errors,
+    }
+    expected = _sign_payload(identity, payload)
+    actual = stored.get("signature", "")
+
+    if not hmac.compare_digest(expected, actual):
+        return False, "signature mismatch — session may have been tampered with"
+
+    return True, "ok"
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_identity(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    sub = getattr(args, "identity_cmd", None)
+
+    if sub == "show":
+        identity = load_identity()
+        if not identity:
+            sys.stdout.write("No identity found. Run: agent-strace identity show\n")
+            sys.stdout.write(f"Identity will be created at: {_identity_path()}\n")
+            identity = load_or_create_identity()
+        ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(identity.created_at))
+        sys.stdout.write(f"\nAgent identity\n\n")
+        sys.stdout.write(f"  ID:         {identity.identity_id}\n")
+        sys.stdout.write(f"  Name:       {identity.agent_name or '(unnamed)'}\n")
+        sys.stdout.write(f"  Created:    {ts}\n")
+        sys.stdout.write(f"  Key file:   {_identity_path()}\n\n")
+        return 0
+
+    elif sub == "sign":
+        session_id = getattr(args, "session_id", None)
+        if not session_id:
+            session_id = store.get_latest_session_id()
+        if not session_id:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+        full_id = store.find_session(session_id)
+        if not full_id:
+            sys.stderr.write(f"Session not found: {session_id}\n")
+            return 1
+        identity = load_or_create_identity(getattr(args, "agent_name", "") or "")
+        ok = sign_session(store, full_id, identity)
+        if ok:
+            sys.stdout.write(f"Signed session {full_id[:12]} with identity {identity.identity_id[:12]}\n")
+            return 0
+        sys.stderr.write("Failed to sign session.\n")
+        return 1
+
+    elif sub == "verify":
+        session_id = getattr(args, "session_id", None)
+        if not session_id:
+            session_id = store.get_latest_session_id()
+        if not session_id:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+        full_id = store.find_session(session_id)
+        if not full_id:
+            sys.stderr.write(f"Session not found: {session_id}\n")
+            return 1
+        identity = load_identity()
+        if not identity:
+            sys.stderr.write("No identity found. Run: agent-strace identity show\n")
+            return 1
+        ok, reason = verify_session(store, full_id, identity)
+        if ok:
+            sys.stdout.write(f"✅ Session {full_id[:12]} signature verified\n")
+            return 0
+        sys.stderr.write(f"❌ Verification failed: {reason}\n")
+        return 1
+
+    else:
+        sys.stderr.write("Usage: agent-strace identity <show|sign|verify>\n")
+        return 1

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -385,16 +385,21 @@ class WatcherConfig:
 @dataclass
 class StreamConfig:
     """Configuration for push-based event streaming."""
-    url: str = ""                    # webhook URL or collector endpoint
+    url: str = ""                    # webhook URL or OTLP collector endpoint
     batch_size: int = 10             # max events per POST
     flush_interval: float = 1.0     # max seconds between flushes
     headers: dict[str, str] = field(default_factory=dict)
     # Filter: only stream these event types (empty = all)
     event_types: list[str] = field(default_factory=list)
+    # When True, flush as OTLP JSON spans instead of raw NDJSON
+    otlp: bool = False
+    # OTel service name used in OTLP spans
+    service_name: str = "agent-trace"
 
     @classmethod
-    def from_url(cls, url: str, headers: dict[str, str] | None = None) -> "StreamConfig":
-        return cls(url=url, headers=headers or {})
+    def from_url(cls, url: str, headers: dict[str, str] | None = None,
+                 otlp: bool = False) -> "StreamConfig":
+        return cls(url=url, headers=headers or {}, otlp=otlp)
 
 
 class EventStreamer:
@@ -451,9 +456,15 @@ class EventStreamer:
                 last_flush = now
 
     def _flush(self, events: list[TraceEvent]) -> None:
-        """POST a batch of events as NDJSON."""
+        """POST a batch of events as NDJSON or OTLP JSON spans."""
         if not events or not self.config.url:
             return
+        if self.config.otlp:
+            self._flush_otlp(events)
+        else:
+            self._flush_ndjson(events)
+
+    def _flush_ndjson(self, events: list[TraceEvent]) -> None:
         body = "\n".join(e.to_json() for e in events).encode("utf-8")
         headers = {"Content-Type": "application/x-ndjson"}
         headers.update(self.config.headers)
@@ -471,6 +482,44 @@ class EventStreamer:
                     )
         except Exception as exc:
             sys.stderr.write(f"[stream] POST to {self.config.url} failed: {exc}\n")
+
+    def _flush_otlp(self, events: list[TraceEvent]) -> None:
+        """Convert events to OTLP GenAI spans and POST to /v1/traces."""
+        import json as _json
+        try:
+            from .otlp import session_to_otlp_genai
+            from .models import SessionMeta as _SessionMeta
+        except ImportError:
+            self._flush_ndjson(events)
+            return
+
+        # Group by session_id; build a minimal SessionMeta for each group
+        by_session: dict[str, list[TraceEvent]] = {}
+        for ev in events:
+            by_session.setdefault(ev.session_id, []).append(ev)
+
+        url = self.config.url.rstrip("/") + "/v1/traces"
+        for sid, evs in by_session.items():
+            meta = _SessionMeta(agent_name=self.config.service_name)
+            meta.session_id = sid
+            try:
+                payload = session_to_otlp_genai(
+                    meta, evs, service_name=self.config.service_name
+                )
+            except Exception:
+                continue
+            body = _json.dumps(payload).encode("utf-8")
+            req_headers = {"Content-Type": "application/json"}
+            req_headers.update(self.config.headers)
+            req = urllib.request.Request(url, data=body, headers=req_headers, method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    if resp.status not in (200, 202):
+                        sys.stderr.write(
+                            f"[stream] OTLP POST to {url} returned {resp.status}\n"
+                        )
+            except Exception as exc:
+                sys.stderr.write(f"[stream] OTLP POST to {url} failed: {exc}\n")
 
 
 @dataclass
@@ -1054,6 +1103,7 @@ def cmd_watch(args: argparse.Namespace) -> int:
             url=stream_url,
             batch_size=getattr(args, "stream_batch_size", 10),
             flush_interval=getattr(args, "stream_flush_interval", 2.0),
+            otlp=getattr(args, "stream_otlp", False),
         )
 
     watch_session(store, full_id, config, nanny_rules=nanny_rules, dry_run=dry_run,

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,179 @@
+"""Tests for baseline anomaly detection (issue #134)."""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.baseline import (
+    BaselineProfile,
+    MetricStats,
+    AnomalyResult,
+    build_baseline,
+    check_session,
+    save_baseline,
+    load_baseline,
+    _mean,
+    _stddev,
+    _z_score,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_store_with_sessions(tmpdir: str, n: int = 10, tool_calls: int = 5) -> TraceStore:
+    """Create a store with n completed sessions."""
+    store = TraceStore(tmpdir)
+    for i in range(n):
+        meta = SessionMeta(agent_name="test-agent")
+        meta.tool_calls = tool_calls
+        meta.llm_requests = 2
+        meta.started_at = time.time() - 86400 * (i + 1)
+        meta.ended_at = meta.started_at + 60.0
+        meta.total_duration_ms = 60_000.0
+        store.create_session(meta)
+        store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.SESSION_START, session_id=meta.session_id,
+        ))
+        store.update_meta(meta)
+    return store
+
+
+class TestStatHelpers(unittest.TestCase):
+    def test_mean(self):
+        self.assertAlmostEqual(_mean([1.0, 2.0, 3.0]), 2.0)
+
+    def test_mean_empty(self):
+        self.assertEqual(_mean([]), 0.0)
+
+    def test_stddev(self):
+        values = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+        mean = _mean(values)
+        sd = _stddev(values, mean)
+        self.assertAlmostEqual(sd, 2.0, places=0)
+
+    def test_stddev_single_value(self):
+        self.assertEqual(_stddev([5.0], 5.0), 0.0)
+
+    def test_z_score_zero_stddev(self):
+        self.assertEqual(_z_score(10.0, 5.0, 0.0), 0.0)
+
+    def test_z_score_normal(self):
+        z = _z_score(7.0, 5.0, 2.0)
+        self.assertAlmostEqual(z, 1.0)
+
+
+class TestBuildBaseline(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_builds_from_sessions(self):
+        store = _make_store_with_sessions(self.tmpdir, n=10)
+        profile = build_baseline(store, since_days=30)
+        self.assertGreater(profile.session_count, 0)
+        self.assertGreater(profile.tool_calls.mean, 0)
+
+    def test_empty_store_returns_zero_profile(self):
+        store = TraceStore(self.tmpdir)
+        profile = build_baseline(store, since_days=30)
+        self.assertEqual(profile.session_count, 0)
+
+    def test_excludes_sessions_outside_window(self):
+        store = TraceStore(self.tmpdir)
+        # Create a session 60 days ago (outside 30-day window)
+        meta = SessionMeta(agent_name="old")
+        meta.started_at = time.time() - 86400 * 60
+        meta.ended_at = meta.started_at + 60
+        meta.total_cost_usd = 99.0
+        meta.tool_calls = 100
+        store.create_session(meta)
+        store.update_meta(meta)
+        profile = build_baseline(store, since_days=30)
+        self.assertEqual(profile.session_count, 0)
+
+
+class TestBaselinePersistence(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_save_and_load_roundtrip(self):
+        profile = BaselineProfile(session_count=5)
+        profile.cost_usd = MetricStats(mean=1.5, stddev=0.3, min=1.0, max=2.0, count=5)
+        path = os.path.join(self.tmpdir, "baseline.json")
+        save_baseline(profile, path)
+        loaded = load_baseline(path)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.session_count, 5)
+        self.assertAlmostEqual(loaded.cost_usd.mean, 1.5)
+
+    def test_load_missing_returns_none(self):
+        result = load_baseline("/nonexistent/path/baseline.json")
+        self.assertIsNone(result)
+
+
+class TestCheckSession(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def _make_profile(self, mean_tools: float = 5.0, stddev_tools: float = 1.0) -> BaselineProfile:
+        profile = BaselineProfile(session_count=20)
+        profile.cost_usd = MetricStats(mean=0.0, stddev=0.0, min=0.0, max=0.0, count=20)
+        profile.tool_calls = MetricStats(mean=mean_tools, stddev=stddev_tools,
+                                         min=2.0, max=10.0, count=20)
+        profile.duration_ms = MetricStats(mean=60000.0, stddev=5000.0,
+                                          min=10000.0, max=120000.0, count=20)
+        profile.error_rate = MetricStats(mean=0.0, stddev=0.0, min=0.0, max=0.0, count=20)
+        profile.llm_requests = MetricStats(mean=2.0, stddev=0.5, min=1.0, max=5.0, count=20)
+        return profile
+
+    def _make_session(self, tool_calls: int = 5) -> str:
+        store = TraceStore(self.tmpdir)
+        meta = SessionMeta(agent_name="test")
+        meta.tool_calls = tool_calls
+        meta.llm_requests = 2
+        meta.started_at = time.time() - 120
+        meta.ended_at = time.time()
+        meta.total_duration_ms = 60_000.0
+        store.create_session(meta)
+        store.update_meta(meta)
+        return meta.session_id
+
+    def test_normal_session_not_anomalous(self):
+        store = TraceStore(self.tmpdir)
+        sid = self._make_session(tool_calls=5)
+        profile = self._make_profile(mean_tools=5.0, stddev_tools=1.0)
+        result = check_session(store, sid, profile, sigma=2.0)
+        self.assertFalse(result.anomalous)
+
+    def test_high_tool_call_session_flagged(self):
+        store = TraceStore(self.tmpdir)
+        sid = self._make_session(tool_calls=100)  # far above mean of 5
+        profile = self._make_profile(mean_tools=5.0, stddev_tools=1.0)
+        result = check_session(store, sid, profile, sigma=2.0)
+        self.assertTrue(result.anomalous)
+        self.assertIn("tool_calls", result.deviations)
+        self.assertGreater(result.deviations["tool_calls"], 2.0)
+
+    def test_deviations_dict_populated(self):
+        store = TraceStore(self.tmpdir)
+        sid = self._make_session(tool_calls=5)
+        profile = self._make_profile()
+        result = check_session(store, sid, profile)
+        self.assertIsInstance(result.deviations, dict)
+        self.assertIn("tool_calls", result.deviations)
+
+    def test_insufficient_baseline_data_skipped(self):
+        """Metrics with count < 3 should not contribute to anomaly detection."""
+        store = TraceStore(self.tmpdir)
+        sid = self._make_session(tool_calls=999)
+        profile = BaselineProfile(session_count=2)
+        profile.tool_calls = MetricStats(mean=5.0, stddev=1.0, min=2.0, max=10.0, count=2)
+        result = check_session(store, sid, profile, sigma=2.0)
+        self.assertFalse(result.anomalous)  # count < 3, skipped
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,158 @@
+"""Tests for machine identity and session signing (issue #141)."""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.identity import (
+    AgentIdentity,
+    load_or_create_identity,
+    load_identity,
+    sign_session,
+    verify_session,
+    _sign_payload,
+    _IDENTITY_FILE_ENV,
+)
+from agent_trace.models import SessionMeta, TraceEvent
+from agent_trace.models import EventType
+from agent_trace.store import TraceStore
+
+
+def _make_store_with_session(tmpdir: str) -> tuple[TraceStore, str]:
+    store = TraceStore(tmpdir)
+    meta = SessionMeta(agent_name="test-agent")
+    meta.started_at = time.time() - 60
+    meta.ended_at = time.time()
+    meta.tool_calls = 3
+    meta.errors = 0
+    store.create_session(meta)
+    store.update_meta(meta)
+    return store, meta.session_id
+
+
+class TestAgentIdentity(unittest.TestCase):
+    def test_new_identity_has_unique_id(self):
+        a = AgentIdentity()
+        b = AgentIdentity()
+        self.assertNotEqual(a.identity_id, b.identity_id)
+
+    def test_key_bytes_is_32_bytes(self):
+        identity = AgentIdentity()
+        self.assertEqual(len(identity.key_bytes), 32)
+
+    def test_to_public_dict_excludes_key(self):
+        identity = AgentIdentity(agent_name="my-agent")
+        pub = identity.to_public_dict()
+        self.assertIn("identity_id", pub)
+        self.assertIn("agent_name", pub)
+        self.assertNotIn("_key_hex", pub)
+        self.assertNotIn("key_hex", pub)
+
+    def test_json_roundtrip(self):
+        identity = AgentIdentity(agent_name="roundtrip-agent")
+        loaded = AgentIdentity.from_json(identity.to_json())
+        self.assertEqual(loaded.identity_id, identity.identity_id)
+        self.assertEqual(loaded.agent_name, identity.agent_name)
+        self.assertEqual(loaded._key_hex, identity._key_hex)
+
+
+class TestIdentityPersistence(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_env = os.environ.get(_IDENTITY_FILE_ENV)
+        os.environ[_IDENTITY_FILE_ENV] = os.path.join(self.tmpdir, "identity.json")
+
+    def tearDown(self):
+        if self._orig_env is None:
+            os.environ.pop(_IDENTITY_FILE_ENV, None)
+        else:
+            os.environ[_IDENTITY_FILE_ENV] = self._orig_env
+
+    def test_creates_identity_on_first_call(self):
+        identity = load_or_create_identity("my-agent")
+        self.assertIsNotNone(identity)
+        self.assertEqual(identity.agent_name, "my-agent")
+        path = os.environ[_IDENTITY_FILE_ENV]
+        self.assertTrue(os.path.exists(path))
+
+    def test_loads_same_identity_on_second_call(self):
+        first = load_or_create_identity("agent-a")
+        second = load_or_create_identity("agent-a")
+        self.assertEqual(first.identity_id, second.identity_id)
+        self.assertEqual(first._key_hex, second._key_hex)
+
+    def test_load_identity_returns_none_when_missing(self):
+        result = load_identity()
+        self.assertIsNone(result)
+
+
+class TestSignAndVerify(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_sign_and_verify_succeeds(self):
+        store, sid = _make_store_with_session(self.tmpdir)
+        identity = AgentIdentity(agent_name="signer")
+        ok = sign_session(store, sid, identity)
+        self.assertTrue(ok)
+        verified, reason = verify_session(store, sid, identity)
+        self.assertTrue(verified)
+        self.assertEqual(reason, "ok")
+
+    def test_verify_fails_with_wrong_identity(self):
+        store, sid = _make_store_with_session(self.tmpdir)
+        signer = AgentIdentity(agent_name="signer")
+        verifier = AgentIdentity(agent_name="other")
+        sign_session(store, sid, signer)
+        ok, reason = verify_session(store, sid, verifier)
+        self.assertFalse(ok)
+        self.assertIn("identity mismatch", reason)
+
+    def test_verify_fails_on_unsigned_session(self):
+        store, sid = _make_store_with_session(self.tmpdir)
+        identity = AgentIdentity()
+        ok, reason = verify_session(store, sid, identity)
+        self.assertFalse(ok)
+        self.assertIn("no signature", reason)
+
+    def test_verify_fails_after_metadata_tampered(self):
+        store, sid = _make_store_with_session(self.tmpdir)
+        identity = AgentIdentity(agent_name="signer")
+        sign_session(store, sid, identity)
+
+        # Tamper: change tool_calls after signing
+        meta = store.load_meta(sid)
+        meta.tool_calls = 999
+        store.update_meta(meta)
+
+        ok, reason = verify_session(store, sid, identity)
+        self.assertFalse(ok)
+        self.assertIn("signature mismatch", reason)
+
+    def test_sign_nonexistent_session_returns_false(self):
+        store = TraceStore(self.tmpdir)
+        identity = AgentIdentity()
+        # Use a valid hex session_id format that simply doesn't exist on disk
+        ok = sign_session(store, "deadbeefdeadbeef", identity)
+        self.assertFalse(ok)
+
+    def test_hmac_is_deterministic(self):
+        identity = AgentIdentity()
+        payload = {"session_id": "abc", "tool_calls": 5}
+        sig1 = _sign_payload(identity, payload)
+        sig2 = _sign_payload(identity, payload)
+        self.assertEqual(sig1, sig2)
+
+    def test_hmac_differs_for_different_payloads(self):
+        identity = AgentIdentity()
+        sig1 = _sign_payload(identity, {"tool_calls": 5})
+        sig2 = _sign_payload(identity, {"tool_calls": 6})
+        self.assertNotEqual(sig1, sig2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #132
Closes #134
Closes #141

This is the v0.6.0 milestone release. Three major features, all stdlib-only.

---

## Live OTLP streaming (`#132`)

`agent-strace watch` can now stream events directly to any OTLP-compatible backend (Datadog, Honeycomb, Grafana, etc.) as GenAI spans:

```bash
agent-strace watch --stream-to https://api.honeycomb.io \
  --stream-otlp \
  --stream-to-header "x-honeycomb-team=<API_KEY>"
```

`StreamConfig` gains `otlp: bool` and `service_name: str`. When `otlp=True`, `EventStreamer._flush_otlp()` converts each batch to OTLP JSON spans via the existing `session_to_otlp_genai()` and POSTs to `<url>/v1/traces`.

---

## Baseline anomaly detection (`#134`)

Build a statistical profile from historical sessions and flag regressions automatically:

```bash
# Build baseline from last 30 days
agent-strace baseline update

# Check latest session (exits 1 if anomalous)
agent-strace baseline check --sigma 2.0

# Show baseline stats
agent-strace baseline show
```

`baseline.py` computes mean/stddev for `tool_calls`, `duration_ms`, `error_rate`, `llm_requests`, and `cost_usd` (when available). `check_session()` uses z-scores; metrics with fewer than 3 samples are skipped. Baseline persisted as JSON at `.agent-traces/baseline.json`.

---

## Machine identity (`#141`)

Sign sessions with a stable per-machine HMAC-SHA256 identity so collectors and reviewers can verify provenance:

```bash
agent-strace identity show    # create or display identity
agent-strace identity sign    # sign latest session
agent-strace identity verify  # verify signature
```

Identity stored at `~/.agent-trace/identity.json` (override: `AGENT_TRACE_IDENTITY_FILE`). Signatures stored as `identity.json` sidecar alongside each session. Zero new dependencies — stdlib `hmac`/`hashlib`/`uuid` only.

---

1259/1259 tests passing.