### PR TITLE
feat: RBAC — org and workspace-scoped access control (v0.8.0)

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -26,6 +26,7 @@ from .a2a import cmd_a2a_tree
 from .mcp_server import cmd_mcp
 from .annotate import cmd_annotate
 from .approval import cmd_approval
+from .rbac import cmd_rbac
 from .baseline import cmd_baseline
 from .compliance import cmd_compliance
 from .drift import cmd_drift
@@ -872,6 +873,36 @@ def build_parser() -> argparse.ArgumentParser:
     p_appr_deny.add_argument("--no-kill", dest="no_kill", action="store_true",
                              help="deny without sending SIGTERM to the agent")
 
+    # rbac (role-based access control)
+    p_rbac = sub.add_parser("rbac", help="manage role-based access control assignments")
+    rbac_sub = p_rbac.add_subparsers(dest="rbac_cmd")
+
+    p_rbac_assign = rbac_sub.add_parser("assign", help="assign a role to a user or group")
+    p_rbac_assign.add_argument("--user", metavar="EMAIL", default="", help="user email")
+    p_rbac_assign.add_argument("--group", metavar="GROUP", default="", help="group identifier")
+    p_rbac_assign.add_argument("--role", required=True,
+                               help="role to assign (owner/admin/member/viewer/machine or workspace:*)")
+    p_rbac_assign.add_argument("--workspace", metavar="ID", default="",
+                               help="workspace ID for workspace-scoped role")
+    p_rbac_assign.add_argument("--by", default="", help="assigner name for audit trail")
+
+    p_rbac_revoke = rbac_sub.add_parser("revoke", help="revoke a role assignment")
+    p_rbac_revoke.add_argument("--user", metavar="EMAIL", default="", help="user email")
+    p_rbac_revoke.add_argument("--group", metavar="GROUP", default="", help="group identifier")
+    p_rbac_revoke.add_argument("--workspace", metavar="ID", default="",
+                               help="workspace ID (omit for org-level)")
+
+    p_rbac_list = rbac_sub.add_parser("list", help="list all role assignments")
+    p_rbac_list.add_argument("--workspace", metavar="ID", default="",
+                             help="filter by workspace ID")
+
+    p_rbac_check = rbac_sub.add_parser("check", help="check if a user can perform an action")
+    p_rbac_check.add_argument("--user", metavar="EMAIL", required=True)
+    p_rbac_check.add_argument("--action", required=True,
+                              help="action to check (e.g. read_sessions, manage_policies)")
+    p_rbac_check.add_argument("--workspace", metavar="ID", default="",
+                              help="workspace context for the check")
+
     # compliance (compliance export)
     p_comp = sub.add_parser("compliance", help="export compliance reports (EU AI Act, SOC 2, HIPAA)")
     comp_sub = p_comp.add_subparsers(dest="compliance_cmd")
@@ -1218,6 +1249,7 @@ def main() -> None:
         "workspace": cmd_workspace,
         "compliance": cmd_compliance,
         "approval": cmd_approval,
