### PR TITLE
feat: IaC CLI — apply/config-diff for .agent-strace.yaml (v0.9.0)

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -27,6 +27,7 @@ from .mcp_server import cmd_mcp
 from .annotate import cmd_annotate
 from .approval import cmd_approval
 from .rbac import cmd_rbac
+from .iac import cmd_apply, cmd_config_diff
 from .baseline import cmd_baseline
 from .compliance import cmd_compliance
 from .drift import cmd_drift
@@ -903,6 +904,27 @@ def build_parser() -> argparse.ArgumentParser:
     p_rbac_check.add_argument("--workspace", metavar="ID", default="",
                               help="workspace context for the check")
 
+    # apply (IaC — apply .agent-strace.yaml to local store or hosted collector)
+    p_apply = sub.add_parser("apply", help="apply .agent-strace.yaml config to local store or hosted collector")
+    p_apply.add_argument("--config", metavar="FILE", default=".agent-strace.yaml",
+                         help="config file (default: .agent-strace.yaml)")
+    p_apply.add_argument("--server", metavar="URL", default="",
+                         help="hosted collector URL (omit for local apply)")
+    p_apply.add_argument("--auth-key", metavar="KEY", dest="auth_key", default="",
+                         help="API key for hosted collector")
+    p_apply.add_argument("--dry-run", action="store_true", dest="dry_run",
+                         help="show planned changes without applying")
+    p_apply.add_argument("--dir", metavar="DIR", default=None,
+                         help="trace store directory (default: .agent-traces)")
+
+    # config-diff (IaC — show drift between config file and local store)
+    p_cdiff = sub.add_parser("config-diff",
+                              help="show drift between .agent-strace.yaml and current store state")
+    p_cdiff.add_argument("--config", metavar="FILE", default=".agent-strace.yaml",
+                         help="config file (default: .agent-strace.yaml)")
+    p_cdiff.add_argument("--dir", metavar="DIR", default=None,
+                         help="trace store directory (default: .agent-traces)")
+
     # compliance (compliance export)
     p_comp = sub.add_parser("compliance", help="export compliance reports (EU AI Act, SOC 2, HIPAA)")
     comp_sub = p_comp.add_subparsers(dest="compliance_cmd")
@@ -1250,6 +1272,8 @@ def main() -> None:
         "compliance": cmd_compliance,
         "approval": cmd_approval,
         "rbac": cmd_rbac,
