### PR TITLE
feat: Slack/Teams notifications and team budget grouping

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.60.0"
+__version__ = "0.61.0"

--- a/src/agent_trace/budget_report.py
+++ b/src/agent_trace/budget_report.py
@@ -33,6 +33,7 @@ class SessionSpend:
     tool_breakdown: dict[str, float]   # tool_name -> estimated cost share
     watchdog_terminated: bool = False
     watchdog_budget: float | None = None   # budget ceiling at time of kill
+    team: str = ""                         # team name (from SessionMeta.team)
 
 
 @dataclass
@@ -188,6 +189,7 @@ def build_report(
             tool_breakdown=breakdown,
             watchdog_terminated=watchdog_terminated,
             watchdog_budget=watchdog_budget,
+            team=getattr(meta, "team", "") or "",
         )
 
         if in_window:
@@ -222,6 +224,22 @@ def _fmt_delta(current: float, prior: float, higher_is_worse: bool = True) -> st
     arrow = "↑" if pct > 0 else "↓"
     direction = "worse" if (pct > 0) == higher_is_worse else "better"
     return f"({arrow} {abs(pct):.0f}% vs prior period)"
+
+
+def team_summary(sessions: list[SessionSpend]) -> dict[str, dict]:
+    """Aggregate spend by team. Returns {team_name: {cost, sessions, agents}}."""
+    teams: dict[str, dict] = {}
+    for s in sessions:
+        key = s.team or "(unassigned)"
+        if key not in teams:
+            teams[key] = {"cost": 0.0, "sessions": 0, "agents": set()}
+        teams[key]["cost"] += s.cost
+        teams[key]["sessions"] += 1
+        teams[key]["agents"].add(s.agent_name)
+    # Convert sets to counts for serialisability
+    for v in teams.values():
+        v["agents"] = len(v["agents"])
+    return dict(sorted(teams.items(), key=lambda x: x[1]["cost"], reverse=True))
 
 
 def format_report_text(report: BudgetReport, out: TextIO = sys.stdout) -> None:
@@ -262,6 +280,16 @@ def format_report_text(report: BudgetReport, out: TextIO = sys.stdout) -> None:
         for tool, cost in list(tool_totals.items())[:8]:
             pct = cost / report.total_cost * 100
             w(f"  {tool:<20}  ${cost:.2f}  ({pct:.0f}%)\n")
+        w("\n")
+
+    # Team breakdown (only shown when at least one session has a team set)
+    teams = team_summary(report.sessions)
+    if any(k != "(unassigned)" for k in teams):
+        w("Cost by team:\n")
+        for team_name, stats in teams.items():
+            pct = stats["cost"] / report.total_cost * 100 if report.total_cost else 0
+            w(f"  {team_name:<24}  ${stats['cost']:.2f}  ({pct:.0f}%)  "
+              f"{stats['sessions']} sessions  {stats['agents']} agents\n")
         w("\n")
 
     # Watchdog savings
@@ -374,6 +402,7 @@ def _parse_date(s: str) -> float:
 def cmd_budget_report(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
     fmt = getattr(args, "format", "text")
+    team_filter = getattr(args, "team", "") or ""
 
     # Time window
     since_str = getattr(args, "since", None)
@@ -384,6 +413,11 @@ def cmd_budget_report(args: argparse.Namespace) -> int:
     window_start = _parse_date(since_str) if since_str else (window_end - 7 * 86400)
 
     report = build_report(store, window_start, window_end)
+
+    # Apply team filter
+    if team_filter:
+        report.sessions = [s for s in report.sessions if s.team == team_filter]
+        report.prior_sessions = [s for s in report.prior_sessions if s.team == team_filter]
 
     if fmt == "json":
         sys.stdout.write(format_report_json(report) + "\n")

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -1001,6 +1001,8 @@ def build_parser() -> argparse.ArgumentParser:
                           help="start of window (ISO date or duration like 7d; default: 7 days ago)")
     p_budget.add_argument("--until", metavar="DATE",
                           help="end of window (ISO date; default: now)")
