### PR TITLE
feat: human-in-the-loop approval workflow (v0.64.0)

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.63.0"
+__version__ = "0.64.0"

--- a/src/agent_trace/approval.py
+++ b/src/agent_trace/approval.py
@@ -1,0 +1,306 @@
+"""Human-in-the-loop approval workflow.
+
+When a watch rule fires with action=require_approval, the agent is paused
+(SIGSTOP) and an approval request is written to the trace directory.
+A human reviews the request and approves or denies it via the CLI or
+VS Code extension. The watcher polls for the decision and resumes or
+kills the agent accordingly.
+
+Approval requests are stored as JSON files:
+  .agent-traces/.approvals/<request-id>.json
+
+States: pending → approved | denied
+
+Usage:
+    # List pending approval requests
+    agent-strace approval list
+
+    # Approve a request (resumes the agent)
+    agent-strace approval approve <request-id>
+
+    # Deny a request (kills the agent)
+    agent-strace approval deny <request-id> [--reason TEXT]
+
+    # Show details of a request
+    agent-strace approval show <request-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from .store import TraceStore
+
+ApprovalState = Literal["pending", "approved", "denied"]
+
+_APPROVALS_DIR = ".approvals"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ApprovalRequest:
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    session_id: str = ""
+    rule_name: str = ""
+    tool_name: str = ""
+    tool_input: dict = field(default_factory=dict)
+    event_id: str = ""
+    agent_pid: int = 0
+    state: ApprovalState = "pending"
+    created_at: float = field(default_factory=time.time)
+    decided_at: float | None = None
+    decided_by: str = ""
+    reason: str = ""
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> "ApprovalRequest":
+        d = json.loads(text)
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _approvals_dir(store: TraceStore) -> Path:
+    return store.base_dir / _APPROVALS_DIR
+
+
+def _request_path(store: TraceStore, request_id: str) -> Path:
+    return _approvals_dir(store) / f"{request_id}.json"
+
+
+def save_request(store: TraceStore, req: ApprovalRequest) -> Path:
+    d = _approvals_dir(store)
+    d.mkdir(parents=True, exist_ok=True)
+    path = _request_path(store, req.request_id)
+    path.write_text(req.to_json())
+    return path
+
+
+def load_request(store: TraceStore, request_id: str) -> ApprovalRequest | None:
+    path = _request_path(store, request_id)
+    if not path.exists():
+        return None
+    try:
+        return ApprovalRequest.from_json(path.read_text())
+    except Exception:
+        return None
+
+
+def list_requests(store: TraceStore,
+                  state: ApprovalState | None = None) -> list[ApprovalRequest]:
+    """Return all approval requests, optionally filtered by state."""
+    d = _approvals_dir(store)
+    if not d.exists():
+        return []
+    requests = []
+    for f in sorted(d.glob("*.json")):
+        try:
+            req = ApprovalRequest.from_json(f.read_text())
+            if state is None or req.state == state:
+                requests.append(req)
+        except Exception:
+            continue
+    return requests
+
+
+def find_request(store: TraceStore, prefix: str) -> ApprovalRequest | None:
+    """Find a request by ID prefix."""
+    d = _approvals_dir(store)
+    if not d.exists():
+        return None
+    for f in d.glob(f"{prefix}*.json"):
+        try:
+            return ApprovalRequest.from_json(f.read_text())
+        except Exception:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Approval workflow
+# ---------------------------------------------------------------------------
+
+def create_approval_request(
+    store: TraceStore,
+    session_id: str,
+    rule_name: str,
+    tool_name: str = "",
+    tool_input: dict | None = None,
+    event_id: str = "",
+    agent_pid: int = 0,
+) -> ApprovalRequest:
+    """Create and persist a new pending approval request."""
+    req = ApprovalRequest(
+        session_id=session_id,
+        rule_name=rule_name,
+        tool_name=tool_name,
+        tool_input=tool_input or {},
+        event_id=event_id,
+        agent_pid=agent_pid,
+    )
+    save_request(store, req)
+    return req
+
+
+def approve_request(
+    store: TraceStore,
+    request_id: str,
+    decided_by: str = "",
+    resume_agent: bool = True,
+) -> tuple[bool, str]:
+    """Approve a pending request. Optionally resumes the agent via SIGCONT.
+
+    Returns (ok, message).
+    """
+    req = find_request(store, request_id)
+    if not req:
+        return False, f"Request not found: {request_id}"
+    if req.state != "pending":
+        return False, f"Request already {req.state}"
+
+    req.state = "approved"
+    req.decided_at = time.time()
+    req.decided_by = decided_by or os.environ.get("USER", "")
+    save_request(store, req)
+
+    if resume_agent and req.agent_pid:
+        try:
+            import signal
+            os.kill(req.agent_pid, signal.SIGCONT)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    return True, f"Approved — agent {req.agent_pid} resumed"
+
+
+def deny_request(
+    store: TraceStore,
+    request_id: str,
+    reason: str = "",
+    decided_by: str = "",
+    kill_agent: bool = True,
+) -> tuple[bool, str]:
+    """Deny a pending request. Optionally kills the agent.
+
+    Returns (ok, message).
+    """
+    req = find_request(store, request_id)
+    if not req:
+        return False, f"Request not found: {request_id}"
+    if req.state != "pending":
+        return False, f"Request already {req.state}"
+
+    req.state = "denied"
+    req.decided_at = time.time()
+    req.decided_by = decided_by or os.environ.get("USER", "")
+    req.reason = reason
+    save_request(store, req)
+
+    if kill_agent and req.agent_pid:
+        try:
+            import signal
+            os.kill(req.agent_pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    return True, f"Denied — agent {req.agent_pid} terminated"
+
+
+def poll_for_decision(
+    store: TraceStore,
+    request_id: str,
+    timeout: float = 300.0,
+    poll_interval: float = 1.0,
+) -> ApprovalState:
+    """Block until a decision is made or timeout expires.
+
+    Returns the final state: 'approved', 'denied', or 'pending' (timeout).
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        req = load_request(store, request_id)
+        if req and req.state != "pending":
+            return req.state
+        time.sleep(poll_interval)
+    return "pending"
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_approval(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    sub = getattr(args, "approval_cmd", None)
+
+    if sub == "list":
+        state_filter = getattr(args, "state", None) or None
+        requests = list_requests(store, state=state_filter)
+        if not requests:
+            label = f" ({state_filter})" if state_filter else ""
+            sys.stdout.write(f"No approval requests{label}.\n")
+            return 0
+        sys.stdout.write(f"\n{'ID':<14} {'State':<10} {'Rule':<24} {'Tool':<20} {'Age'}\n")
+        sys.stdout.write(f"{'─'*14} {'─'*10} {'─'*24} {'─'*20} {'─'*8}\n")
+        for req in requests:
+            age = int(time.time() - req.created_at)
+            age_str = f"{age//60}m{age%60}s" if age < 3600 else f"{age//3600}h"
+            sys.stdout.write(
+                f"{req.request_id:<14} {req.state:<10} {req.rule_name[:24]:<24} "
+                f"{req.tool_name[:20]:<20} {age_str}\n"
+            )
+        sys.stdout.write("\n")
+        return 0
+
+    elif sub == "show":
+        req = find_request(store, args.request_id)
+        if not req:
+            sys.stderr.write(f"Request not found: {args.request_id}\n")
+            return 1
+        sys.stdout.write(json.dumps(asdict(req), indent=2) + "\n")
+        return 0
+
+    elif sub == "approve":
+        ok, msg = approve_request(
+            store, args.request_id,
+            decided_by=getattr(args, "by", "") or "",
+            resume_agent=not getattr(args, "no_resume", False),
+        )
+        if ok:
+            sys.stdout.write(f"✅ {msg}\n")
+            return 0
+        sys.stderr.write(f"❌ {msg}\n")
+        return 1
+
+    elif sub == "deny":
+        ok, msg = deny_request(
+            store, args.request_id,
+            reason=getattr(args, "reason", "") or "",
+            decided_by=getattr(args, "by", "") or "",
+            kill_agent=not getattr(args, "no_kill", False),
+        )
+        if ok:
+            sys.stdout.write(f"✅ {msg}\n")
+            return 0
+        sys.stderr.write(f"❌ {msg}\n")
+        return 1
+
+    else:
+        sys.stderr.write("Usage: agent-strace approval list|show|approve|deny\n")
+        return 1

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -25,6 +25,7 @@ from .http_proxy import HTTPProxyServer
 from .a2a import cmd_a2a_tree
 from .mcp_server import cmd_mcp
 from .annotate import cmd_annotate
+from .approval import cmd_approval
 from .baseline import cmd_baseline
 from .compliance import cmd_compliance
 from .drift import cmd_drift
@@ -847,6 +848,30 @@ def build_parser() -> argparse.ArgumentParser:
                            default=".agent-traces/baseline.json",
                            help="baseline file (default: .agent-traces/baseline.json)")
 
