### PR TITLE
feat: replay --diff dual-session viewer and hash chain audit

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.61.0"
+__version__ = "0.62.0"

--- a/src/agent_trace/audit.py
+++ b/src/agent_trace/audit.py
@@ -419,6 +419,74 @@ def format_audit(report: AuditReport, out: TextIO = sys.stdout) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Hash-chain verification
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ChainVerifyResult:
+    session_id: str
+    ok: bool
+    total_events: int
+    broken_at: int | None = None   # 0-based index of first broken link
+    broken_event_id: str = ""
+
+    def format(self, out: TextIO = sys.stdout) -> None:
+        if self.ok:
+            out.write(f"✅ Chain intact — {self.total_events} events verified\n")
+        else:
+            out.write(
+                f"❌ Chain broken at event #{self.broken_at} "
+                f"(id={self.broken_event_id})\n"
+                f"   {self.total_events} events checked — session may have been tampered with\n"
+            )
+
+
+def verify_chain(store: TraceStore, session_id: str) -> ChainVerifyResult:
+    """Verify the SHA-256 hash chain for a session's event log.
+
+    Each event stores prev_hash = SHA-256(previous event JSON line).
+    Events without prev_hash (written before v0.62.0) are skipped.
+    Returns ChainVerifyResult with ok=True if no broken links are found.
+    """
+    import hashlib
+
+    events_path = store._session_dir(session_id) / "events.ndjson"
+    if not events_path.exists():
+        return ChainVerifyResult(session_id=session_id, ok=False,
+                                 total_events=0, broken_at=0)
+
+    lines = [l for l in events_path.read_text().splitlines() if l.strip()]
+    if not lines:
+        return ChainVerifyResult(session_id=session_id, ok=True, total_events=0)
+
+    import json as _json
+    prev_line = ""
+    checked = 0
+    for i, line in enumerate(lines):
+        try:
+            obj = _json.loads(line)
+        except Exception:
+            continue
+        stored_hash = obj.get("prev_hash", "")
+        if not stored_hash:
+            # Pre-v0.62.0 event — no hash, skip
+            prev_line = line
+            continue
+        expected = hashlib.sha256(prev_line.encode()).hexdigest() if prev_line else ""
+        if stored_hash != expected:
+            event_id = obj.get("event_id", "")
+            return ChainVerifyResult(
+                session_id=session_id, ok=False,
+                total_events=len(lines), broken_at=i,
+                broken_event_id=event_id,
+            )
+        prev_line = line
+        checked += 1
+
+    return ChainVerifyResult(session_id=session_id, ok=True, total_events=len(lines))
+
+
+# ---------------------------------------------------------------------------
 # CLI handler
 # ---------------------------------------------------------------------------
 
@@ -435,6 +503,13 @@ def cmd_audit(args: argparse.Namespace) -> int:
     if not full_id:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
+
+    # --verify-chain: check hash chain integrity before policy audit
+    if getattr(args, "verify_chain", False):
+        chain_result = verify_chain(store, full_id)
+        chain_result.format()
+        if not chain_result.ok:
+            return 1
 
     policy_path = getattr(args, "policy", ".agent-scope.json")
     report = audit_session(store, full_id, policy_path=policy_path)

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -188,6 +188,18 @@ def cmd_replay(args: argparse.Namespace) -> int:
             return 1
 
     fmt = getattr(args, "format", "terminal") or "terminal"
+
+    # --diff: side-by-side HTML diff viewer
+    diff_session_id = getattr(args, "diff", "") or ""
+    if diff_session_id:
+        from .replay import replay_to_html_diff
+        diff_full = store.find_session(diff_session_id) or diff_session_id
+        output_path = getattr(args, "output", "") or \
+            f"diff-{session_id[:8]}-vs-{diff_full[:8]}.html"
+        replay_to_html_diff(store, session_id, diff_full, output_path=output_path)
+        sys.stdout.write(f"Diff HTML written to {output_path}\n")
+        return 0
+
     if fmt == "html":
         from .replay import replay_to_html
         output_path = getattr(args, "output", "") or f"session-{session_id[:12]}.html"
@@ -499,6 +511,8 @@ def build_parser() -> argparse.ArgumentParser:
                           help="cap output at N events (default: all); useful for quick inspection of large sessions")
     p_replay.add_argument("--format", choices=["terminal", "html"], default="terminal",
                           help="output format: terminal timeline or self-contained HTML viewer (default: terminal)")