+    p_budget.add_argument("--team", metavar="TEAM",
+                         help="filter report to a specific team name")
     p_budget.add_argument("--format", choices=["text", "markdown", "json"], default="text",
                           dest="format", help="output format (default: text)")
     p_budget.add_argument("--endpoint", metavar="URL",

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -84,6 +84,8 @@ class SessionMeta:
     parent_session_id: str = ""   # session ID of the spawning agent
     parent_event_id: str = ""     # event_id of the tool_call that spawned this session
     depth: int = 0                # nesting depth (0 = root, 1 = first subagent, etc.)
+    # Team grouping (optional — used for team budget reports)
+    team: str = ""
     # Attribution (who/what started this session)
     attribution: dict = field(default_factory=dict)
 

--- a/src/agent_trace/notify.py
+++ b/src/agent_trace/notify.py
@@ -1,0 +1,267 @@
+"""Slack, Microsoft Teams, and generic webhook notifications.
+
+Sends structured notifications on watch violations, session end, and
+budget alerts. All HTTP — no third-party SDKs required.
+
+Configuration (env vars):
+    AGENT_STRACE_SLACK_WEBHOOK      Slack incoming webhook URL
+    AGENT_STRACE_TEAMS_WEBHOOK      Microsoft Teams incoming webhook URL
+    AGENT_STRACE_NOTIFY_WEBHOOK     Generic JSON webhook URL (fallback)
+
+Usage:
+    from agent_trace.notify import notify
+
+    notify(
+        title="Policy violation",
+        message="Bash tool blocked by scope policy",
+        level="error",          # info | warning | error
+        session_id="abc123",
+        fields={"tool": "Bash", "policy": "no-network"},
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+import urllib.error
+from dataclasses import dataclass, field
+from typing import Literal
+
+Level = Literal["info", "warning", "error"]
+
+# Env var names
+_SLACK_ENV = "AGENT_STRACE_SLACK_WEBHOOK"
+_TEAMS_ENV = "AGENT_STRACE_TEAMS_WEBHOOK"
+_GENERIC_ENV = "AGENT_STRACE_NOTIFY_WEBHOOK"
+
+# Slack colour map
+_SLACK_COLORS: dict[str, str] = {
+    "info": "#36a64f",
+    "warning": "#ff9900",
+    "error": "#cc0000",
+}
+
+# Retry config
+_MAX_RETRIES = 3
+_RETRY_DELAY = 1.0  # seconds, doubled each attempt
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+def _slack_payload(
+    title: str,
+    message: str,
+    level: Level = "info",
+    session_id: str = "",
+    fields: dict[str, str] | None = None,
+) -> dict:
+    """Build a Slack Block Kit message payload."""
+    color = _SLACK_COLORS.get(level, "#36a64f")
+    attachment: dict = {
+        "color": color,
+        "title": title,
+        "text": message,
+        "footer": "agent-strace",
+        "ts": int(time.time()),
+    }
+    if fields:
+        attachment["fields"] = [
+            {"title": k, "value": str(v), "short": True}
+            for k, v in fields.items()
+        ]
+    if session_id:
+        attachment["footer_icon"] = ""
+        attachment["fields"] = attachment.get("fields", []) + [
+            {"title": "session", "value": session_id[:12], "short": True}
+        ]
+    return {"attachments": [attachment]}
+
+
+def _teams_payload(
+    title: str,
+    message: str,
+    level: Level = "info",
+    session_id: str = "",
+    fields: dict[str, str] | None = None,
+) -> dict:
+    """Build a Microsoft Teams Adaptive Card payload (legacy connector format)."""
+    theme_color = {"info": "0076D7", "warning": "FF9900", "error": "CC0000"}.get(level, "0076D7")
+    facts = []
+    if session_id:
+        facts.append({"name": "Session", "value": session_id[:12]})
+    if fields:
+        facts.extend({"name": k, "value": str(v)} for k, v in fields.items())
+
+    payload: dict = {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": theme_color,
+        "summary": title,
+        "sections": [
+            {
+                "activityTitle": f"**{title}**",
+                "activityText": message,
+                "facts": facts,
+                "markdown": True,
+            }
+        ],
+    }
+    return payload
+
+
+def _generic_payload(
+    title: str,
+    message: str,
+    level: Level = "info",
+    session_id: str = "",
+    fields: dict[str, str] | None = None,
+) -> dict:
+    return {
+        "title": title,
+        "message": message,
+        "level": level,
+        "session_id": session_id,
+        "fields": fields or {},
+        "timestamp": time.time(),
+        "source": "agent-strace",
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP delivery with retry
+# ---------------------------------------------------------------------------
+
+def _post(url: str, payload: dict, retries: int = _MAX_RETRIES) -> bool:
+    """POST JSON payload to url. Returns True on success."""
+    body = json.dumps(payload).encode("utf-8")
+    delay = _RETRY_DELAY
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status in (200, 202, 204):
+                    return True
+        except urllib.error.HTTPError as exc:
+            if exc.code < 500:
+                # 4xx — don't retry
+                import sys
+                sys.stderr.write(f"[notify] HTTP {exc.code} from {url}: {exc.reason}\n")
+                return False
+        except Exception:
+            pass
+        if attempt < retries - 1:
+            time.sleep(delay)
+            delay *= 2
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def notify(
+    title: str,
+    message: str,
+    level: Level = "info",
+    session_id: str = "",
+    fields: dict[str, str] | None = None,
+    slack_url: str = "",
+    teams_url: str = "",
+    webhook_url: str = "",
+) -> dict[str, bool]:
+    """Send a notification to all configured channels.
+
+    URL priority: explicit argument > env var.
+    Returns a dict of {channel: success} for each attempted delivery.
+    """
+    results: dict[str, bool] = {}
+
+    slack = slack_url or os.environ.get(_SLACK_ENV, "")
+    teams = teams_url or os.environ.get(_TEAMS_ENV, "")
+    generic = webhook_url or os.environ.get(_GENERIC_ENV, "")
+
+    if slack:
+        payload = _slack_payload(title, message, level, session_id, fields)
+        results["slack"] = _post(slack, payload)
+
+    if teams:
+        payload = _teams_payload(title, message, level, session_id, fields)
+        results["teams"] = _post(teams, payload)
+
+    if generic and not (slack or teams):
+        # Only fall back to generic if no provider-specific URL is set
+        payload = _generic_payload(title, message, level, session_id, fields)
+        results["webhook"] = _post(generic, payload)
+
+    return results
+
+
+def notify_violation(
+    rule_name: str,
+    tool_name: str,
+    session_id: str = "",
+    action: str = "alert",
+    **kwargs,
+) -> dict[str, bool]:
+    """Convenience wrapper for watch rule violations."""
+    return notify(
+        title=f"Agent policy violation: {rule_name}",
+        message=f"Rule `{rule_name}` fired on tool `{tool_name}` — action: {action}",
+        level="error",
+        session_id=session_id,
+        fields={"rule": rule_name, "tool": tool_name, "action": action},
+        **kwargs,
+    )
+
+
+def notify_budget_alert(
+    agent_name: str,
+    spent: float,
+    budget: float,
+    session_id: str = "",
+    **kwargs,
+) -> dict[str, bool]:
+    """Convenience wrapper for budget threshold alerts."""
+    pct = int(spent / budget * 100) if budget else 0
+    return notify(
+        title=f"Budget alert: {agent_name}",
+        message=f"Agent `{agent_name}` has spent ${spent:.4f} ({pct}% of ${budget:.2f} budget)",
+        level="warning",
+        session_id=session_id,
+        fields={"agent": agent_name, "spent": f"${spent:.4f}", "budget": f"${budget:.2f}"},
+        **kwargs,
+    )
+
+
+def notify_session_end(
+    agent_name: str,
+    session_id: str,
+    cost: float,
+    tool_calls: int,
+    duration_ms: float,
+    **kwargs,
+) -> dict[str, bool]:
+    """Convenience wrapper for session-end summaries."""
+    return notify(
+        title=f"Session complete: {agent_name}",
+        message=f"Session `{session_id[:12]}` finished — {tool_calls} tool calls, ${cost:.4f}, {duration_ms/1000:.1f}s",
+        level="info",
+        session_id=session_id,
+        fields={
+            "agent": agent_name,
+            "tool_calls": str(tool_calls),
+            "cost": f"${cost:.4f}",
+            "duration": f"{duration_ms/1000:.1f}s",
+        },
+        **kwargs,
+    )

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -617,9 +617,25 @@ def _dispatch_alert(
         _alert_file(message, config.alert_log)
     if config.webhook_url:
         _alert_webhook(message, config.webhook_url)
-    # notify field from nanny rules (e.g. "slack:#alerts")
-    if notify and notify.startswith("slack:") and config.webhook_url:
-        _alert_webhook(f"[{notify}] {message}", config.webhook_url)
+
+    # Route to Slack/Teams via notify.py when env vars or rule hint is set
+    try:
+        from .notify import notify as _notify, notify_violation as _notify_violation
+        import os as _os
+        has_slack = bool(_os.environ.get("AGENT_STRACE_SLACK_WEBHOOK"))
+        has_teams = bool(_os.environ.get("AGENT_STRACE_TEAMS_WEBHOOK"))
+        if has_slack or has_teams:
+            _notify_violation(
+                rule_name=notify or "watch-rule",
+                tool_name="",
+                session_id=session_id,
+                action=action or "alert",
+            )
+        elif notify and notify.startswith("slack:") and config.webhook_url:
+            # Legacy: route slack: hint through the generic webhook URL
+            _alert_webhook(f"[{notify}] {message}", config.webhook_url)
+    except Exception:
+        pass
 
     if dry_run:
         _alert_terminal(f"[dry-run] would {action} agent process")

--- a/tests/test_budget_report.py
+++ b/tests/test_budget_report.py
@@ -15,6 +15,7 @@ from agent_trace.budget_report import (
     format_report_json,
     format_report_markdown,
     format_report_text,
+    team_summary,
     cmd_budget_report,
     _parse_date,
     _read_postmortem,
@@ -389,6 +390,109 @@ class TestCmdBudgetReport(unittest.TestCase):
         args = self._args(store.base_dir, since="7d", until="1d")
         result = cmd_budget_report(args)
         self.assertEqual(result, 0)
+
+
+class TestTeamSummary(unittest.TestCase):
+    def _make_spends(self):
+        return [
+            SessionSpend("s1", "agent-a", time.time(), 1.0, {}, team="backend"),
+            SessionSpend("s2", "agent-b", time.time(), 2.0, {}, team="backend"),
+            SessionSpend("s3", "agent-c", time.time(), 0.5, {}, team="frontend"),
+            SessionSpend("s4", "agent-d", time.time(), 0.3, {}, team=""),
+        ]
+
+    def test_groups_by_team(self):
+        spends = self._make_spends()
+        summary = team_summary(spends)
+        self.assertIn("backend", summary)
+        self.assertIn("frontend", summary)
+        self.assertIn("(unassigned)", summary)
+
+    def test_cost_aggregated_per_team(self):
+        spends = self._make_spends()
+        summary = team_summary(spends)
+        self.assertAlmostEqual(summary["backend"]["cost"], 3.0)
+        self.assertAlmostEqual(summary["frontend"]["cost"], 0.5)
+
+    def test_session_count_per_team(self):
+        spends = self._make_spends()
+        summary = team_summary(spends)
+        self.assertEqual(summary["backend"]["sessions"], 2)
+        self.assertEqual(summary["frontend"]["sessions"], 1)
+
+    def test_agent_count_per_team(self):
+        spends = self._make_spends()
+        summary = team_summary(spends)
+        self.assertEqual(summary["backend"]["agents"], 2)
+
+    def test_sorted_by_cost_descending(self):
+        spends = self._make_spends()
+        summary = team_summary(spends)
+        costs = [v["cost"] for v in summary.values()]
+        self.assertEqual(costs, sorted(costs, reverse=True))
+
+    def test_empty_sessions(self):
+        self.assertEqual(team_summary([]), {})
+
+
+class TestTeamBudgetFilter(unittest.TestCase):
+    def _args(self, trace_dir, team=""):
+        import argparse
+        args = argparse.Namespace()
+        args.trace_dir = str(trace_dir)
+        args.format = "text"
+        args.since = None
+        args.until = None
+        args.team = team
+        return args
+
+    def test_team_filter_excludes_other_teams(self):
+        import io, tempfile
+        from unittest.mock import patch
+        tmpdir = tempfile.mkdtemp()
+        store = TraceStore(tmpdir)
+        now = time.time()
+
+        # Add two sessions with different teams
+        for team in ("alpha", "beta"):
+            meta = SessionMeta(agent_name=f"agent-{team}")
+            meta.team = team
+            meta.started_at = now - 86400
+            meta.ended_at = now
+            store.create_session(meta)
+            store.update_meta(meta)
+
+        args = self._args(tmpdir, team="alpha")
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_budget_report(args)
+        output = captured.getvalue()
+        self.assertIn("agent-alpha", output)
+        self.assertNotIn("agent-beta", output)
+
+    def test_team_breakdown_shown_in_text_output(self):
+        import io, tempfile
+        from unittest.mock import patch
+        tmpdir = tempfile.mkdtemp()
+        store = TraceStore(tmpdir)
+        now = time.time()
+
+        for team in ("alpha", "beta"):
+            meta = SessionMeta(agent_name=f"agent-{team}")
+            meta.team = team
+            meta.started_at = now - 86400
+            meta.ended_at = now
+            store.create_session(meta)
+            store.update_meta(meta)
+
+        args = self._args(tmpdir)
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            cmd_budget_report(args)
+        output = captured.getvalue()
+        self.assertIn("Cost by team", output)
+        self.assertIn("alpha", output)
+        self.assertIn("beta", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,183 @@
+"""Tests for Slack/Teams/webhook notifications (issue #138)."""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.notify import (
+    _slack_payload,
+    _teams_payload,
+    _generic_payload,
+    _post,
+    notify,
+    notify_violation,
+    notify_budget_alert,
+    notify_session_end,
+    _SLACK_ENV,
+    _TEAMS_ENV,
+    _GENERIC_ENV,
+)
+
+
+class TestSlackPayload(unittest.TestCase):
+    def test_contains_title_and_message(self):
+        p = _slack_payload("Test title", "Test message")
+        att = p["attachments"][0]
+        self.assertEqual(att["title"], "Test title")
+        self.assertEqual(att["text"], "Test message")
+
+    def test_error_level_uses_red_color(self):
+        p = _slack_payload("t", "m", level="error")
+        self.assertEqual(p["attachments"][0]["color"], "#cc0000")
+
+    def test_warning_level_uses_orange(self):
+        p = _slack_payload("t", "m", level="warning")
+        self.assertEqual(p["attachments"][0]["color"], "#ff9900")
+
+    def test_fields_included(self):
+        p = _slack_payload("t", "m", fields={"tool": "Bash", "action": "block"})
+        fields = p["attachments"][0]["fields"]
+        titles = [f["title"] for f in fields]
+        self.assertIn("tool", titles)
+        self.assertIn("action", titles)
+
+    def test_session_id_appended_to_fields(self):
+        p = _slack_payload("t", "m", session_id="abc123def456")
+        fields = p["attachments"][0].get("fields", [])
+        values = [f["value"] for f in fields]
+        self.assertTrue(any("abc123def456"[:12] in v for v in values))
+
+
+class TestTeamsPayload(unittest.TestCase):
+    def test_message_card_type(self):
+        p = _teams_payload("Title", "Body")
+        self.assertEqual(p["@type"], "MessageCard")
+
+    def test_error_theme_color(self):
+        p = _teams_payload("t", "m", level="error")
+        self.assertEqual(p["themeColor"], "CC0000")
+
+    def test_facts_from_fields(self):
+        p = _teams_payload("t", "m", fields={"rule": "no-network"})
+        facts = p["sections"][0]["facts"]
+        names = [f["name"] for f in facts]
+        self.assertIn("rule", names)
+
+    def test_session_id_in_facts(self):
+        p = _teams_payload("t", "m", session_id="sess001")
+        facts = p["sections"][0]["facts"]
+        self.assertTrue(any(f["name"] == "Session" for f in facts))
+
+
+class TestGenericPayload(unittest.TestCase):
+    def test_has_required_keys(self):
+        p = _generic_payload("t", "m", level="warning", session_id="s1")
+        self.assertEqual(p["title"], "t")
+        self.assertEqual(p["level"], "warning")
+        self.assertEqual(p["session_id"], "s1")
+        self.assertIn("timestamp", p)
+
+
+class TestPost(unittest.TestCase):
+    def test_returns_true_on_200(self):
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.status = 200
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = _post("http://example.com/hook", {"text": "hi"}, retries=1)
+        self.assertTrue(result)
+
+    def test_returns_false_on_4xx(self):
+        import urllib.error
+        with patch("urllib.request.urlopen",
+                   side_effect=urllib.error.HTTPError("url", 400, "Bad Request", {}, None)):
+            result = _post("http://example.com/hook", {}, retries=1)
+        self.assertFalse(result)
+
+    def test_returns_false_on_repeated_failure(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            with patch("time.sleep"):  # don't actually sleep in tests
+                result = _post("http://example.com/hook", {}, retries=2)
+        self.assertFalse(result)
+
+
+class TestNotify(unittest.TestCase):
+    def setUp(self):
+        # Clear env vars before each test
+        for var in (_SLACK_ENV, _TEAMS_ENV, _GENERIC_ENV):
+            os.environ.pop(var, None)
+
+    def test_no_channels_returns_empty(self):
+        results = notify("title", "message")
+        self.assertEqual(results, {})
+
+    def test_slack_channel_used_when_env_set(self):
+        os.environ[_SLACK_ENV] = "http://slack.example.com/hook"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            results = notify("t", "m")
+        self.assertIn("slack", results)
+        mock_post.assert_called_once()
+        payload = mock_post.call_args[0][1]
+        self.assertIn("attachments", payload)
+
+    def test_teams_channel_used_when_env_set(self):
+        os.environ[_TEAMS_ENV] = "http://teams.example.com/hook"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            results = notify("t", "m")
+        self.assertIn("teams", results)
+        payload = mock_post.call_args[0][1]
+        self.assertEqual(payload["@type"], "MessageCard")
+
+    def test_generic_fallback_when_no_provider(self):
+        os.environ[_GENERIC_ENV] = "http://generic.example.com/hook"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            results = notify("t", "m")
+        self.assertIn("webhook", results)
+
+    def test_generic_not_used_when_slack_set(self):
+        os.environ[_SLACK_ENV] = "http://slack.example.com/hook"
+        os.environ[_GENERIC_ENV] = "http://generic.example.com/hook"
+        with patch("agent_trace.notify._post", return_value=True):
+            results = notify("t", "m")
+        self.assertIn("slack", results)
+        self.assertNotIn("webhook", results)
+
+    def test_explicit_url_overrides_env(self):
+        os.environ[_SLACK_ENV] = "http://env-slack.example.com"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            notify("t", "m", slack_url="http://explicit-slack.example.com")
+        called_url = mock_post.call_args[0][0]
+        self.assertEqual(called_url, "http://explicit-slack.example.com")
+
+
+class TestConvenienceWrappers(unittest.TestCase):
+    def setUp(self):
+        for var in (_SLACK_ENV, _TEAMS_ENV, _GENERIC_ENV):
+            os.environ.pop(var, None)
+
+    def test_notify_violation_returns_empty_when_no_channels(self):
+        result = notify_violation("no-network", "Bash")
+        self.assertEqual(result, {})
+
+    def test_notify_budget_alert_message_contains_pct(self):
+        os.environ[_GENERIC_ENV] = "http://example.com"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            notify_budget_alert("my-agent", spent=4.0, budget=5.0)
+        payload = mock_post.call_args[0][1]
+        self.assertIn("80%", payload["message"])
+
+    def test_notify_session_end_includes_tool_calls(self):
+        os.environ[_GENERIC_ENV] = "http://example.com"
+        with patch("agent_trace.notify._post", return_value=True) as mock_post:
+            notify_session_end("agent", "sess123", cost=0.05, tool_calls=7, duration_ms=3000)
+        payload = mock_post.call_args[0][1]
+        self.assertIn("7", payload["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #138
Closes #136

## What changed

**Slack/Teams/webhook notifications** (`#138`)

New `notify.py` — structured notifications with provider-specific payloads:

```bash
# Configure via env vars (no code changes needed)
export AGENT_STRACE_SLACK_WEBHOOK=https://hooks.slack.com/...
export AGENT_STRACE_TEAMS_WEBHOOK=https://company.webhook.office.com/...
```

- Slack: Block Kit attachment with colour-coded severity, fields, session ID
- Teams: Adaptive Card (legacy connector format) with facts table
- Generic: plain JSON fallback when no provider URL is set
- Retry with exponential backoff (3 attempts); 4xx not retried
- `watch` violations now route to Slack/Teams automatically when env vars are set
- Convenience wrappers: `notify_violation()`, `notify_budget_alert()`, `notify_session_end()`

**Team budget grouping** (`#136`)

`SessionMeta` gains a `team` field (backward-compatible). Budget reports now show a per-team breakdown and support filtering:

```bash
# Show spend broken down by team
agent-strace budget-report

# Filter to one team
agent-strace budget-report --team backend
```

Set the team when starting a session:
```python
meta = SessionMeta(agent_name="billing-agent", team="backend")
```

61/61 tests passing.