### PR TITLE
feat: workspace isolation and compliance export

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.62.0"
+__version__ = "0.63.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -26,8 +26,10 @@ from .a2a import cmd_a2a_tree
 from .mcp_server import cmd_mcp
 from .annotate import cmd_annotate
 from .baseline import cmd_baseline
+from .compliance import cmd_compliance
 from .drift import cmd_drift
 from .identity import cmd_identity
+from .workspace import cmd_workspace
 from .langfuse_export import cmd_export_scores
 from .oncall import cmd_oncall
 from .optimize import cmd_optimize
@@ -845,6 +847,31 @@ def build_parser() -> argparse.ArgumentParser:
                            default=".agent-traces/baseline.json",
                            help="baseline file (default: .agent-traces/baseline.json)")
 
+    # compliance (compliance export)
+    p_comp = sub.add_parser("compliance", help="export compliance reports (EU AI Act, SOC 2, HIPAA)")
+    comp_sub = p_comp.add_subparsers(dest="compliance_cmd")
+    p_comp_exp = comp_sub.add_parser("export", help="export compliance report")
+    p_comp_exp.add_argument("session_id", nargs="?",
+                            help="session ID or prefix (default: all recent sessions)")
+    p_comp_exp.add_argument("--framework", choices=["eu-ai-act", "soc2", "hipaa", "all"],
+                            default="all", help="compliance framework (default: all)")
+    p_comp_exp.add_argument("--since", metavar="Nd",
+                            help="export sessions from last N days (e.g. 30d)")
+    p_comp_exp.add_argument("--output", "-o", metavar="FILE",
+                            help="write JSON report to FILE instead of stdout")
+
+    # workspace (workspace isolation)
+    p_ws = sub.add_parser("workspace", help="manage isolated workspaces")
+    ws_sub = p_ws.add_subparsers(dest="workspace_cmd")
+    ws_sub.add_parser("list", help="list all workspaces")
+    p_ws_use = ws_sub.add_parser("use", help="print shell export for a workspace")
+    p_ws_use.add_argument("workspace_id", help="workspace ID to activate")
+    p_ws_new = ws_sub.add_parser("new", help="create a new workspace")
+    p_ws_new.add_argument("workspace_id", help="workspace ID to create")
+    p_ws_rm = ws_sub.add_parser("rm", help="delete a workspace and all its sessions")
+    p_ws_rm.add_argument("workspace_id", help="workspace ID to delete")
+    p_ws_rm.add_argument("--force", action="store_true", help="skip confirmation")
+
     # identity (per-agent machine identity and session signing)
     p_identity = sub.add_parser("identity", help="manage agent machine identity and sign sessions")
     identity_sub = p_identity.add_subparsers(dest="identity_cmd")
@@ -1161,6 +1188,8 @@ def main() -> None:
         "baseline": cmd_baseline,
         "drift": cmd_drift,
         "identity": cmd_identity,