+        "apply": cmd_apply,
+        "config-diff": cmd_config_diff,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/iac.py
+++ b/src/agent_trace/iac.py
@@ -1,0 +1,434 @@
+"""Infrastructure-as-code support for agent-trace.
+
+Reads ``.agent-strace.yaml`` (or a custom path) and applies the declared
+configuration to a local store or a hosted collector via HTTP.
+
+Supported config sections:
+    workspaces:   list of workspace IDs to create
+    policies:     named policy files to register (path on disk)
+    identities:   agent identities (name, team, workspace)
+    team_budgets: team spending limits
+    rbac:         role assignments
+
+CLI:
+    agent-strace apply [--config .agent-strace.yaml] [--server URL] [--dry-run]
+    agent-strace config-diff [--config .agent-strace.yaml] [--server URL]
+
+When ``--server`` is omitted the config is applied to the local store only
+(workspaces and RBAC are written to disk; policies are validated).
+
+Example ``.agent-strace.yaml``:
+
+    workspaces:
+      - name: production
+      - name: staging
+
+    identities:
+      - name: billing-agent
+        team: backend
+        workspace: production
+
+    team_budgets:
+      - team: backend
+        workspace: production
+        monthly: 500.0
+        alert_threshold: 0.8
+
+    rbac:
+      - user: alice@example.com
+        role: admin
+      - group: eng@example.com
+        role: member
+      - user: bob@example.com
+        role: workspace:member
+        workspace: production
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .store import DEFAULT_TRACE_DIR
+from .workspace import create_workspace, list_workspaces
+from .rbac import RBACStore
+
+DEFAULT_CONFIG = ".agent-strace.yaml"
+
+# ---------------------------------------------------------------------------
+# YAML-free parser (stdlib only)
+# ---------------------------------------------------------------------------
+
+def _parse_yaml(text: str) -> dict:
+    """Minimal YAML parser for the subset used in .agent-strace.yaml.
+
+    Supports:
+    - Top-level keys
+    - List items (- key: value)
+    - Nested key: value pairs under list items
+    - String, float, int, bool values
+    - Inline comments (#)
+
+    Does NOT support: anchors, multi-line strings, flow style, nested dicts.
+    """
+    result: dict[str, Any] = {}
+    current_key: str | None = None
+    current_list: list | None = None
+    current_item: dict | None = None
+
+    for raw_line in text.splitlines():
+        # Strip inline comments
+        line = raw_line.split("#")[0].rstrip()
+        if not line.strip():
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        if indent == 0:
+            # Top-level key
+            if ":" in line:
+                k, _, v = line.partition(":")
+                k = k.strip()
+                v = v.strip()
+                if v:
+                    result[k] = _coerce(v)
+                    current_key = None
+                    current_list = None
+                    current_item = None
+                else:
+                    current_key = k
+                    current_list = []
+                    result[k] = current_list
+                    current_item = None
+        elif indent == 2 and line.lstrip().startswith("- "):
+            # List item start
+            rest = line.lstrip()[2:].strip()
+            if current_list is None:
+                continue
+            if ":" in rest:
+                k, _, v = rest.partition(":")
+                current_item = {k.strip(): _coerce(v.strip())}
+            else:
+                current_item = {}
+            current_list.append(current_item)
+        elif indent >= 4 and current_item is not None:
+            # Nested key under list item
+            stripped = line.strip()
+            if ":" in stripped:
+                k, _, v = stripped.partition(":")
+                current_item[k.strip()] = _coerce(v.strip())
+
+    return result
+
+
+def _coerce(v: str) -> Any:
+    """Convert a string value to int, float, bool, or str."""
+    if v.lower() == "true":
+        return True
+    if v.lower() == "false":
+        return False
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    # Strip surrounding quotes
+    if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+        return v[1:-1]
+    return v
+
+
+def load_config(path: str | Path) -> dict:
+    """Load and parse an .agent-strace.yaml file. Returns empty dict if missing."""
+    p = Path(path)
+    if not p.exists():
+        return {}
+    return _parse_yaml(p.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Local apply helpers
+# ---------------------------------------------------------------------------
+
+def _apply_workspaces(cfg: dict, base_dir: str, dry_run: bool) -> list[str]:
+    changes = []
+    existing = set(list_workspaces(base_dir))
+    for ws in cfg.get("workspaces", []):
+        name = ws.get("name", "")
+        if not name:
+            continue
+        if name not in existing:
+            if not dry_run:
+                create_workspace(name, base_dir)
+            changes.append(f"+ workspace: {name}")
+        else:
+            changes.append(f"  workspace: {name} (exists)")
+    return changes
+
+
+def _apply_rbac(cfg: dict, base_dir: str, dry_run: bool) -> list[str]:
+    changes = []
+    store = RBACStore(base_dir)
+    for entry in cfg.get("rbac", []):
+        principal = entry.get("user") or entry.get("group", "")
+        if not principal:
+            continue
+        ptype = "group" if "group" in entry else "user"
+        role = entry.get("role", "")
+        workspace_id = entry.get("workspace", "")
+        if not role:
+            continue
+        existing = store.get_role(principal, workspace_id)
+        if existing == role:
+            changes.append(f"  rbac: {principal} → {role} (no change)")
+        else:
+            if not dry_run:
+                try:
+                    store.assign(principal, ptype, role, workspace_id=workspace_id,
+                                 assigned_by="agent-strace apply")
+                except ValueError as exc:
+                    changes.append(f"! rbac: {principal} → {role}: {exc}")
+                    continue
+            action = "+" if existing is None else "~"
+            changes.append(f"{action} rbac: {principal} → {role}"
+                           + (f" (workspace: {workspace_id})" if workspace_id else ""))
+    return changes
+
+
+def _apply_identities(cfg: dict, base_dir: str, dry_run: bool) -> list[str]:
+    """Write identity entries to .agent-traces/identities.json."""
+    changes = []
+    identities_path = Path(base_dir) / "identities.json"
+    existing: dict = {}
+    if identities_path.exists():
+        try:
+            existing = json.loads(identities_path.read_text())
+        except Exception:
+            existing = {}
+
+    for entry in cfg.get("identities", []):
+        name = entry.get("name", "")
+        if not name:
+            continue
+        if existing.get(name) == entry:
+            changes.append(f"  identity: {name} (no change)")
+        else:
+            action = "+" if name not in existing else "~"
+            if not dry_run:
+                existing[name] = entry
+            changes.append(f"{action} identity: {name}")
+
+    if not dry_run and changes:
+        identities_path.parent.mkdir(parents=True, exist_ok=True)
+        identities_path.write_text(json.dumps(existing, indent=2))
+    return changes
+
+
+def _apply_team_budgets(cfg: dict, base_dir: str, dry_run: bool) -> list[str]:
+    """Write team budget entries to .agent-traces/team_budgets.json."""
+    changes = []
+    budgets_path = Path(base_dir) / "team_budgets.json"
+    existing: dict = {}
+    if budgets_path.exists():
+        try:
+            existing = json.loads(budgets_path.read_text())
+        except Exception:
+            existing = {}
+
+    for entry in cfg.get("team_budgets", []):
+        team = entry.get("team", "")
+        if not team:
+            continue
+        key = f"{team}/{entry.get('workspace', '')}"
+        if existing.get(key) == entry:
+            changes.append(f"  team_budget: {key} (no change)")
+        else:
+            action = "+" if key not in existing else "~"
+            if not dry_run:
+                existing[key] = entry
+            changes.append(f"{action} team_budget: {key} monthly={entry.get('monthly', '?')}")
+
+    if not dry_run and changes:
+        budgets_path.parent.mkdir(parents=True, exist_ok=True)
+        budgets_path.write_text(json.dumps(existing, indent=2))
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Remote apply (HTTP)
+# ---------------------------------------------------------------------------
+
+def _http_get(url: str, auth_key: str = "") -> Any:
+    headers = {}
+    if auth_key:
+        headers["Authorization"] = f"Bearer {auth_key}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"GET {url} → {e.code}") from e
+
+
+def _http_post(url: str, data: dict, auth_key: str = "") -> Any:
+    body = json.dumps(data).encode()
+    headers = {"Content-Type": "application/json"}
+    if auth_key:
+        headers["Authorization"] = f"Bearer {auth_key}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"POST {url} → {e.code}") from e
+
+
+def _apply_remote(cfg: dict, server: str, auth_key: str, dry_run: bool) -> list[str]:
+    """Push config sections to a hosted collector via HTTP."""
+    changes = []
+    base = server.rstrip("/")
+
+    # Workspaces
+    try:
+        remote_ws = {w["name"] for w in _http_get(f"{base}/api/workspaces", auth_key)}
+    except Exception:
+        remote_ws = set()
+
+    for ws in cfg.get("workspaces", []):
+        name = ws.get("name", "")
+        if not name:
+            continue
+        if name in remote_ws:
+            changes.append(f"  workspace: {name} (exists on server)")
+        else:
+            if not dry_run:
+                try:
+                    _http_post(f"{base}/api/workspaces", {"name": name}, auth_key)
+                except Exception as exc:
+                    changes.append(f"! workspace: {name}: {exc}")
+                    continue
+            changes.append(f"+ workspace: {name}")
+
+    # RBAC
+    for entry in cfg.get("rbac", []):
+        principal = entry.get("user") or entry.get("group", "")
+        role = entry.get("role", "")
+        workspace_id = entry.get("workspace", "")
+        if not principal or not role:
+            continue
+        if not dry_run:
+            try:
+                _http_post(f"{base}/api/rbac", {
+                    "principal": principal,
+                    "principal_type": "group" if "group" in entry else "user",
+                    "role": role,
+                    "workspace_id": workspace_id,
+                }, auth_key)
+            except Exception as exc:
+                changes.append(f"! rbac: {principal} → {role}: {exc}")
+                continue
+        changes.append(f"+ rbac: {principal} → {role}")
+
+    return changes
+
+
+# ---------------------------------------------------------------------------
+# Config diff
+# ---------------------------------------------------------------------------
+
+def config_diff(cfg: dict, base_dir: str) -> list[str]:
+    """Compare local config against the current local store state."""
+    lines = []
+
+    # Workspaces
+    existing_ws = set(list_workspaces(base_dir))
+    declared_ws = {ws.get("name", "") for ws in cfg.get("workspaces", [])} - {""}
+    for name in sorted(declared_ws - existing_ws):
+        lines.append(f"+ workspace: {name}  (declared, not created)")
+    for name in sorted(existing_ws - declared_ws):
+        lines.append(f"- workspace: {name}  (exists, not in config)")
+
+    # RBAC
+    store = RBACStore(base_dir)
+    existing_rbac = {(a.principal, a.workspace_id): a.role
+                     for a in store.list_assignments()}
+    for entry in cfg.get("rbac", []):
+        principal = entry.get("user") or entry.get("group", "")
+        role = entry.get("role", "")
+        workspace_id = entry.get("workspace", "")
+        if not principal or not role:
+            continue
+        current = existing_rbac.get((principal, workspace_id))
+        if current is None:
+            lines.append(f"+ rbac: {principal} → {role}  (declared, not assigned)")
+        elif current != role:
+            lines.append(f"~ rbac: {principal}: {current} → {role}  (role changed)")
+
+    if not lines:
+        lines.append("No drift detected.")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers
+# ---------------------------------------------------------------------------
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    config_path = getattr(args, "config", DEFAULT_CONFIG) or DEFAULT_CONFIG
+    dry_run = getattr(args, "dry_run", False)
+    server = getattr(args, "server", "") or ""
+    auth_key = getattr(args, "auth_key", "") or ""
+    base_dir = getattr(args, "dir", None) or DEFAULT_TRACE_DIR
+
+    cfg = load_config(config_path)
+    if not cfg:
+        sys.stderr.write(f"No config found at {config_path}\n")
+        return 1
+
+    prefix = "[dry-run] " if dry_run else ""
+    sys.stdout.write(f"{prefix}Applying {config_path}...\n")
+
+    all_changes: list[str] = []
+
+    if server:
+        all_changes += _apply_remote(cfg, server, auth_key, dry_run)
+    else:
+        all_changes += _apply_workspaces(cfg, base_dir, dry_run)
+        all_changes += _apply_rbac(cfg, base_dir, dry_run)
+        all_changes += _apply_identities(cfg, base_dir, dry_run)
+        all_changes += _apply_team_budgets(cfg, base_dir, dry_run)
+
+    for line in all_changes:
+        sys.stdout.write(f"  {line}\n")
+
+    added = sum(1 for l in all_changes if l.strip().startswith("+"))
+    changed = sum(1 for l in all_changes if l.strip().startswith("~"))
+    errors = sum(1 for l in all_changes if l.strip().startswith("!"))
+
+    sys.stdout.write(
+        f"\n{prefix}Done. +{added} added, ~{changed} updated, !{errors} errors\n"
+    )
+    return 1 if errors else 0
+
+
+def cmd_config_diff(args: argparse.Namespace) -> int:
+    config_path = getattr(args, "config", DEFAULT_CONFIG) or DEFAULT_CONFIG
+    base_dir = getattr(args, "dir", None) or DEFAULT_TRACE_DIR
+
+    cfg = load_config(config_path)
+    if not cfg:
+        sys.stderr.write(f"No config found at {config_path}\n")
+        return 1
+
+    lines = config_diff(cfg, base_dir)
+    for line in lines:
+        sys.stdout.write(f"  {line}\n")
+    return 0

--- a/tests/test_iac.py
+++ b/tests/test_iac.py
@@ -1,0 +1,329 @@
+"""Tests for iac.py — config parsing, apply, and config-diff."""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from agent_trace.iac import (
+    _parse_yaml,
+    _coerce,
+    load_config,
+    config_diff,
+    _apply_workspaces,
+    _apply_rbac,
+    _apply_identities,
+    _apply_team_budgets,
+    cmd_apply,
+    cmd_config_diff,
+    DEFAULT_CONFIG,
+)
+from agent_trace.workspace import list_workspaces
+from agent_trace.rbac import RBACStore
+
+
+# ---------------------------------------------------------------------------
+# YAML parser
+# ---------------------------------------------------------------------------
+
+class TestParseYaml:
+    def test_empty(self):
+        assert _parse_yaml("") == {}
+
+    def test_simple_key_value(self):
+        result = _parse_yaml("foo: bar\n")
+        assert result["foo"] == "bar"
+
+    def test_int_coercion(self):
+        result = _parse_yaml("count: 42\n")
+        assert result["count"] == 42
+
+    def test_float_coercion(self):
+        result = _parse_yaml("amount: 3.14\n")
+        assert result["amount"] == pytest.approx(3.14)
+
+    def test_bool_coercion(self):
+        result = _parse_yaml("flag: true\n")
+        assert result["flag"] is True
+
+    def test_list_of_dicts(self):
+        yaml = (
+            "workspaces:\n"
+            "  - name: production\n"
+            "  - name: staging\n"
+        )
+        result = _parse_yaml(yaml)
+        assert result["workspaces"] == [{"name": "production"}, {"name": "staging"}]
+
+    def test_nested_list_item(self):
+        yaml = (
+            "team_budgets:\n"
+            "  - team: backend\n"
+            "    monthly: 500.0\n"
+            "    alert_threshold: 0.8\n"
+        )
+        result = _parse_yaml(yaml)
+        assert result["team_budgets"][0]["team"] == "backend"
+        assert result["team_budgets"][0]["monthly"] == pytest.approx(500.0)
+        assert result["team_budgets"][0]["alert_threshold"] == pytest.approx(0.8)
+
+    def test_inline_comment_stripped(self):
+        result = _parse_yaml("foo: bar  # this is a comment\n")
+        assert result["foo"] == "bar"
+
+    def test_full_config(self):
+        yaml = (
+            "workspaces:\n"
+            "  - name: prod\n"
+            "identities:\n"
+            "  - name: billing-agent\n"
+            "    team: backend\n"
+            "    workspace: prod\n"
+            "rbac:\n"
+            "  - user: alice@example.com\n"
+            "    role: admin\n"
+            "  - group: eng@example.com\n"
+            "    role: member\n"
+        )
+        result = _parse_yaml(yaml)
+        assert len(result["workspaces"]) == 1
+        assert len(result["identities"]) == 1
+        assert len(result["rbac"]) == 2
+        assert result["rbac"][0]["user"] == "alice@example.com"
+        assert result["rbac"][1]["group"] == "eng@example.com"
+
+
+class TestCoerce:
+    def test_true(self):
+        assert _coerce("true") is True
+
+    def test_false(self):
+        assert _coerce("false") is False
+
+    def test_int(self):
+        assert _coerce("42") == 42
+
+    def test_float(self):
+        assert _coerce("3.14") == pytest.approx(3.14)
+
+    def test_string(self):
+        assert _coerce("hello") == "hello"
+
+    def test_quoted_string(self):
+        assert _coerce('"hello world"') == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+class TestLoadConfig:
+    def test_missing_file_returns_empty(self, tmp_path):
+        result = load_config(tmp_path / "nonexistent.yaml")
+        assert result == {}
+
+    def test_loads_yaml(self, tmp_path):
+        f = tmp_path / ".agent-strace.yaml"
+        f.write_text("workspaces:\n  - name: prod\n")
+        result = load_config(f)
+        assert result["workspaces"] == [{"name": "prod"}]
+
+
+# ---------------------------------------------------------------------------
+# Apply helpers
+# ---------------------------------------------------------------------------
+
+class TestApplyWorkspaces:
+    def test_creates_new_workspace(self, tmp_path):
+        cfg = {"workspaces": [{"name": "prod"}]}
+        changes = _apply_workspaces(cfg, str(tmp_path), dry_run=False)
+        assert any("+ workspace: prod" in c for c in changes)
+        assert "prod" in list_workspaces(str(tmp_path))
+
+    def test_dry_run_does_not_create(self, tmp_path):
+        cfg = {"workspaces": [{"name": "prod"}]}
+        _apply_workspaces(cfg, str(tmp_path), dry_run=True)
+        assert "prod" not in list_workspaces(str(tmp_path))
+
+    def test_existing_workspace_no_change(self, tmp_path):
+        from agent_trace.workspace import create_workspace
+        create_workspace("prod", str(tmp_path))
+        cfg = {"workspaces": [{"name": "prod"}]}
+        changes = _apply_workspaces(cfg, str(tmp_path), dry_run=False)
+        assert any("exists" in c for c in changes)
+
+    def test_empty_workspaces(self, tmp_path):
+        changes = _apply_workspaces({}, str(tmp_path), dry_run=False)
+        assert changes == []
+
+
+class TestApplyRbac:
+    def test_assigns_new_role(self, tmp_path):
+        cfg = {"rbac": [{"user": "alice@example.com", "role": "admin"}]}
+        changes = _apply_rbac(cfg, str(tmp_path), dry_run=False)
+        assert any("+ rbac" in c for c in changes)
+        store = RBACStore(str(tmp_path))
+        assert store.get_role("alice@example.com") == "admin"
+
+    def test_dry_run_does_not_assign(self, tmp_path):
+        cfg = {"rbac": [{"user": "alice@example.com", "role": "admin"}]}
+        _apply_rbac(cfg, str(tmp_path), dry_run=True)
+        store = RBACStore(str(tmp_path))
+        assert store.get_role("alice@example.com") is None
+
+    def test_no_change_when_role_matches(self, tmp_path):
+        store = RBACStore(str(tmp_path))
+        store.assign("alice@example.com", "user", "admin")
+        cfg = {"rbac": [{"user": "alice@example.com", "role": "admin"}]}
+        changes = _apply_rbac(cfg, str(tmp_path), dry_run=False)
+        assert any("no change" in c for c in changes)
+
+    def test_workspace_role(self, tmp_path):
+        cfg = {"rbac": [{"user": "bob@example.com", "role": "workspace:member",
+                          "workspace": "prod"}]}
+        changes = _apply_rbac(cfg, str(tmp_path), dry_run=False)
+        assert any("workspace:member" in c for c in changes)
+
+
+class TestApplyIdentities:
+    def test_creates_identity(self, tmp_path):
+        cfg = {"identities": [{"name": "billing-agent", "team": "backend"}]}
+        changes = _apply_identities(cfg, str(tmp_path), dry_run=False)
+        assert any("+ identity: billing-agent" in c for c in changes)
+        data = json.loads((tmp_path / "identities.json").read_text())
+        assert "billing-agent" in data
+
+    def test_dry_run_no_file(self, tmp_path):
+        cfg = {"identities": [{"name": "billing-agent", "team": "backend"}]}
+        _apply_identities(cfg, str(tmp_path), dry_run=True)
+        assert not (tmp_path / "identities.json").exists()
+
+
+class TestApplyTeamBudgets:
+    def test_creates_budget(self, tmp_path):
+        cfg = {"team_budgets": [{"team": "backend", "monthly": 500.0}]}
+        changes = _apply_team_budgets(cfg, str(tmp_path), dry_run=False)
+        assert any("+ team_budget" in c for c in changes)
+        data = json.loads((tmp_path / "team_budgets.json").read_text())
+        assert "backend/" in data
+
+    def test_dry_run_no_file(self, tmp_path):
+        cfg = {"team_budgets": [{"team": "backend", "monthly": 500.0}]}
+        _apply_team_budgets(cfg, str(tmp_path), dry_run=True)
+        assert not (tmp_path / "team_budgets.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# config_diff
+# ---------------------------------------------------------------------------
+
+class TestConfigDiff:
+    def test_no_drift(self, tmp_path):
+        from agent_trace.workspace import create_workspace
+        create_workspace("prod", str(tmp_path))
+        store = RBACStore(str(tmp_path))
+        store.assign("alice@example.com", "user", "admin")
+        cfg = {
+            "workspaces": [{"name": "prod"}],
+            "rbac": [{"user": "alice@example.com", "role": "admin"}],
+        }
+        lines = config_diff(cfg, str(tmp_path))
+        assert lines == ["No drift detected."]
+
+    def test_missing_workspace(self, tmp_path):
+        cfg = {"workspaces": [{"name": "prod"}]}
+        lines = config_diff(cfg, str(tmp_path))
+        assert any("+ workspace: prod" in l for l in lines)
+
+    def test_extra_workspace(self, tmp_path):
+        from agent_trace.workspace import create_workspace
+        create_workspace("orphan", str(tmp_path))
+        cfg = {}
+        lines = config_diff(cfg, str(tmp_path))
+        assert any("- workspace: orphan" in l for l in lines)
+
+    def test_missing_rbac(self, tmp_path):
+        cfg = {"rbac": [{"user": "alice@example.com", "role": "admin"}]}
+        lines = config_diff(cfg, str(tmp_path))
+        assert any("+ rbac: alice@example.com" in l for l in lines)
+
+    def test_changed_rbac(self, tmp_path):
+        store = RBACStore(str(tmp_path))
+        store.assign("alice@example.com", "user", "viewer")
+        cfg = {"rbac": [{"user": "alice@example.com", "role": "admin"}]}
+        lines = config_diff(cfg, str(tmp_path))
+        assert any("~ rbac" in l and "viewer" in l and "admin" in l for l in lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _run(cmd_fn, argv_dict: dict, tmp_path) -> tuple[int, str]:
+    import argparse
+    ns = argparse.Namespace(**argv_dict)
+    buf = StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        rc = cmd_fn(ns)
+    finally:
+        sys.stdout = old
+    return rc, buf.getvalue()
+
+
+class TestCLIApply:
+    def test_apply_creates_workspace(self, tmp_path):
+        cfg_file = tmp_path / ".agent-strace.yaml"
+        cfg_file.write_text("workspaces:\n  - name: prod\n")
+        rc, out = _run(cmd_apply, {
+            "config": str(cfg_file), "dry_run": False,
+            "server": "", "auth_key": "", "dir": str(tmp_path),
+        }, tmp_path)
+        assert rc == 0
+        assert "+ workspace: prod" in out
+
+    def test_apply_dry_run(self, tmp_path):
+        cfg_file = tmp_path / ".agent-strace.yaml"
+        cfg_file.write_text("workspaces:\n  - name: prod\n")
+        rc, out = _run(cmd_apply, {
+            "config": str(cfg_file), "dry_run": True,
+            "server": "", "auth_key": "", "dir": str(tmp_path),
+        }, tmp_path)
+        assert rc == 0
+        assert "dry-run" in out
+        ws_names = {w.name for w in list_workspaces(str(tmp_path))}
+        assert "prod" not in ws_names
+
+    def test_apply_missing_config(self, tmp_path):
+        rc, _ = _run(cmd_apply, {
+            "config": str(tmp_path / "missing.yaml"), "dry_run": False,
+            "server": "", "auth_key": "", "dir": str(tmp_path),
+        }, tmp_path)
+        assert rc == 1
+
+
+class TestCLIConfigDiff:
+    def test_config_diff_no_drift(self, tmp_path):
+        from agent_trace.workspace import create_workspace
+        create_workspace("prod", str(tmp_path))
+        cfg_file = tmp_path / ".agent-strace.yaml"
+        cfg_file.write_text("workspaces:\n  - name: prod\n")
+        rc, out = _run(cmd_config_diff, {
+            "config": str(cfg_file), "dir": str(tmp_path),
+        }, tmp_path)
+        assert rc == 0
+        assert "No drift" in out
+
+    def test_config_diff_shows_missing(self, tmp_path):
+        cfg_file = tmp_path / ".agent-strace.yaml"
+        cfg_file.write_text("workspaces:\n  - name: prod\n")
+        rc, out = _run(cmd_config_diff, {
+            "config": str(cfg_file), "dir": str(tmp_path),
+        }, tmp_path)
+        assert rc == 0
+        assert "prod" in out


### PR DESCRIPTION
Closes #148

## What

Adds `agent-strace apply` and `agent-strace config-diff` — infrastructure-as-code primitives for managing agent-trace configuration from a checked-in `.agent-strace.yaml` file. Zero new dependencies (stdlib-only YAML parser).

## Usage

```bash
# Apply config to local store
agent-strace apply

# Dry-run: show planned changes without applying
agent-strace apply --dry-run

# Apply to hosted collector
agent-strace apply --server https://collector.company.com --auth-key ast_<key>

# Show drift between config file and current store state
agent-strace config-diff
```

## `.agent-strace.yaml` format

```yaml
workspaces:
  - name: production
  - name: staging

identities:
  - name: billing-agent
    team: backend
    workspace: production

team_budgets:
  - team: backend
    workspace: production
    monthly: 500.0
    alert_threshold: 0.8

rbac:
  - user: alice@example.com
    role: admin
  - group: eng@example.com
    role: member
  - user: bob@example.com
    role: workspace:member
    workspace: production
```

## Design notes

- YAML parser handles the subset needed (lists of dicts, scalar values, inline comments) — no PyYAML dependency
- `apply` is idempotent: re-running with the same config produces no changes
- `config-diff` output uses `+` (declared, not applied), `-` (exists, not declared), `~` (value changed)
- Remote apply (`--server`) uses the same HTTP API as the existing collector

## Tests

```
39 passed in 0.09s   (test_iac.py)
1453 passed in 24.17s (full suite)
```