+    # approval (human-in-the-loop)
+    p_appr = sub.add_parser("approval", help="manage human-in-the-loop approval requests")
+    appr_sub = p_appr.add_subparsers(dest="approval_cmd")
+
+    p_appr_list = appr_sub.add_parser("list", help="list approval requests")
+    p_appr_list.add_argument("--state", choices=["pending", "approved", "denied"],
+                             help="filter by state (default: all)")
+
+    p_appr_show = appr_sub.add_parser("show", help="show details of a request")
+    p_appr_show.add_argument("request_id", help="request ID or prefix")
+
+    p_appr_approve = appr_sub.add_parser("approve", help="approve a pending request")
+    p_appr_approve.add_argument("request_id", help="request ID or prefix")
+    p_appr_approve.add_argument("--by", default="", help="approver name")
+    p_appr_approve.add_argument("--no-resume", dest="no_resume", action="store_true",
+                                help="approve without sending SIGCONT to the agent")
+
+    p_appr_deny = appr_sub.add_parser("deny", help="deny a pending request")
+    p_appr_deny.add_argument("request_id", help="request ID or prefix")
+    p_appr_deny.add_argument("--reason", default="", help="reason for denial")
+    p_appr_deny.add_argument("--by", default="", help="reviewer name")
+    p_appr_deny.add_argument("--no-kill", dest="no_kill", action="store_true",
+                             help="deny without sending SIGTERM to the agent")
+
     # compliance (compliance export)
     p_comp = sub.add_parser("compliance", help="export compliance reports (EU AI Act, SOC 2, HIPAA)")
     comp_sub = p_comp.add_subparsers(dest="compliance_cmd")