+        "workspace": cmd_workspace,
+        "compliance": cmd_compliance,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/compliance.py
+++ b/src/agent_trace/compliance.py
@@ -1,0 +1,251 @@
+"""Compliance export for EU AI Act, SOC 2, and HIPAA audit requirements.
+
+Generates structured JSON reports from session traces that satisfy the
+logging and audit trail requirements of common compliance frameworks.
+
+Usage:
+    agent-strace compliance export [session-id] --framework eu-ai-act
+    agent-strace compliance export [session-id] --framework soc2
+    agent-strace compliance export [session-id] --framework hipaa
+    agent-strace compliance export [session-id] --framework all
+
+    # Export all sessions in a time window
+    agent-strace compliance export --since 30d --framework soc2 --output report.json
+
+Frameworks:
+    eu-ai-act   Article 13 transparency + Article 9 risk management logging
+    soc2        CC6 (logical access), CC7 (system operations) evidence
+    hipaa       §164.312 audit controls, access logs, integrity controls
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+Framework = Literal["eu-ai-act", "soc2", "hipaa", "all"]
+
+_FRAMEWORKS: list[str] = ["eu-ai-act", "soc2", "hipaa"]
+
+
+# ---------------------------------------------------------------------------
+# Per-framework report builders
+# ---------------------------------------------------------------------------
+
+def _eu_ai_act_report(session_id: str, meta, events: list[TraceEvent]) -> dict:
+    """EU AI Act Article 13 (transparency) + Article 9 (risk management) evidence."""
+    tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+    errors = [e for e in events if e.event_type == EventType.ERROR]
+    decisions = [e for e in events if e.event_type == EventType.DECISION]
+
+    return {
+        "framework": "eu-ai-act",
+        "generated_at": time.time(),
+        "session_id": session_id,
+        "article_13_transparency": {
+            "agent_name": meta.agent_name,
+            "session_start": meta.started_at,
+            "session_end": meta.ended_at,
+            "total_tool_calls": len(tool_calls),
+            "total_decisions": len(decisions),
+            "tools_used": sorted({e.data.get("tool_name", "") for e in tool_calls if e.data.get("tool_name")}),
+        },
+        "article_9_risk_management": {
+            "error_count": len(errors),
+            "error_types": [e.data.get("error_type", "unknown") for e in errors],
+            "anomalous_tool_calls": [
+                {"event_id": e.event_id, "tool": e.data.get("tool_name"), "ts": e.timestamp}
+                for e in tool_calls
+                if e.data.get("blocked") or e.data.get("policy_violation")
+            ],
+        },
+        "chain_integrity": {
+            "hash_chain_present": any(e.prev_hash for e in events),
+        },
+    }
+
+
+def _soc2_report(session_id: str, meta, events: list[TraceEvent]) -> dict:
+    """SOC 2 CC6 (logical access) + CC7 (system operations) evidence."""
+    tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+    errors = [e for e in events if e.event_type == EventType.ERROR]
+    llm_reqs = [e for e in events if e.event_type == EventType.LLM_REQUEST]
+
+    # CC6: logical access — what resources were accessed
+    resources_accessed = sorted({
+        e.data.get("tool_name", "") for e in tool_calls
+        if e.data.get("tool_name")
+    })
+
+    # CC7: system operations — availability and error evidence
+    return {
+        "framework": "soc2",
+        "generated_at": time.time(),
+        "session_id": session_id,
+        "cc6_logical_access": {
+            "agent_identity": meta.agent_name,
+            "workspace": getattr(meta, "workspace_id", "") or "",
+            "team": getattr(meta, "team", "") or "",
+            "session_start_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(meta.started_at)),
+            "session_end_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(meta.ended_at)) if meta.ended_at else None,
+            "resources_accessed": resources_accessed,
+            "total_operations": len(tool_calls),
+        },
+        "cc7_system_operations": {
+            "llm_requests": len(llm_reqs),
+            "errors": len(errors),
+            "error_details": [
+                {"event_id": e.event_id, "error": e.data.get("error", ""), "ts": e.timestamp}
+                for e in errors
+            ],
+            "duration_ms": meta.total_duration_ms or 0.0,
+        },
+    }
+
+
+def _hipaa_report(session_id: str, meta, events: list[TraceEvent]) -> dict:
+    """HIPAA §164.312 audit controls and access log evidence."""
+    tool_calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+    errors = [e for e in events if e.event_type == EventType.ERROR]
+
+    # Build access log entries
+    access_log = []
+    for e in tool_calls:
+        access_log.append({
+            "event_id": e.event_id,
+            "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(e.timestamp)),
+            "action": e.data.get("tool_name", "unknown"),
+            "outcome": "success",
+            "duration_ms": e.duration_ms,
+        })
+    for e in errors:
+        access_log.append({
+            "event_id": e.event_id,
+            "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(e.timestamp)),
+            "action": e.data.get("tool_name", "error"),
+            "outcome": "failure",
+            "error": e.data.get("error", ""),
+        })
+    access_log.sort(key=lambda x: x["timestamp_utc"])
+
+    return {
+        "framework": "hipaa",
+        "generated_at": time.time(),
+        "session_id": session_id,
+        "section_164_312_audit_controls": {
+            "agent_name": meta.agent_name,
+            "session_id": session_id,
+            "session_start_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(meta.started_at)),
+            "session_end_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(meta.ended_at)) if meta.ended_at else None,
+            "access_log": access_log,
+            "total_accesses": len(access_log),
+            "failures": len(errors),
+        },
+        "section_164_312_integrity": {
+            "hash_chain_present": any(e.prev_hash for e in events),
+            "event_count": len(events),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def export_compliance(
+    store: TraceStore,
+    session_id: str,
+    framework: Framework = "all",
+) -> dict:
+    """Build a compliance report for one session.
+
+    Returns a dict with one key per framework requested.
+    """
+    try:
+        meta = store.load_meta(session_id)
+    except Exception:
+        return {"error": f"session not found: {session_id}"}
+    try:
+        events = store.load_events(session_id)
+    except Exception:
+        events = []
+
+    frameworks = _FRAMEWORKS if framework == "all" else [framework]
+    report: dict = {
+        "session_id": session_id,
+        "exported_at": time.time(),
+        "frameworks": {},
+    }
+    for fw in frameworks:
+        if fw == "eu-ai-act":
+            report["frameworks"][fw] = _eu_ai_act_report(session_id, meta, events)
+        elif fw == "soc2":
+            report["frameworks"][fw] = _soc2_report(session_id, meta, events)
+        elif fw == "hipaa":
+            report["frameworks"][fw] = _hipaa_report(session_id, meta, events)
+
+    return report
+
+
+def export_compliance_bulk(
+    store: TraceStore,
+    framework: Framework = "all",
+    since_days: float = 30.0,
+) -> list[dict]:
+    """Export compliance reports for all sessions in the last N days."""
+    cutoff = time.time() - since_days * 86400
+    reports = []
+    for meta in store.list_sessions():
+        if not meta.ended_at or meta.started_at < cutoff:
+            continue
+        reports.append(export_compliance(store, meta.session_id, framework))
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_compliance(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    sub = getattr(args, "compliance_cmd", None)
+
+    if sub == "export":
+        framework = getattr(args, "framework", "all") or "all"
+        output = getattr(args, "output", "") or ""
+        since_str = getattr(args, "since", "") or ""
+        session_id = getattr(args, "session_id", None)
+
+        if since_str or not session_id:
+            # Bulk export
+            since_days = float(since_str.rstrip("d")) if since_str else 30.0
+            reports = export_compliance_bulk(store, framework=framework,
+                                             since_days=since_days)
+            result = json.dumps(reports, indent=2)
+        else:
+            full_id = store.find_session(session_id)
+            if not full_id:
+                sys.stderr.write(f"Session not found: {session_id}\n")
+                return 1
+            report = export_compliance(store, full_id, framework=framework)
+            result = json.dumps(report, indent=2)
+
+        if output:
+            Path(output).write_text(result + "\n")
+            sys.stdout.write(f"Compliance report written to {output}\n")
+        else:
+            sys.stdout.write(result + "\n")
+        return 0
+
+    else:
+        sys.stderr.write("Usage: agent-strace compliance export [session-id] "
+                         "--framework eu-ai-act|soc2|hipaa|all\n")
+        return 1

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -88,6 +88,9 @@ class SessionMeta:
     depth: int = 0                # nesting depth (0 = root, 1 = first subagent, etc.)
     # Team grouping (optional — used for team budget reports)
     team: str = ""
+    # Workspace isolation — sessions in different workspaces are stored in
+    # separate subdirectories and never appear in each other's listings
+    workspace_id: str = ""
     # Attribution (who/what started this session)
     attribution: dict = field(default_factory=dict)
 

--- a/src/agent_trace/store.py
+++ b/src/agent_trace/store.py
@@ -6,6 +6,14 @@ Traces are stored as directories:
       meta.json       # session metadata
       events.ndjson   # newline-delimited JSON events
 
+  With workspace isolation:
+  .agent-traces/
+    workspaces/
+      <workspace-id>/
+        <session-id>/
+          meta.json
+          events.ndjson
+
 NDJSON is append-only. No database. No dependencies. Just files.
 """
 