+    p_replay.add_argument("--diff", metavar="SESSION_B",
+                         help="generate side-by-side HTML diff against SESSION_B")
     p_replay.add_argument("--output", "-o", default="",
                           help="output file path for --format html (default: session-<id>.html)")
     p_replay.add_argument("--expand-subagents", action="store_true",
@@ -610,6 +624,8 @@ def build_parser() -> argparse.ArgumentParser:
     # audit
     p_audit = sub.add_parser("audit", help="check session tool calls against a policy file")
     p_audit.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_audit.add_argument("--verify-chain", dest="verify_chain", action="store_true",
+                         help="verify SHA-256 hash chain integrity before policy audit")
     p_audit.add_argument("--policy", default=".agent-scope.json",
                          help="path to policy file (default: .agent-scope.json)")
 

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -53,6 +53,8 @@ class TraceEvent:
     parent_id: str = ""  # links tool_result to tool_call, llm_response to llm_request
     duration_ms: float | None = None
     data: dict[str, Any] = field(default_factory=dict)
+    # SHA-256 hex digest of the previous event's JSON line (empty on first event)
+    prev_hash: str = ""
 
     def to_json(self) -> str:
         d = asdict(self)

--- a/src/agent_trace/replay.py
+++ b/src/agent_trace/replay.py
@@ -660,3 +660,166 @@ def replay_to_html(
         Path(output_path).write_text(html, encoding="utf-8")
 
     return html
+
+
+# ---------------------------------------------------------------------------
+# Dual-session diff HTML viewer
+# ---------------------------------------------------------------------------
+
+_DIFF_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>agent-strace diff: {sid_a} vs {sid_b}</title>
+<style>
+  body{{font-family:monospace;background:#0d1117;color:#c9d1d9;margin:0;padding:16px}}
+  h1{{font-size:1rem;color:#58a6ff;margin-bottom:4px}}
+  .subtitle{{color:#8b949e;font-size:.8rem;margin-bottom:16px}}
+  .grid{{display:grid;grid-template-columns:1fr 1fr;gap:12px}}
+  .col{{background:#161b22;border:1px solid #30363d;border-radius:6px;padding:12px;overflow-y:auto;max-height:80vh}}
+  .col h2{{font-size:.85rem;color:#58a6ff;margin:0 0 8px}}
+  .event{{padding:4px 6px;border-radius:4px;margin-bottom:4px;font-size:.78rem;border-left:3px solid transparent}}
+  .event.tool_call{{border-color:#3fb950;background:#0d2b0d}}
+  .event.tool_result{{border-color:#1f6feb;background:#0d1b2e}}
+  .event.llm_request{{border-color:#d29922;background:#2b1d00}}
+  .event.llm_response{{border-color:#d29922;background:#2b1d00}}
+  .event.error{{border-color:#f85149;background:#2d0d0d}}
+  .event.decision{{border-color:#bc8cff;background:#1a0d2e}}
+  .event.only-a{{outline:2px solid #f85149}}
+  .event.only-b{{outline:2px solid #3fb950}}
+  .legend{{display:flex;gap:16px;font-size:.75rem;margin-bottom:12px;flex-wrap:wrap}}
+  .legend span{{padding:2px 8px;border-radius:3px}}
+  .leg-a{{background:#2d0d0d;border:1px solid #f85149;color:#f85149}}
+  .leg-b{{background:#0d2b0d;border:1px solid #3fb950;color:#3fb950}}
+  .leg-both{{background:#161b22;border:1px solid #30363d}}
+  .stats{{display:flex;gap:24px;margin-bottom:12px;font-size:.8rem}}
+  .stat{{color:#8b949e}}.stat b{{color:#c9d1d9}}
+</style>
+</head>
+<body>
+<h1>agent-strace diff</h1>
+<div class="subtitle">{sid_a} &nbsp;vs&nbsp; {sid_b}</div>
+<div class="legend">
+  <span class="leg-a">only in A</span>
+  <span class="leg-b">only in B</span>
+  <span class="leg-both">in both</span>
+</div>
+<div class="stats">
+  <div class="stat">A: <b>{count_a}</b> events &nbsp; <b>${cost_a:.4f}</b></div>
+  <div class="stat">B: <b>{count_b}</b> events &nbsp; <b>${cost_b:.4f}</b></div>
+  <div class="stat">Divergence index: <b>{divergence_index:.0%}</b></div>
+</div>
+<div class="grid">
+  <div class="col">
+    <h2>A &mdash; {sid_a}</h2>
+    <div id="col-a"></div>
+  </div>
+  <div class="col">
+    <h2>B &mdash; {sid_b}</h2>
+    <div id="col-b"></div>
+  </div>
+</div>
+<script>
+const eventsA = {events_a_json};
+const eventsB = {events_b_json};
+const onlyA = new Set({only_a_json});
+const onlyB = new Set({only_b_json});
+
+function renderEvents(events, onlySet, colId) {{
+  const col = document.getElementById(colId);
+  events.forEach(e => {{
+    const div = document.createElement('div');
+    const et = e.event_type;
+    div.className = 'event ' + et + (onlySet.has(e.event_id) ? (colId==='col-a' ? ' only-a' : ' only-b') : '');
+    const tool = e.data.tool_name || e.data.model || '';
+    const label = tool ? et + ' · ' + tool : et;
+    const offset = e._offset !== undefined ? ' +' + e._offset.toFixed(1) + 's' : '';
+    div.textContent = label + offset;
+    div.title = JSON.stringify(e.data, null, 2);
+    col.appendChild(div);
+  }});
+}}
+renderEvents(eventsA, onlyA, 'col-a');
+renderEvents(eventsB, onlyB, 'col-b');
+</script>
+</body>
+</html>
+"""
+
+
+def replay_to_html_diff(
+    store: TraceStore,
+    session_a: str,
+    session_b: str,
+    output_path: str | None = None,
+) -> str:
+    """Generate a side-by-side HTML diff viewer for two sessions.
+
+    Events present in only one session are highlighted with a coloured outline.
+    Returns the HTML string; writes to output_path if given.
+    """
+    import json as _json
+    from .cost import _dollars, _event_tokens
+    from .diff import diff_sessions
+
+    events_a = store.load_events(session_a)
+    events_b = store.load_events(session_b)
+
+    def _build_event_data(events: list) -> list[dict]:
+        base_ts = events[0].timestamp if events else 0.0
+        result = []
+        for e in events:
+            result.append({
+                "event_type": e.event_type.value,
+                "event_id": e.event_id,
+                "_offset": round(e.timestamp - base_ts, 3),
+                "duration_ms": e.duration_ms,
+                "data": dict(e.data),
+            })
+        return result
+
+    def _session_cost(events: list) -> float:
+        total = 0.0
+        for e in events:
+            inp, out = _event_tokens(e)
+            total += _dollars(inp, out, "sonnet")
+        return total
+
+    # Compute which event_ids are unique to each session (by tool_name+type key)
+    def _event_key(e) -> str:
+        return f"{e.event_type.value}:{e.data.get('tool_name','')}"
+
+    keys_a = {_event_key(e) for e in events_a}
+    keys_b = {_event_key(e) for e in events_b}
+    only_a_keys = keys_a - keys_b
+    only_b_keys = keys_b - keys_a
+
+    only_a_ids = [e.event_id for e in events_a if _event_key(e) in only_a_keys]
+    only_b_ids = [e.event_id for e in events_b if _event_key(e) in only_b_keys]
+
+    # Divergence index from diff engine
+    try:
+        diff_result = diff_sessions(store, session_a, session_b)
+        divergence_index = diff_result.divergence_index
+    except Exception:
+        divergence_index = 0.0
+
+    html = _DIFF_HTML_TEMPLATE.format(
+        sid_a=session_a[:16],
+        sid_b=session_b[:16],
+        count_a=len(events_a),
+        count_b=len(events_b),
+        cost_a=_session_cost(events_a),
+        cost_b=_session_cost(events_b),
+        divergence_index=divergence_index,
+        events_a_json=_json.dumps(_build_event_data(events_a), separators=(",", ":")),
+        events_b_json=_json.dumps(_build_event_data(events_b), separators=(",", ":")),
+        only_a_json=_json.dumps(only_a_ids, separators=(",", ":")),
+        only_b_json=_json.dumps(only_b_ids, separators=(",", ":")),
+    )
+
+    if output_path:
+        Path(output_path).write_text(html, encoding="utf-8")
+
+    return html

--- a/src/agent_trace/store.py
+++ b/src/agent_trace/store.py
@@ -37,6 +37,15 @@ class TraceStore:
 
     def append_event(self, session_id: str, event: TraceEvent) -> None:
         f = self._session_dir(session_id) / "events.ndjson"
+        # Compute hash chain: SHA-256 of the last line in the file
+        if not event.prev_hash:
+            try:
+                import hashlib as _hashlib
+                text = f.read_text() if f.exists() else ""
+                last_line = text.rstrip("\n").rsplit("\n", 1)[-1] if text.strip() else ""
+                event.prev_hash = _hashlib.sha256(last_line.encode()).hexdigest() if last_line else ""
+            except Exception:
+                pass
         with open(f, "a") as fh:
             fh.write(event.to_json() + "\n")
 

--- a/tests/test_hash_chain.py
+++ b/tests/test_hash_chain.py
@@ -1,0 +1,149 @@
+"""Tests for tamper-evident hash chain audit (issue #143)."""
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.audit import verify_chain, ChainVerifyResult
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_session(store: TraceStore, n_events: int = 3) -> str:
+    meta = SessionMeta(agent_name="test")
+    meta.started_at = time.time() - 60
+    meta.ended_at = time.time()
+    store.create_session(meta)
+    for i in range(n_events):
+        store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={"tool_name": f"tool-{i}"},
+        ))
+    store.update_meta(meta)
+    return meta.session_id
+
+
+class TestHashChainAppend(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_first_event_has_empty_prev_hash(self):
+        sid = _make_session(self.store, n_events=1)
+        events = self.store.load_events(sid)
+        self.assertEqual(events[0].prev_hash, "")
+
+    def test_second_event_has_prev_hash(self):
+        sid = _make_session(self.store, n_events=2)
+        events = self.store.load_events(sid)
+        self.assertNotEqual(events[1].prev_hash, "")
+
+    def test_prev_hash_is_sha256_hex(self):
+        sid = _make_session(self.store, n_events=2)
+        events = self.store.load_events(sid)
+        h = events[1].prev_hash
+        self.assertEqual(len(h), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_prev_hash_matches_sha256_of_previous_line(self):
+        sid = _make_session(self.store, n_events=3)
+        events_path = self.store._session_dir(sid) / "events.ndjson"
+        lines = [l for l in events_path.read_text().splitlines() if l.strip()]
+        # Check event[2].prev_hash == sha256(lines[1])
+        expected = hashlib.sha256(lines[1].encode()).hexdigest()
+        obj = json.loads(lines[2])
+        self.assertEqual(obj["prev_hash"], expected)
+
+
+class TestVerifyChain(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_intact_chain_returns_ok(self):
+        sid = _make_session(self.store, n_events=5)
+        result = verify_chain(self.store, sid)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.total_events, 5)
+
+    def test_empty_session_returns_ok(self):
+        meta = SessionMeta(agent_name="empty")
+        self.store.create_session(meta)
+        result = verify_chain(self.store, meta.session_id)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.total_events, 0)
+
+    def test_tampered_event_detected(self):
+        sid = _make_session(self.store, n_events=4)
+        events_path = self.store._session_dir(sid) / "events.ndjson"
+        lines = events_path.read_text().splitlines()
+
+        # Tamper: modify the second event's data
+        obj = json.loads(lines[1])
+        obj["data"]["tool_name"] = "TAMPERED"
+        lines[1] = json.dumps(obj)
+        events_path.write_text("\n".join(lines) + "\n")
+
+        result = verify_chain(self.store, sid)
+        self.assertFalse(result.ok)
+        self.assertIsNotNone(result.broken_at)
+        self.assertGreater(result.broken_at, 0)
+
+    def test_inserted_event_detected(self):
+        sid = _make_session(self.store, n_events=3)
+        events_path = self.store._session_dir(sid) / "events.ndjson"
+        lines = events_path.read_text().splitlines()
+
+        # Insert a fake event between lines[0] and lines[1]
+        fake = json.loads(lines[0])
+        fake["event_id"] = "fakeevent00"
+        fake["prev_hash"] = ""  # wrong hash
+        lines.insert(1, json.dumps(fake))
+        events_path.write_text("\n".join(lines) + "\n")
+
+        result = verify_chain(self.store, sid)
+        self.assertFalse(result.ok)
+
+    def test_pre_v062_events_without_hash_skipped(self):
+        """Events without prev_hash (legacy) must not cause a false failure."""
+        meta = SessionMeta(agent_name="legacy")
+        self.store.create_session(meta)
+        # Write events manually without prev_hash
+        events_path = self.store._session_dir(meta.session_id) / "events.ndjson"
+        for i in range(3):
+            obj = {"event_type": "tool_call", "event_id": f"ev{i:04d}",
+                   "timestamp": time.time(), "data": {}}
+            events_path.open("a").write(json.dumps(obj) + "\n")
+
+        result = verify_chain(self.store, meta.session_id)
+        self.assertTrue(result.ok)
+
+    def test_result_format_ok(self):
+        import io
+        sid = _make_session(self.store, n_events=2)
+        result = verify_chain(self.store, sid)
+        buf = io.StringIO()
+        result.format(buf)
+        self.assertIn("intact", buf.getvalue())
+
+    def test_result_format_broken(self):
+        import io
+        result = ChainVerifyResult(
+            session_id="abc", ok=False, total_events=5,
+            broken_at=2, broken_event_id="ev0002"
+        )
+        buf = io.StringIO()
+        result.format(buf)
+        self.assertIn("broken", buf.getvalue())
+        self.assertIn("ev0002", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_replay_diff.py
+++ b/tests/test_replay_diff.py
@@ -1,0 +1,82 @@
+"""Tests for replay --diff dual-session HTML viewer (issue #139)."""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.replay import replay_to_html_diff
+from agent_trace.store import TraceStore
+
+
+def _make_session(store: TraceStore, tool_names: list[str]) -> str:
+    meta = SessionMeta(agent_name="test")
+    meta.started_at = time.time() - 60
+    meta.ended_at = time.time()
+    store.create_session(meta)
+    for name in tool_names:
+        store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={"tool_name": name},
+        ))
+    store.update_meta(meta)
+    return meta.session_id
+
+
+class TestReplayDiff(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_returns_html_string(self):
+        sid_a = _make_session(self.store, ["Bash", "Read"])
+        sid_b = _make_session(self.store, ["Bash", "Write"])
+        html = replay_to_html_diff(self.store, sid_a, sid_b)
+        self.assertIsInstance(html, str)
+        self.assertIn("<!DOCTYPE html>", html)
+
+    def test_both_session_ids_in_output(self):
+        sid_a = _make_session(self.store, ["Bash"])
+        sid_b = _make_session(self.store, ["Read"])
+        html = replay_to_html_diff(self.store, sid_a, sid_b)
+        self.assertIn(sid_a[:16], html)
+        self.assertIn(sid_b[:16], html)
+
+    def test_event_counts_in_output(self):
+        sid_a = _make_session(self.store, ["Bash", "Read", "Write"])
+        sid_b = _make_session(self.store, ["Bash"])
+        html = replay_to_html_diff(self.store, sid_a, sid_b)
+        # A has 3 events — the count should appear in the stats section
+        self.assertIn("<b>3</b>", html)
+
+    def test_writes_to_output_path(self):
+        sid_a = _make_session(self.store, ["Bash"])
+        sid_b = _make_session(self.store, ["Read"])
+        out = os.path.join(self.tmpdir, "diff.html")
+        replay_to_html_diff(self.store, sid_a, sid_b, output_path=out)
+        self.assertTrue(os.path.exists(out))
+        content = open(out).read()
+        self.assertIn("<!DOCTYPE html>", content)
+
+    def test_only_a_ids_in_output(self):
+        sid_a = _make_session(self.store, ["UniqueToolA"])
+        sid_b = _make_session(self.store, ["UniqueToolB"])
+        html = replay_to_html_diff(self.store, sid_a, sid_b)
+        # JS variables onlyA / onlyB must be present
+        self.assertIn("onlyA", html)
+        self.assertIn("onlyB", html)
+
+    def test_empty_sessions_dont_crash(self):
+        sid_a = _make_session(self.store, [])
+        sid_b = _make_session(self.store, [])
+        html = replay_to_html_diff(self.store, sid_a, sid_b)
+        self.assertIn("<!DOCTYPE html>", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #139
Closes #143

## What changed

**`replay --diff` dual-session HTML viewer** (`#139`)

```bash
agent-strace replay <session-a> --diff <session-b>
agent-strace replay <session-a> --diff <session-b> --output diff.html
```

Generates a self-contained side-by-side HTML viewer. Events present in only one session are highlighted with a coloured outline (red = only in A, green = only in B). Stats bar shows event counts, cost, and divergence index from the existing `diff_sessions()` engine.

**Tamper-evident hash chain** (`#143`)

Every `TraceEvent` now stores `prev_hash` — the SHA-256 hex digest of the previous event's JSON line. The first event in a session gets an empty string. Existing sessions without `prev_hash` (pre-v0.62.0) are handled transparently.

```bash
# Verify a session's event log hasn't been tampered with
agent-strace audit --verify-chain [session-id]
```

`verify_chain()` re-derives each hash and reports the first broken link with its event ID. Exits 1 if the chain is broken so CI can catch tampering.

1306/1306 tests passing.