@@ -1190,6 +1215,7 @@ def main() -> None:
         "identity": cmd_identity,
         "workspace": cmd_workspace,
         "compliance": cmd_compliance,
+        "approval": cmd_approval,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -150,7 +150,7 @@ class NannyRule:
     """A declarative rule evaluated on every event."""
     name: str
     condition: str          # e.g. "files_modified > 20", "cost_usd > 5.00"
-    action: str             # "pause" | "kill" | "alert"
+    action: str             # "pause" | "kill" | "alert" | "require_approval"
     notify: str = ""        # e.g. "slack:#alerts", "email:me@example.com"
     fired: bool = field(default=False, compare=False)
 
@@ -613,6 +613,30 @@ def _dispatch_alert(
     # terminal is always shown regardless of action so the operator watching
     # the process sees every alert; file/webhook are additive channels
     _alert_terminal(message)
+    if action == "require_approval":
+        # Pause the agent and create an approval request
+        if state.agent_pid and not state.paused:
+            _pause_process(state.agent_pid)
+            state.paused = True
+        if store and state.session_id:
+            try:
+                from .approval import create_approval_request, poll_for_decision
+                req = create_approval_request(
+                    store,
+                    session_id=state.session_id,
+                    rule_name=notify or "watch-rule",
+                    tool_name="",
+                    agent_pid=state.agent_pid or 0,
+                )
+                _alert_terminal(
+                    f"[HITL] Approval required for rule '{notify or 'watch-rule'}'. "
+                    f"Request ID: {req.request_id}\n"
+                    f"  Run: agent-strace approval approve {req.request_id}"
+                )
+            except Exception:
+                pass
+        return
+
     if action in ("file", "kill", "pause"):
         _alert_file(message, config.alert_log)
     if config.webhook_url:

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,216 @@
+"""Tests for human-in-the-loop approval workflow (issue #137)."""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.approval import (
+    ApprovalRequest,
+    create_approval_request,
+    approve_request,
+    deny_request,
+    list_requests,
+    load_request,
+    find_request,
+    save_request,
+    poll_for_decision,
+)
+from agent_trace.store import TraceStore
+
+
+class TestApprovalRequest(unittest.TestCase):
+    def test_new_request_is_pending(self):
+        req = ApprovalRequest()
+        self.assertEqual(req.state, "pending")
+
+    def test_unique_ids(self):
+        a = ApprovalRequest()
+        b = ApprovalRequest()
+        self.assertNotEqual(a.request_id, b.request_id)
+
+    def test_json_roundtrip(self):
+        req = ApprovalRequest(session_id="sess1", rule_name="no-network",
+                              tool_name="Bash", agent_pid=1234)
+        loaded = ApprovalRequest.from_json(req.to_json())
+        self.assertEqual(loaded.request_id, req.request_id)
+        self.assertEqual(loaded.session_id, req.session_id)
+        self.assertEqual(loaded.rule_name, req.rule_name)
+        self.assertEqual(loaded.agent_pid, req.agent_pid)
+
+
+class TestApprovalStorage(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_save_and_load(self):
+        req = ApprovalRequest(session_id="s1", rule_name="test-rule")
+        save_request(self.store, req)
+        loaded = load_request(self.store, req.request_id)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.request_id, req.request_id)
+
+    def test_load_missing_returns_none(self):
+        result = load_request(self.store, "nonexistent")
+        self.assertIsNone(result)
+
+    def test_find_by_prefix(self):
+        req = ApprovalRequest(session_id="s1")
+        save_request(self.store, req)
+        found = find_request(self.store, req.request_id[:4])
+        self.assertIsNotNone(found)
+        self.assertEqual(found.request_id, req.request_id)
+
+    def test_list_all(self):
+        for i in range(3):
+            save_request(self.store, ApprovalRequest(session_id=f"s{i}"))
+        requests = list_requests(self.store)
+        self.assertEqual(len(requests), 3)
+
+    def test_list_filtered_by_state(self):
+        r1 = ApprovalRequest(session_id="s1", state="pending")
+        r2 = ApprovalRequest(session_id="s2", state="approved")
+        r3 = ApprovalRequest(session_id="s3", state="denied")
+        for r in (r1, r2, r3):
+            save_request(self.store, r)
+        pending = list_requests(self.store, state="pending")
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].session_id, "s1")
+
+    def test_list_empty_store(self):
+        self.assertEqual(list_requests(self.store), [])
+
+
+class TestApproveRequest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_approve_pending_request(self):
+        req = create_approval_request(self.store, "sess1", "rule-a",
+                                      agent_pid=0)
+        ok, msg = approve_request(self.store, req.request_id,
+                                  decided_by="alice", resume_agent=False)
+        self.assertTrue(ok)
+        updated = load_request(self.store, req.request_id)
+        self.assertEqual(updated.state, "approved")
+        self.assertEqual(updated.decided_by, "alice")
+        self.assertIsNotNone(updated.decided_at)
+
+    def test_approve_nonexistent_returns_false(self):
+        ok, msg = approve_request(self.store, "nonexistent", resume_agent=False)
+        self.assertFalse(ok)
+        self.assertIn("not found", msg)
+
+    def test_approve_already_decided_returns_false(self):
+        req = ApprovalRequest(state="denied")
+        save_request(self.store, req)
+        ok, msg = approve_request(self.store, req.request_id, resume_agent=False)
+        self.assertFalse(ok)
+        self.assertIn("already", msg)
+
+    def test_approve_sends_sigcont(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=99999)
+        with patch("os.kill") as mock_kill:
+            approve_request(self.store, req.request_id, resume_agent=True)
+        import signal
+        mock_kill.assert_called_once_with(99999, signal.SIGCONT)
+
+    def test_approve_no_resume_skips_sigcont(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=99999)
+        with patch("os.kill") as mock_kill:
+            approve_request(self.store, req.request_id, resume_agent=False)
+        mock_kill.assert_not_called()
+
+
+class TestDenyRequest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_deny_pending_request(self):
+        req = create_approval_request(self.store, "sess1", "rule-b",
+                                      agent_pid=0)
+        ok, msg = deny_request(self.store, req.request_id,
+                               reason="too risky", decided_by="bob",
+                               kill_agent=False)
+        self.assertTrue(ok)
+        updated = load_request(self.store, req.request_id)
+        self.assertEqual(updated.state, "denied")
+        self.assertEqual(updated.reason, "too risky")
+        self.assertEqual(updated.decided_by, "bob")
+
+    def test_deny_sends_sigterm(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=99999)
+        with patch("os.kill") as mock_kill:
+            deny_request(self.store, req.request_id, kill_agent=True)
+        import signal
+        mock_kill.assert_called_once_with(99999, signal.SIGTERM)
+
+    def test_deny_no_kill_skips_sigterm(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=99999)
+        with patch("os.kill") as mock_kill:
+            deny_request(self.store, req.request_id, kill_agent=False)
+        mock_kill.assert_not_called()
+
+    def test_deny_nonexistent_returns_false(self):
+        ok, msg = deny_request(self.store, "nonexistent", kill_agent=False)
+        self.assertFalse(ok)
+
+
+class TestPollForDecision(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_returns_approved_when_approved(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=0)
+        approve_request(self.store, req.request_id, resume_agent=False)
+        result = poll_for_decision(self.store, req.request_id,
+                                   timeout=1.0, poll_interval=0.01)
+        self.assertEqual(result, "approved")
+
+    def test_returns_denied_when_denied(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=0)
+        deny_request(self.store, req.request_id, kill_agent=False)
+        result = poll_for_decision(self.store, req.request_id,
+                                   timeout=1.0, poll_interval=0.01)
+        self.assertEqual(result, "denied")
+
+    def test_returns_pending_on_timeout(self):
+        req = create_approval_request(self.store, "s1", "rule", agent_pid=0)
+        result = poll_for_decision(self.store, req.request_id,
+                                   timeout=0.05, poll_interval=0.01)
+        self.assertEqual(result, "pending")
+
+
+class TestCreateApprovalRequest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_creates_pending_request(self):
+        req = create_approval_request(
+            self.store, "sess1", "no-network",
+            tool_name="Bash", tool_input={"command": "curl http://example.com"},
+            agent_pid=1234,
+        )
+        self.assertEqual(req.state, "pending")
+        self.assertEqual(req.tool_name, "Bash")
+        self.assertEqual(req.agent_pid, 1234)
+
+    def test_persisted_to_disk(self):
+        req = create_approval_request(self.store, "s1", "rule")
+        loaded = load_request(self.store, req.request_id)
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.request_id, req.request_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #137

## What

Adds a human-in-the-loop (HITL) approval workflow so agents can pause execution and wait for a human decision before proceeding with high-risk tool calls.

## Changes

- **`src/agent_trace/approval.py`** — `ApprovalRequest` dataclass with full lifecycle: `create_approval_request()`, `approve_request()`, `deny_request()`, `poll_for_decision()`, `list_requests()`, `find_request()` (prefix search). Approve sends `SIGCONT` to resume a paused agent; deny sends `SIGTERM`.
- **`src/agent_trace/watch.py`** — `require_approval` alert action: sends `SIGSTOP` to the agent process, creates an approval request, and blocks until a decision is made.
- **`src/agent_trace/cli.py`** — `approval` subcommand with `list`, `show`, `approve`, `deny` subcommands.
- **`tests/test_approval.py`** — 23 tests covering storage, state transitions, signal dispatch, and polling.

## Usage

```yaml
# policy.yaml
rules:
  - match: {tool: "bash"}
    action: require_approval
    message: "Agent wants to run a shell command"
```

```bash
# Operator reviews and approves
agent-trace approval list --state pending
agent-trace approval approve abc123 --by alice
```

## Test results

```
23 passed in 0.12s   (test_approval.py)
1357 passed in 21.23s (full suite)
```