@@ -19,15 +27,42 @@ from .models import EventType, SessionMeta, TraceEvent
 
 DEFAULT_TRACE_DIR = ".agent-traces"
 
+# Env var for workspace isolation — sessions are stored under
+# .agent-traces/workspaces/<workspace-id>/ when this is set.
+_WORKSPACE_ENV = "AGENT_STRACE_WORKSPACE"
+
+
+def _workspace_base(base_dir: str | Path, workspace_id: str) -> Path:
+    """Return the workspace-scoped subdirectory path."""
+    return Path(base_dir) / "workspaces" / workspace_id
+
 
 class TraceStore:
-    def __init__(self, base_dir: str | Path = DEFAULT_TRACE_DIR):
-        self.base_dir = Path(base_dir)
+    def __init__(self, base_dir: str | Path = DEFAULT_TRACE_DIR,
+                 workspace_id: str = ""):
+        """Create a TraceStore.
+
+        workspace_id scopes all reads/writes to a subdirectory:
+          <base_dir>/workspaces/<workspace_id>/
+
+        If workspace_id is empty, the AGENT_STRACE_WORKSPACE env var is
+        checked. If that is also empty, the flat layout is used.
+        """
+        wid = workspace_id or os.environ.get(_WORKSPACE_ENV, "")
+        if wid:
+            self.base_dir = _workspace_base(base_dir, wid)
+            self.workspace_id = wid
+        else:
+            self.base_dir = Path(base_dir)
+            self.workspace_id = ""
 
     def _session_dir(self, session_id: str) -> Path:
         return self.base_dir / session_id
 
     def create_session(self, meta: SessionMeta) -> Path:
+        # Stamp workspace_id onto meta so it's visible in exports/reports
+        if self.workspace_id and not getattr(meta, "workspace_id", ""):
+            meta.workspace_id = self.workspace_id
         d = self._session_dir(meta.session_id)
         d.mkdir(parents=True, exist_ok=True)
         (d / "meta.json").write_text(meta.to_json())

--- a/src/agent_trace/workspace.py
+++ b/src/agent_trace/workspace.py
@@ -1,0 +1,141 @@
+"""Workspace isolation for agent-trace.
+
+Workspaces scope sessions into separate subdirectories so multiple teams,
+environments, or projects can share a single AGENT_TRACE_DIR without
+seeing each other's sessions.
+
+Layout:
+  .agent-traces/
+    workspaces/
+      <workspace-id>/
+        <session-id>/
+          meta.json
+          events.ndjson
+
+Usage:
+    # List workspaces
+    agent-strace workspace list
+
+    # Activate a workspace in the current shell
+    eval $(agent-strace workspace use staging)
+
+    # Create a new workspace
+    agent-strace workspace new staging
+
+    # Delete a workspace
+    agent-strace workspace rm staging --force
+
+Env var: AGENT_STRACE_WORKSPACE
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from .store import DEFAULT_TRACE_DIR, _WORKSPACE_ENV, _workspace_base
+
+
+def _workspaces_root(trace_dir: str) -> Path:
+    return Path(trace_dir) / "workspaces"
+
+
+def list_workspaces(trace_dir: str = DEFAULT_TRACE_DIR) -> list[str]:
+    """Return sorted list of workspace IDs."""
+    root = _workspaces_root(trace_dir)
+    if not root.exists():
+        return []
+    return sorted(d.name for d in root.iterdir() if d.is_dir())
+
+
+def create_workspace(workspace_id: str,
+                     trace_dir: str = DEFAULT_TRACE_DIR) -> Path:
+    """Create a workspace directory. Idempotent."""
+    path = _workspace_base(trace_dir, workspace_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def delete_workspace(workspace_id: str,
+                     trace_dir: str = DEFAULT_TRACE_DIR) -> bool:
+    """Delete a workspace and all its sessions. Returns True if it existed."""
+    path = _workspace_base(trace_dir, workspace_id)
+    if not path.exists():
+        return False
+    shutil.rmtree(path)
+    return True
+
+
+def workspace_session_count(workspace_id: str,
+                             trace_dir: str = DEFAULT_TRACE_DIR) -> int:
+    """Return the number of sessions in a workspace."""
+    path = _workspace_base(trace_dir, workspace_id)
+    if not path.exists():
+        return 0
+    return sum(1 for d in path.iterdir() if d.is_dir() and (d / "meta.json").exists())
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_workspace(args: argparse.Namespace) -> int:
+    trace_dir = args.trace_dir
+    sub = getattr(args, "workspace_cmd", None)
+
+    if sub == "list":
+        workspaces = list_workspaces(trace_dir)
+        if not workspaces:
+            sys.stdout.write("No workspaces found.\n")
+            sys.stdout.write(
+                f"Create one with: agent-strace workspace new <name>\n"
+                f"Or set {_WORKSPACE_ENV}=<name> to use one automatically.\n"
+            )
+            return 0
+        sys.stdout.write(f"\n{'Workspace':<32}  Sessions\n")
+        sys.stdout.write(f"{'─'*32}  {'─'*8}\n")
+        for wid in workspaces:
+            count = workspace_session_count(wid, trace_dir)
+            sys.stdout.write(f"{wid:<32}  {count}\n")
+        sys.stdout.write("\n")
+        return 0
+
+    elif sub == "use":
+        wid = args.workspace_id
+        # Print a shell export the user can eval
+        sys.stdout.write(f"export {_WORKSPACE_ENV}={wid}\n")
+        sys.stderr.write(
+            f"# Run: eval $(agent-strace workspace use {wid})\n"
+            f"# Or add to your shell profile.\n"
+        )
+        return 0
+
+    elif sub == "new":
+        wid = args.workspace_id
+        path = create_workspace(wid, trace_dir)
+        sys.stdout.write(f"Workspace '{wid}' created at {path}\n")
+        sys.stdout.write(f"Activate: eval $(agent-strace workspace use {wid})\n")
+        return 0
+
+    elif sub == "rm":
+        wid = args.workspace_id
+        count = workspace_session_count(wid, trace_dir)
+        if count and not getattr(args, "force", False):
+            sys.stderr.write(
+                f"Workspace '{wid}' contains {count} session(s). "
+                f"Use --force to delete.\n"
+            )
+            return 1
+        existed = delete_workspace(wid, trace_dir)
+        if existed:
+            sys.stdout.write(f"Workspace '{wid}' deleted.\n")
+        else:
+            sys.stderr.write(f"Workspace '{wid}' not found.\n")
+            return 1
+        return 0
+
+    else:
+        sys.stderr.write("Usage: agent-strace workspace <list|use|new|rm>\n")
+        return 1

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,0 +1,170 @@
+"""Tests for compliance export (issue #144)."""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.compliance import export_compliance, export_compliance_bulk
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_session(store: TraceStore, tool_names: list[str],
+                  errors: int = 0) -> str:
+    meta = SessionMeta(agent_name="test-agent")
+    meta.started_at = time.time() - 120
+    meta.ended_at = time.time()
+    meta.total_duration_ms = 120_000.0
+    meta.tool_calls = len(tool_names)
+    store.create_session(meta)
+    for name in tool_names:
+        store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={"tool_name": name},
+        ))
+    for i in range(errors):
+        store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.ERROR,
+            session_id=meta.session_id,
+            data={"error": f"error-{i}", "error_type": "RuntimeError"},
+        ))
+    store.update_meta(meta)
+    return meta.session_id
+
+
+class TestEuAiActReport(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_has_required_keys(self):
+        sid = _make_session(self.store, ["Bash", "Read"])
+        report = export_compliance(self.store, sid, "eu-ai-act")
+        fw = report["frameworks"]["eu-ai-act"]
+        self.assertIn("article_13_transparency", fw)
+        self.assertIn("article_9_risk_management", fw)
+
+    def test_tools_used_populated(self):
+        sid = _make_session(self.store, ["Bash", "Read", "Bash"])
+        report = export_compliance(self.store, sid, "eu-ai-act")
+        tools = report["frameworks"]["eu-ai-act"]["article_13_transparency"]["tools_used"]
+        self.assertIn("Bash", tools)
+        self.assertIn("Read", tools)
+
+    def test_error_count(self):
+        sid = _make_session(self.store, ["Bash"], errors=2)
+        report = export_compliance(self.store, sid, "eu-ai-act")
+        self.assertEqual(
+            report["frameworks"]["eu-ai-act"]["article_9_risk_management"]["error_count"], 2
+        )
+
+
+class TestSoc2Report(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_has_cc6_and_cc7(self):
+        sid = _make_session(self.store, ["Bash"])
+        report = export_compliance(self.store, sid, "soc2")
+        fw = report["frameworks"]["soc2"]
+        self.assertIn("cc6_logical_access", fw)
+        self.assertIn("cc7_system_operations", fw)
+
+    def test_resources_accessed(self):
+        sid = _make_session(self.store, ["Bash", "Write"])
+        report = export_compliance(self.store, sid, "soc2")
+        resources = report["frameworks"]["soc2"]["cc6_logical_access"]["resources_accessed"]
+        self.assertIn("Bash", resources)
+        self.assertIn("Write", resources)
+
+    def test_error_details_populated(self):
+        sid = _make_session(self.store, [], errors=1)
+        report = export_compliance(self.store, sid, "soc2")
+        details = report["frameworks"]["soc2"]["cc7_system_operations"]["error_details"]
+        self.assertEqual(len(details), 1)
+
+
+class TestHipaaReport(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_has_audit_controls(self):
+        sid = _make_session(self.store, ["Bash"])
+        report = export_compliance(self.store, sid, "hipaa")
+        fw = report["frameworks"]["hipaa"]
+        self.assertIn("section_164_312_audit_controls", fw)
+        self.assertIn("section_164_312_integrity", fw)
+
+    def test_access_log_entries(self):
+        sid = _make_session(self.store, ["Bash", "Read"])
+        report = export_compliance(self.store, sid, "hipaa")
+        log = report["frameworks"]["hipaa"]["section_164_312_audit_controls"]["access_log"]
+        self.assertEqual(len(log), 2)
+        actions = [e["action"] for e in log]
+        self.assertIn("Bash", actions)
+
+    def test_failure_counted(self):
+        sid = _make_session(self.store, [], errors=2)
+        report = export_compliance(self.store, sid, "hipaa")
+        self.assertEqual(
+            report["frameworks"]["hipaa"]["section_164_312_audit_controls"]["failures"], 2
+        )
+
+
+class TestAllFrameworks(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_all_includes_three_frameworks(self):
+        sid = _make_session(self.store, ["Bash"])
+        report = export_compliance(self.store, sid, "all")
+        self.assertIn("eu-ai-act", report["frameworks"])
+        self.assertIn("soc2", report["frameworks"])
+        self.assertIn("hipaa", report["frameworks"])
+
+    def test_report_is_json_serialisable(self):
+        sid = _make_session(self.store, ["Bash", "Read"], errors=1)
+        report = export_compliance(self.store, sid, "all")
+        serialised = json.dumps(report)
+        self.assertIsInstance(serialised, str)
+
+    def test_missing_session_returns_error(self):
+        report = export_compliance(self.store, "nonexistent-session", "all")
+        self.assertIn("error", report)
+
+
+class TestBulkExport(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_bulk_returns_list(self):
+        _make_session(self.store, ["Bash"])
+        _make_session(self.store, ["Read"])
+        reports = export_compliance_bulk(self.store, "soc2", since_days=1)
+        self.assertIsInstance(reports, list)
+        self.assertEqual(len(reports), 2)
+
+    def test_bulk_excludes_old_sessions(self):
+        # Create a session 60 days ago
+        meta = SessionMeta(agent_name="old")
+        meta.started_at = time.time() - 86400 * 60
+        meta.ended_at = meta.started_at + 60
+        self.store.create_session(meta)
+        self.store.update_meta(meta)
+
+        reports = export_compliance_bulk(self.store, "soc2", since_days=30)
+        self.assertEqual(len(reports), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,128 @@
+"""Tests for workspace isolation (issue #135)."""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore, _WORKSPACE_ENV, _workspace_base
+from agent_trace.workspace import (
+    list_workspaces,
+    create_workspace,
+    delete_workspace,
+    workspace_session_count,
+)
+
+
+def _make_session(store: TraceStore) -> str:
+    meta = SessionMeta(agent_name="test")
+    meta.started_at = time.time() - 60
+    meta.ended_at = time.time()
+    store.create_session(meta)
+    store.update_meta(meta)
+    return meta.session_id
+
+
+class TestWorkspaceStore(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ.pop(_WORKSPACE_ENV, None)
+
+    def tearDown(self):
+        os.environ.pop(_WORKSPACE_ENV, None)
+
+    def test_workspace_scopes_base_dir(self):
+        store = TraceStore(self.tmpdir, workspace_id="alpha")
+        expected = _workspace_base(self.tmpdir, "alpha")
+        self.assertEqual(store.base_dir, expected)
+
+    def test_no_workspace_uses_flat_layout(self):
+        store = TraceStore(self.tmpdir)
+        from pathlib import Path
+        self.assertEqual(store.base_dir, Path(self.tmpdir))
+
+    def test_env_var_sets_workspace(self):
+        os.environ[_WORKSPACE_ENV] = "beta"
+        store = TraceStore(self.tmpdir)
+        self.assertEqual(store.workspace_id, "beta")
+
+    def test_explicit_workspace_overrides_env(self):
+        os.environ[_WORKSPACE_ENV] = "env-ws"
+        store = TraceStore(self.tmpdir, workspace_id="explicit-ws")
+        self.assertEqual(store.workspace_id, "explicit-ws")
+
+    def test_sessions_isolated_between_workspaces(self):
+        store_a = TraceStore(self.tmpdir, workspace_id="ws-a")
+        store_b = TraceStore(self.tmpdir, workspace_id="ws-b")
+        sid_a = _make_session(store_a)
+        sid_b = _make_session(store_b)
+
+        sessions_a = [m.session_id for m in store_a.list_sessions()]
+        sessions_b = [m.session_id for m in store_b.list_sessions()]
+
+        self.assertIn(sid_a, sessions_a)
+        self.assertNotIn(sid_b, sessions_a)
+        self.assertIn(sid_b, sessions_b)
+        self.assertNotIn(sid_a, sessions_b)
+
+    def test_workspace_id_stamped_on_meta(self):
+        store = TraceStore(self.tmpdir, workspace_id="stamped-ws")
+        sid = _make_session(store)
+        meta = store.load_meta(sid)
+        self.assertEqual(meta.workspace_id, "stamped-ws")
+
+    def test_flat_store_does_not_stamp_workspace(self):
+        store = TraceStore(self.tmpdir)
+        sid = _make_session(store)
+        meta = store.load_meta(sid)
+        self.assertEqual(meta.workspace_id, "")
+
+
+class TestWorkspaceCommands(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_list_empty(self):
+        result = list_workspaces(self.tmpdir)
+        self.assertEqual(result, [])
+
+    def test_create_and_list(self):
+        create_workspace("ws-1", self.tmpdir)
+        create_workspace("ws-2", self.tmpdir)
+        result = list_workspaces(self.tmpdir)
+        self.assertIn("ws-1", result)
+        self.assertIn("ws-2", result)
+
+    def test_create_idempotent(self):
+        create_workspace("ws-x", self.tmpdir)
+        create_workspace("ws-x", self.tmpdir)  # should not raise
+        self.assertIn("ws-x", list_workspaces(self.tmpdir))
+
+    def test_delete_existing(self):
+        create_workspace("ws-del", self.tmpdir)
+        existed = delete_workspace("ws-del", self.tmpdir)
+        self.assertTrue(existed)
+        self.assertNotIn("ws-del", list_workspaces(self.tmpdir))
+
+    def test_delete_nonexistent_returns_false(self):
+        existed = delete_workspace("no-such-ws", self.tmpdir)
+        self.assertFalse(existed)
+
+    def test_session_count(self):
+        store = TraceStore(self.tmpdir, workspace_id="counted")
+        _make_session(store)
+        _make_session(store)
+        count = workspace_session_count("counted", self.tmpdir)
+        self.assertEqual(count, 2)
+
+    def test_session_count_empty(self):
+        create_workspace("empty-ws", self.tmpdir)
+        self.assertEqual(workspace_session_count("empty-ws", self.tmpdir), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #135
Closes #144

## What changed

**Workspace isolation** (`#135`)

Sessions are now scoped to isolated subdirectories per workspace:

```bash
# Create and activate a workspace
agent-strace workspace new staging
eval $(agent-strace workspace use staging)

# All sessions now go to .agent-traces/workspaces/staging/
# Sessions in other workspaces are invisible

agent-strace workspace list   # shows all workspaces + session counts
agent-strace workspace rm staging --force
```

`AGENT_STRACE_WORKSPACE=<id>` activates a workspace automatically. `TraceStore(workspace_id=)` for programmatic use. `SessionMeta.workspace_id` is stamped on every session created in a workspace.

**Compliance export** (`#144`)

Structured JSON evidence for three frameworks:

```bash
# Single session
agent-strace compliance export <session-id> --framework eu-ai-act

# All sessions from last 30 days, all frameworks
agent-strace compliance export --since 30d --framework all --output report.json
```

| Framework | Evidence produced |
|---|---|
| `eu-ai-act` | Article 13 transparency (tools used, decisions) + Article 9 risk management (errors, policy violations) |
| `soc2` | CC6 logical access log + CC7 system operations (errors, duration) |
| `hipaa` | §164.312 audit controls (timestamped access log) + integrity (hash chain presence) |

1334/1334 tests passing.