+        "rbac": cmd_rbac,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/rbac.py
+++ b/src/agent_trace/rbac.py
@@ -1,0 +1,300 @@
+"""Role-based access control for agent-trace.
+
+Stores role assignments in a JSON file alongside the trace store.
+Supports org-level and workspace-scoped roles.
+
+Org-level roles (in order of privilege):
+    owner   — full access including billing and SSO config
+    admin   — manage policies, identities, workspaces
+    member  — read sessions, run agents
+    viewer  — read-only
+    machine — for agent identities (programmatic access)
+
+Workspace-scoped roles (override org-level for a specific workspace):
+    workspace:admin   — full access within workspace
+    workspace:member  — read/run within workspace
+    workspace:viewer  — read-only within workspace
+
+CLI:
+    agent-strace rbac assign --user alice@example.com --role admin
+    agent-strace rbac assign --group eng@example.com --role member
+    agent-strace rbac assign --user bob@example.com --role workspace:member --workspace prod
+    agent-strace rbac revoke --user bob@example.com --workspace prod
+    agent-strace rbac list
+    agent-strace rbac check --user alice@example.com --action read_sessions
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from .store import DEFAULT_TRACE_DIR
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ORG_ROLES = ("owner", "admin", "member", "viewer", "machine")
+WORKSPACE_ROLES = ("workspace:admin", "workspace:member", "workspace:viewer")
+ALL_ROLES = ORG_ROLES + WORKSPACE_ROLES
+
+# Privilege order for org-level roles (higher index = more privilege)
+_ORG_RANK = {r: i for i, r in enumerate(("viewer", "machine", "member", "admin", "owner"))}
+
+# Actions and the minimum org-level role required (when no workspace override)
+_ACTION_MIN_ROLE: dict[str, str] = {
+    "read_sessions": "viewer",
+    "run_agent": "member",
+    "annotate": "member",
+    "manage_policies": "admin",
+    "manage_identities": "admin",
+    "manage_workspaces": "admin",
+    "export_compliance": "admin",
+    "manage_rbac": "owner",
+    "manage_billing": "owner",
+    "manage_sso": "owner",
+}
+
+_RBAC_FILE = "rbac.json"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RoleAssignment:
+    """A single role assignment for a user or group."""
+    principal: str          # email or group identifier
+    principal_type: str     # "user" or "group"
+    role: str               # one of ALL_ROLES
+    workspace_id: str = ""  # empty = org-level
+    assigned_by: str = ""
+    assigned_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "RoleAssignment":
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+class RBACStore:
+    """Persist role assignments to a JSON file in the trace store directory."""
+
+    def __init__(self, base_dir: str | Path = DEFAULT_TRACE_DIR) -> None:
+        self._path = Path(base_dir) / _RBAC_FILE
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> list[RoleAssignment]:
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text())
+            return [RoleAssignment.from_dict(d) for d in data]
+        except Exception:
+            return []
+
+    def _save(self, assignments: list[RoleAssignment]) -> None:
+        self._path.write_text(json.dumps([a.to_dict() for a in assignments], indent=2))
+
+    def list_assignments(
+        self,
+        workspace_id: str = "",
+        principal: str = "",
+    ) -> list[RoleAssignment]:
+        """Return all assignments, optionally filtered."""
+        assignments = self._load()
+        if workspace_id:
+            assignments = [a for a in assignments if a.workspace_id == workspace_id]
+        if principal:
+            assignments = [a for a in assignments if a.principal == principal]
+        return assignments
+
+    def assign(
+        self,
+        principal: str,
+        principal_type: str,
+        role: str,
+        workspace_id: str = "",
+        assigned_by: str = "",
+    ) -> RoleAssignment:
+        """Create or update a role assignment. Returns the assignment."""
+        if role not in ALL_ROLES:
+            raise ValueError(f"Unknown role: {role!r}. Valid roles: {ALL_ROLES}")
+        if workspace_id and role not in WORKSPACE_ROLES:
+            raise ValueError(
+                f"Role {role!r} is an org-level role. "
+                f"Use a workspace role (workspace:admin/member/viewer) with --workspace."
+            )
+        if not workspace_id and role in WORKSPACE_ROLES:
+            raise ValueError(
+                f"Role {role!r} requires --workspace to be specified."
+            )
+
+        assignments = self._load()
+        # Remove any existing assignment for this principal+workspace
+        assignments = [
+            a for a in assignments
+            if not (a.principal == principal and a.workspace_id == workspace_id)
+        ]
+        new = RoleAssignment(
+            principal=principal,
+            principal_type=principal_type,
+            role=role,
+            workspace_id=workspace_id,
+            assigned_by=assigned_by,
+        )
+        assignments.append(new)
+        self._save(assignments)
+        return new
+
+    def revoke(self, principal: str, workspace_id: str = "") -> bool:
+        """Remove a role assignment. Returns True if something was removed."""
+        assignments = self._load()
+        before = len(assignments)
+        assignments = [
+            a for a in assignments
+            if not (a.principal == principal and a.workspace_id == workspace_id)
+        ]
+        if len(assignments) < before:
+            self._save(assignments)
+            return True
+        return False
+
+    def get_role(self, principal: str, workspace_id: str = "") -> str | None:
+        """Return the role for *principal* in *workspace_id* (or org-level)."""
+        for a in self._load():
+            if a.principal == principal and a.workspace_id == workspace_id:
+                return a.role
+        return None
+
+    def effective_role(self, principal: str, workspace_id: str = "") -> str | None:
+        """Return the effective role for *principal*, considering workspace override.
+
+        If a workspace-scoped assignment exists, return it.
+        Otherwise fall back to the org-level assignment.
+        """
+        if workspace_id:
+            ws_role = self.get_role(principal, workspace_id)
+            if ws_role:
+                return ws_role
+        return self.get_role(principal, "")
+
+
+# ---------------------------------------------------------------------------
+# Permission check
+# ---------------------------------------------------------------------------
+
+def can(
+    store: RBACStore,
+    principal: str,
+    action: str,
+    workspace_id: str = "",
+) -> bool:
+    """Return True if *principal* is allowed to perform *action*.
+
+    Workspace-scoped roles map to org-level equivalents for the check:
+        workspace:admin   → admin
+        workspace:member  → member
+        workspace:viewer  → viewer
+    """
+    role = store.effective_role(principal, workspace_id)
+    if role is None:
+        return False
+
+    # Normalise workspace roles to their org equivalent
+    ws_map = {
+        "workspace:admin": "admin",
+        "workspace:member": "member",
+        "workspace:viewer": "viewer",
+    }
+    effective = ws_map.get(role, role)
+
+    min_role = _ACTION_MIN_ROLE.get(action, "owner")
+    return _ORG_RANK.get(effective, -1) >= _ORG_RANK.get(min_role, 999)
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_rbac(args: argparse.Namespace) -> int:
+    base_dir = getattr(args, "dir", None) or DEFAULT_TRACE_DIR
+    store = RBACStore(base_dir)
+    sub = getattr(args, "rbac_cmd", None)
+
+    if sub == "assign":
+        principal = args.user or args.group
+        if not principal:
+            sys.stderr.write("error: --user or --group required\n")
+            return 1
+        principal_type = "group" if args.group else "user"
+        workspace_id = getattr(args, "workspace", "") or ""
+        try:
+            a = store.assign(
+                principal=principal,
+                principal_type=principal_type,
+                role=args.role,
+                workspace_id=workspace_id,
+                assigned_by=getattr(args, "by", "") or "",
+            )
+        except ValueError as exc:
+            sys.stderr.write(f"error: {exc}\n")
+            return 1
+        scope = f" (workspace: {workspace_id})" if workspace_id else " (org-level)"
+        sys.stdout.write(f"Assigned {a.role} to {principal}{scope}\n")
+        return 0
+
+    if sub == "revoke":
+        principal = args.user or getattr(args, "group", None)
+        if not principal:
+            sys.stderr.write("error: --user or --group required\n")
+            return 1
+        workspace_id = getattr(args, "workspace", "") or ""
+        removed = store.revoke(principal, workspace_id)
+        if removed:
+            scope = f" (workspace: {workspace_id})" if workspace_id else " (org-level)"
+            sys.stdout.write(f"Revoked role for {principal}{scope}\n")
+        else:
+            sys.stdout.write(f"No assignment found for {principal}\n")
+        return 0
+
+    if sub == "list":
+        workspace_id = getattr(args, "workspace", "") or ""
+        assignments = store.list_assignments(workspace_id=workspace_id)
+        if not assignments:
+            sys.stdout.write("No role assignments found.\n")
+            return 0
+        fmt = "{:<40} {:<8} {:<20} {:<20}\n"
+        sys.stdout.write(fmt.format("Principal", "Type", "Role", "Workspace"))
+        sys.stdout.write("-" * 92 + "\n")
+        for a in sorted(assignments, key=lambda x: (x.workspace_id, x.principal)):
+            sys.stdout.write(fmt.format(
+                a.principal[:39], a.principal_type[:7],
+                a.role[:19], a.workspace_id or "(org-level)",
+            ))
+        return 0
+
+    if sub == "check":
+        principal = args.user
+        action = args.action
+        workspace_id = getattr(args, "workspace", "") or ""
+        allowed = can(store, principal, action, workspace_id)
+        result = "allowed" if allowed else "denied"
+        sys.stdout.write(f"{principal} → {action}: {result}\n")
+        return 0 if allowed else 1
+
+    sys.stderr.write("Usage: agent-strace rbac <assign|revoke|list|check>\n")
+    return 1

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,308 @@
+"""Tests for rbac.py — role assignments, permission checks, and CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+
+import pytest
+
+from agent_trace.rbac import (
+    RBACStore,
+    RoleAssignment,
+    can,
+    cmd_rbac,
+    ALL_ROLES,
+    ORG_ROLES,
+    WORKSPACE_ROLES,
+)
+
+
+# ---------------------------------------------------------------------------
+# RoleAssignment dataclass
+# ---------------------------------------------------------------------------
+
+class TestRoleAssignment:
+    def test_to_dict_roundtrip(self):
+        a = RoleAssignment(principal="alice@example.com", principal_type="user", role="admin")
+        d = a.to_dict()
+        b = RoleAssignment.from_dict(d)
+        assert b.principal == a.principal
+        assert b.role == a.role
+        assert b.workspace_id == ""
+
+    def test_workspace_scoped(self):
+        a = RoleAssignment(principal="bob@example.com", principal_type="user",
+                           role="workspace:member", workspace_id="prod")
+        assert a.workspace_id == "prod"
+
+
+# ---------------------------------------------------------------------------
+# RBACStore — assign / revoke / list / get_role
+# ---------------------------------------------------------------------------
+
+class TestRBACStore:
+    def test_empty_store(self, tmp_path):
+        store = RBACStore(tmp_path)
+        assert store.list_assignments() == []
+
+    def test_assign_org_level(self, tmp_path):
+        store = RBACStore(tmp_path)
+        a = store.assign("alice@example.com", "user", "admin")
+        assert a.role == "admin"
+        assert a.workspace_id == ""
+
+    def test_assign_persisted(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        store2 = RBACStore(tmp_path)
+        assignments = store2.list_assignments()
+        assert len(assignments) == 1
+        assert assignments[0].principal == "alice@example.com"
+
+    def test_assign_overwrites_existing(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        store.assign("alice@example.com", "user", "admin")
+        assignments = store.list_assignments()
+        assert len(assignments) == 1
+        assert assignments[0].role == "admin"
+
+    def test_assign_workspace_role(self, tmp_path):
+        store = RBACStore(tmp_path)
+        a = store.assign("bob@example.com", "user", "workspace:member", workspace_id="prod")
+        assert a.role == "workspace:member"
+        assert a.workspace_id == "prod"
+
+    def test_assign_invalid_role_raises(self, tmp_path):
+        store = RBACStore(tmp_path)
+        with pytest.raises(ValueError, match="Unknown role"):
+            store.assign("alice@example.com", "user", "superuser")
+
+    def test_assign_org_role_with_workspace_raises(self, tmp_path):
+        store = RBACStore(tmp_path)
+        with pytest.raises(ValueError, match="workspace role"):
+            store.assign("alice@example.com", "user", "admin", workspace_id="prod")
+
+    def test_assign_workspace_role_without_workspace_raises(self, tmp_path):
+        store = RBACStore(tmp_path)
+        with pytest.raises(ValueError, match="requires --workspace"):
+            store.assign("alice@example.com", "user", "workspace:admin")
+
+    def test_revoke_existing(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        removed = store.revoke("alice@example.com")
+        assert removed is True
+        assert store.list_assignments() == []
+
+    def test_revoke_nonexistent_returns_false(self, tmp_path):
+        store = RBACStore(tmp_path)
+        assert store.revoke("nobody@example.com") is False
+
+    def test_revoke_workspace_scoped(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("bob@example.com", "user", "workspace:viewer", workspace_id="dev")
+        removed = store.revoke("bob@example.com", workspace_id="dev")
+        assert removed is True
+
+    def test_revoke_workspace_does_not_remove_org(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        store.assign("alice@example.com", "user", "workspace:admin", workspace_id="prod")
+        store.revoke("alice@example.com", workspace_id="prod")
+        assignments = store.list_assignments()
+        assert len(assignments) == 1
+        assert assignments[0].workspace_id == ""
+
+    def test_get_role_org(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "admin")
+        assert store.get_role("alice@example.com") == "admin"
+
+    def test_get_role_missing(self, tmp_path):
+        store = RBACStore(tmp_path)
+        assert store.get_role("nobody@example.com") is None
+
+    def test_list_filter_by_workspace(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        store.assign("bob@example.com", "user", "workspace:member", workspace_id="prod")
+        ws_only = store.list_assignments(workspace_id="prod")
+        assert len(ws_only) == 1
+        assert ws_only[0].principal == "bob@example.com"
+
+    def test_list_filter_by_principal(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "member")
+        store.assign("bob@example.com", "user", "viewer")
+        alice_only = store.list_assignments(principal="alice@example.com")
+        assert len(alice_only) == 1
+
+    def test_group_assignment(self, tmp_path):
+        store = RBACStore(tmp_path)
+        a = store.assign("eng@example.com", "group", "member")
+        assert a.principal_type == "group"
+
+    def test_effective_role_falls_back_to_org(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "admin")
+        # No workspace-specific role → falls back to org
+        assert store.effective_role("alice@example.com", "prod") == "admin"
+
+    def test_effective_role_workspace_overrides_org(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "admin")
+        store.assign("alice@example.com", "user", "workspace:viewer", workspace_id="prod")
+        assert store.effective_role("alice@example.com", "prod") == "workspace:viewer"
+
+
+# ---------------------------------------------------------------------------
+# Permission checks
+# ---------------------------------------------------------------------------
+
+class TestCan:
+    def test_owner_can_do_everything(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("owner@example.com", "user", "owner")
+        for action in ("read_sessions", "manage_policies", "manage_rbac", "manage_billing"):
+            assert can(store, "owner@example.com", action) is True
+
+    def test_viewer_can_only_read(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("viewer@example.com", "user", "viewer")
+        assert can(store, "viewer@example.com", "read_sessions") is True
+        assert can(store, "viewer@example.com", "manage_policies") is False
+        assert can(store, "viewer@example.com", "run_agent") is False
+
+    def test_member_can_run_but_not_manage(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("member@example.com", "user", "member")
+        assert can(store, "member@example.com", "run_agent") is True
+        assert can(store, "member@example.com", "manage_policies") is False
+
+    def test_admin_can_manage_policies(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("admin@example.com", "user", "admin")
+        assert can(store, "admin@example.com", "manage_policies") is True
+        assert can(store, "admin@example.com", "manage_rbac") is False
+
+    def test_no_assignment_denied(self, tmp_path):
+        store = RBACStore(tmp_path)
+        assert can(store, "nobody@example.com", "read_sessions") is False
+
+    def test_workspace_admin_can_manage_policies(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "workspace:admin", workspace_id="prod")
+        assert can(store, "alice@example.com", "manage_policies", workspace_id="prod") is True
+
+    def test_workspace_viewer_cannot_run(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "workspace:viewer", workspace_id="prod")
+        assert can(store, "alice@example.com", "run_agent", workspace_id="prod") is False
+
+    def test_workspace_override_restricts_org_admin(self, tmp_path):
+        store = RBACStore(tmp_path)
+        store.assign("alice@example.com", "user", "admin")
+        store.assign("alice@example.com", "user", "workspace:viewer", workspace_id="restricted")
+        # In the restricted workspace, only viewer-level access
+        assert can(store, "alice@example.com", "manage_policies", workspace_id="restricted") is False
+        assert can(store, "alice@example.com", "read_sessions", workspace_id="restricted") is True
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _run_cmd(argv: list[str], tmp_path) -> tuple[int, str]:
+    """Run cmd_rbac with the given argv, return (exit_code, stdout)."""
+    import argparse
+    from agent_trace.rbac import cmd_rbac, ALL_ROLES, WORKSPACE_ROLES
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="rbac_cmd")
+
+    p_assign = sub.add_parser("assign")
+    p_assign.add_argument("--user", default="")
+    p_assign.add_argument("--group", default="")
+    p_assign.add_argument("--role", required=True)
+    p_assign.add_argument("--workspace", default="")
+    p_assign.add_argument("--by", default="")
+    p_assign.add_argument("--dir", default=str(tmp_path))
+
+    p_revoke = sub.add_parser("revoke")
+    p_revoke.add_argument("--user", default="")
+    p_revoke.add_argument("--group", default="")
+    p_revoke.add_argument("--workspace", default="")
+    p_revoke.add_argument("--dir", default=str(tmp_path))
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--workspace", default="")
+    p_list.add_argument("--dir", default=str(tmp_path))
+
+    p_check = sub.add_parser("check")
+    p_check.add_argument("--user", required=True)
+    p_check.add_argument("--action", required=True)
+    p_check.add_argument("--workspace", default="")
+    p_check.add_argument("--dir", default=str(tmp_path))
+
+    args = parser.parse_args(argv)
+    buf = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        rc = cmd_rbac(args)
+    finally:
+        sys.stdout = old_stdout
+    return rc, buf.getvalue()
+
+
+class TestCLI:
+    def test_assign_and_list(self, tmp_path):
+        rc, out = _run_cmd(["assign", "--user", "alice@example.com", "--role", "admin",
+                            "--dir", str(tmp_path)], tmp_path)
+        assert rc == 0
+        assert "admin" in out
+
+        rc2, out2 = _run_cmd(["list", "--dir", str(tmp_path)], tmp_path)
+        assert rc2 == 0
+        assert "alice@example.com" in out2
+
+    def test_assign_workspace_role(self, tmp_path):
+        rc, out = _run_cmd(["assign", "--user", "bob@example.com",
+                            "--role", "workspace:member", "--workspace", "prod",
+                            "--dir", str(tmp_path)], tmp_path)
+        assert rc == 0
+        assert "workspace:member" in out
+
+    def test_revoke(self, tmp_path):
+        _run_cmd(["assign", "--user", "alice@example.com", "--role", "member",
+                  "--dir", str(tmp_path)], tmp_path)
+        rc, out = _run_cmd(["revoke", "--user", "alice@example.com",
+                            "--dir", str(tmp_path)], tmp_path)
+        assert rc == 0
+        assert "Revoked" in out
+
+    def test_check_allowed(self, tmp_path):
+        _run_cmd(["assign", "--user", "alice@example.com", "--role", "admin",
+                  "--dir", str(tmp_path)], tmp_path)
+        rc, out = _run_cmd(["check", "--user", "alice@example.com",
+                            "--action", "manage_policies",
+                            "--dir", str(tmp_path)], tmp_path)
+        assert rc == 0
+        assert "allowed" in out
+
+    def test_check_denied(self, tmp_path):
+        _run_cmd(["assign", "--user", "viewer@example.com", "--role", "viewer",
+                  "--dir", str(tmp_path)], tmp_path)
+        rc, out = _run_cmd(["check", "--user", "viewer@example.com",
+                            "--action", "manage_policies",
+                            "--dir", str(tmp_path)], tmp_path)
+        assert rc == 1
+        assert "denied" in out
+
+    def test_list_empty(self, tmp_path):
+        rc, out = _run_cmd(["list", "--dir", str(tmp_path)], tmp_path)
+        assert rc == 0
+        assert "No role assignments" in out


### PR DESCRIPTION
Closes #147

## What

Adds role-based access control with org-level and workspace-scoped roles, stored in a JSON file alongside the trace store. Zero new dependencies.

## Roles

**Org-level** (descending privilege): `owner` > `admin` > `member` > `viewer` > `machine`

**Workspace-scoped** (override org-level for a specific workspace): `workspace:admin` / `workspace:member` / `workspace:viewer`

## Usage

```bash
# Assign org-level role
agent-strace rbac assign --user alice@example.com --role admin

# Assign workspace-scoped role
agent-strace rbac assign --user bob@example.com --role workspace:member --workspace prod

# Assign to a group
agent-strace rbac assign --group eng@example.com --role member

# List all assignments
agent-strace rbac list

# Check permission
agent-strace rbac check --user alice@example.com --action manage_policies

# Revoke
agent-strace rbac revoke --user bob@example.com --workspace prod
```

## Permission matrix

| Action | Min role |
|---|---|
| `read_sessions` | viewer |
| `run_agent`, `annotate` | member |
| `manage_policies`, `manage_identities`, `manage_workspaces`, `export_compliance` | admin |
| `manage_rbac`, `manage_billing`, `manage_sso` | owner |

## Design notes

- Workspace-scoped roles override org-level for that workspace only; `effective_role()` falls back to org-level when no workspace assignment exists
- Mixing org roles with `--workspace` (or workspace roles without `--workspace`) raises `ValueError` with a clear message
- Storage: `rbac.json` in the trace store directory

## Tests

```
35 passed in 0.10s   (test_rbac.py)
1414 passed in 23.14s (full suite)
```