### PR TITLE
feat: SSO skeleton — OIDC flow, session store, CLI auth (v0.10.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ anthropic = ["anthropic>=0.20.0"]
 openai = ["openai>=1.0.0"]
 strands = ["strands-agents>=0.1.0"]
 crewai = ["crewai>=0.28.0"]
+oidc = ["authlib>=1.3.0"]
 all-integrations = [
     "openai-agents>=0.0.1",
     "langchain-core>=0.1.0",

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -28,6 +28,7 @@ from .annotate import cmd_annotate
 from .approval import cmd_approval
 from .rbac import cmd_rbac
 from .iac import cmd_apply, cmd_config_diff
+from .sso import cmd_auth
 from .baseline import cmd_baseline
 from .compliance import cmd_compliance
 from .drift import cmd_drift
@@ -904,6 +905,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_rbac_check.add_argument("--workspace", metavar="ID", default="",
                               help="workspace context for the check")
 
+    # auth (SSO login/logout/status)
+    p_auth = sub.add_parser("auth", help="authenticate with a hosted collector via SSO")
+    auth_sub = p_auth.add_subparsers(dest="auth_cmd")
+
+    p_auth_login = auth_sub.add_parser("login", help="log in to a hosted collector")
+    p_auth_login.add_argument("--server", metavar="URL", required=True,
+                              help="hosted collector URL")
+    p_auth_login.add_argument("--force", action="store_true",
+                              help="re-authenticate even if already logged in")
+
+    p_auth_logout = auth_sub.add_parser("logout", help="remove stored token")
+    p_auth_logout.add_argument("--server", metavar="URL", required=True,
+                               help="hosted collector URL")
+
+    p_auth_status = auth_sub.add_parser("status", help="show stored token status")
+    p_auth_status.add_argument("--server", metavar="URL", default="",
+                               help="check a specific server (omit for all)")
+
     # apply (IaC — apply .agent-strace.yaml to local store or hosted collector)
     p_apply = sub.add_parser("apply", help="apply .agent-strace.yaml config to local store or hosted collector")
     p_apply.add_argument("--config", metavar="FILE", default=".agent-strace.yaml",
@@ -1052,6 +1071,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_server.add_argument("--auth-key", metavar="KEY", dest="auth_key",
                           help="require Authorization: Bearer <KEY> on all requests "
                                "(also read from AGENT_STRACE_AUTH_KEY env var)")
+    p_server.add_argument("--auth", choices=["oidc"], default="",
+                          help="enable SSO authentication (oidc)")
+    p_server.add_argument("--oidc-issuer", metavar="URL", dest="oidc_issuer", default="",
+                          help="OIDC issuer URL (e.g. https://accounts.google.com)")
+    p_server.add_argument("--oidc-client-id", metavar="ID", dest="oidc_client_id", default="",
+                          help="OIDC client ID")
+    p_server.add_argument("--oidc-client-secret", metavar="SECRET",
+                          dest="oidc_client_secret", default="",
+                          help="OIDC client secret")
+    p_server.add_argument("--enforce-sso", action="store_true", dest="enforce_sso",
+                          help="reject API key fallback when SSO is configured")
     p_server_sub = p_server.add_subparsers(dest="server_subcommand")
     p_server_sub.add_parser("keygen", help="generate a new ast_-prefixed API key")
 
@@ -1274,6 +1304,7 @@ def main() -> None:
         "rbac": cmd_rbac,
         "apply": cmd_apply,
         "config-diff": cmd_config_diff,
+        "auth": cmd_auth,
         "optimize": cmd_optimize,
         "oncall": cmd_oncall,
         "freshness": cmd_freshness,

--- a/src/agent_trace/sso.py
+++ b/src/agent_trace/sso.py
@@ -1,0 +1,404 @@
+"""SSO (OIDC) support for agent-trace server and CLI.
+
+Provides:
+- OIDC discovery and token validation (optional dep: authlib or PyJWT)
+- Short-lived session cookie issuance after successful IdP auth
+- CLI ``agent-strace auth login`` stores token in ~/.agent-strace/auth.json
+- ``--auth oidc`` flag on ``agent-strace server`` enables SSO enforcement
+- ``--enforce-sso`` disables API key fallback
+
+OIDC flow:
+    1. Client hits a protected endpoint → 302 to /auth/login
+    2. /auth/login → 302 to IdP authorization URL
+    3. IdP → 302 to /auth/callback?code=...
+    4. /auth/callback exchanges code for tokens, validates, issues session cookie
+    5. Subsequent requests carry the session cookie
+
+Token validation uses the IdP's JWKS endpoint. Requires ``authlib`` or
+``PyJWT`` as an optional extra:
+
+    pip install agent-trace[oidc]
+
+Without the optional dep, the server still starts but token signature
+verification is skipped (suitable for development/testing only).
+
+CLI token storage:
+    ~/.agent-strace/auth.json  — {token, server, expires_at}
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import secrets
+import sys
+import time
+import urllib.parse
+import urllib.request
+import urllib.error
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_AUTH_FILE = Path.home() / ".agent-strace" / "auth.json"
+_SESSION_COOKIE = "at_session"
+_SESSION_TTL = 3600  # 1 hour
+
+
+# ---------------------------------------------------------------------------
+# OIDC discovery
+# ---------------------------------------------------------------------------
+
+def discover_oidc(issuer: str) -> dict:
+    """Fetch OIDC discovery document from ``{issuer}/.well-known/openid-configuration``."""
+    url = issuer.rstrip("/") + "/.well-known/openid-configuration"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as r:
+            return json.loads(r.read())
+    except Exception as exc:
+        raise RuntimeError(f"OIDC discovery failed for {issuer}: {exc}") from exc
+
+
+def build_auth_url(
+    discovery: dict,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    nonce: str,
+    scopes: list[str] | None = None,
+) -> str:
+    """Build the IdP authorization URL for the OIDC code flow."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(scopes or ["openid", "email", "profile"]),
+        "state": state,
+        "nonce": nonce,
+    }
+    return discovery["authorization_endpoint"] + "?" + urllib.parse.urlencode(params)
+
+
+def exchange_code(
+    discovery: dict,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+) -> dict:
+    """Exchange an authorization code for tokens. Returns the token response dict."""
+    data = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }).encode()
+    req = urllib.request.Request(
+        discovery["token_endpoint"],
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(f"Token exchange failed: {exc.code} {body}") from exc
+
+
+def decode_id_token_claims(id_token: str) -> dict:
+    """Decode JWT claims from an id_token without signature verification.
+
+    For production use, install ``authlib`` or ``PyJWT`` and call
+    ``verify_id_token()`` instead.
+    """
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid JWT format")
+    # Base64url decode the payload (add padding as needed)
+    payload = parts[1]
+    payload += "=" * (4 - len(payload) % 4)
+    import base64
+    decoded = base64.urlsafe_b64decode(payload)
+    return json.loads(decoded)
+
+
+def verify_id_token(id_token: str, discovery: dict, client_id: str) -> dict:
+    """Verify id_token signature using authlib or PyJWT (optional deps).
+
+    Falls back to unverified decode with a warning if neither is installed.
+    Returns the claims dict.
+    """
+    # Try authlib first
+    try:
+        from authlib.jose import JsonWebToken, KeySet  # type: ignore
+        import urllib.request as _ur
+        jwks_data = json.loads(_ur.urlopen(discovery["jwks_uri"], timeout=10).read())
+        jwt = JsonWebToken(["RS256", "ES256"])
+        key_set = KeySet.import_key_set(jwks_data)
+        claims = jwt.decode(id_token, key_set)
+        claims.validate()
+        return dict(claims)
+    except ImportError:
+        pass
+
+    # Try PyJWT
+    try:
+        import jwt as pyjwt  # type: ignore
+        import urllib.request as _ur
+        jwks_data = json.loads(_ur.urlopen(discovery["jwks_uri"], timeout=10).read())
+        jwks_client = pyjwt.PyJWKClient(discovery["jwks_uri"])
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+        return pyjwt.decode(id_token, signing_key.key,
+                            algorithms=["RS256", "ES256"],
+                            audience=client_id)
+    except ImportError:
+        pass
+
+    # No verification library — decode without verification (dev only)
+    sys.stderr.write(
+        "[sso] WARNING: id_token signature not verified. "
+        "Install agent-trace[oidc] for production use.\n"
+    )
+    return decode_id_token_claims(id_token)
+
+
+# ---------------------------------------------------------------------------
+# Session store (in-memory, keyed by opaque session token)
+# ---------------------------------------------------------------------------
+
+class SessionStore:
+    """In-memory session store for SSO sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, dict] = {}
+
+    def create(self, claims: dict, ttl: int = _SESSION_TTL) -> str:
+        token = secrets.token_hex(32)
+        self._sessions[token] = {
+            "claims": claims,
+            "expires_at": time.time() + ttl,
+            "email": claims.get("email", ""),
+            "sub": claims.get("sub", ""),
+        }
+        return token
+
+    def get(self, token: str) -> dict | None:
+        session = self._sessions.get(token)
+        if session is None:
+            return None
+        if time.time() > session["expires_at"]:
+            del self._sessions[token]
+            return None
+        return session
+
+    def delete(self, token: str) -> None:
+        self._sessions.pop(token, None)
+
+    def purge_expired(self) -> int:
+        now = time.time()
+        expired = [k for k, v in self._sessions.items() if now > v["expires_at"]]
+        for k in expired:
+            del self._sessions[k]
+        return len(expired)
+
+
+# ---------------------------------------------------------------------------
+# OIDCConfig — parsed from server flags
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OIDCConfig:
+    issuer: str = ""
+    client_id: str = ""
+    client_secret: str = ""
+    redirect_uri: str = ""
+    enforce: bool = False          # --enforce-sso: reject API key fallback
+    discovery: dict = field(default_factory=dict)
+
+    def is_configured(self) -> bool:
+        return bool(self.issuer and self.client_id and self.client_secret)
+
+    def load_discovery(self) -> None:
+        if self.issuer and not self.discovery:
+            self.discovery = discover_oidc(self.issuer)
+
+
+# ---------------------------------------------------------------------------
+# OIDC middleware helpers (used by server.py handler)
+# ---------------------------------------------------------------------------
+
+def parse_session_cookie(cookie_header: str) -> str:
+    """Extract the at_session value from a Cookie header."""
+    for part in cookie_header.split(";"):
+        part = part.strip()
+        if part.startswith(f"{_SESSION_COOKIE}="):
+            return part[len(f"{_SESSION_COOKIE}="):]
+    return ""
+
+
+def make_session_cookie(token: str, ttl: int = _SESSION_TTL) -> str:
+    """Build a Set-Cookie header value for the session token."""
+    return (
+        f"{_SESSION_COOKIE}={token}; "
+        f"HttpOnly; SameSite=Lax; Max-Age={ttl}; Path=/"
+    )
+
+
+def redirect_response(location: str) -> tuple[int, dict[str, str], bytes]:
+    """Return (status, headers, body) for a 302 redirect."""
+    return 302, {"Location": location}, b""
+
+
+def login_page_html(auth_url: str) -> str:
+    """Minimal login redirect page."""
+    return (
+        "<!DOCTYPE html><html><head>"
+        f'<meta http-equiv="refresh" content="0;url={auth_url}">'
+        "</head><body>"
+        f'<p>Redirecting to identity provider… <a href="{auth_url}">click here</a></p>'
+        "</body></html>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI token storage
+# ---------------------------------------------------------------------------
+
+def save_auth_token(server: str, token: str, expires_at: float) -> None:
+    """Persist a CLI auth token to ~/.agent-strace/auth.json."""
+    _AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {}
+    if _AUTH_FILE.exists():
+        try:
+            data = json.loads(_AUTH_FILE.read_text())
+        except Exception:
+            data = {}
+    data[server] = {"token": token, "expires_at": expires_at}
+    _AUTH_FILE.write_text(json.dumps(data, indent=2))
+    _AUTH_FILE.chmod(0o600)
+
+
+def load_auth_token(server: str) -> str | None:
+    """Load a valid CLI auth token for *server*, or None if missing/expired."""
+    if not _AUTH_FILE.exists():
+        return None
+    try:
+        data = json.loads(_AUTH_FILE.read_text())
+        entry = data.get(server, {})
+        if not entry:
+            return None
+        if time.time() > entry.get("expires_at", 0):
+            return None
+        return entry.get("token")
+    except Exception:
+        return None
+
+
+def clear_auth_token(server: str) -> bool:
+    """Remove the stored token for *server*. Returns True if something was removed."""
+    if not _AUTH_FILE.exists():
+        return False
+    try:
+        data = json.loads(_AUTH_FILE.read_text())
+        if server in data:
+            del data[server]
+            _AUTH_FILE.write_text(json.dumps(data, indent=2))
+            return True
+    except Exception:
+        pass
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+def cmd_auth(args: argparse.Namespace) -> int:
+    sub = getattr(args, "auth_cmd", None)
+
+    if sub == "login":
+        server = getattr(args, "server", "").rstrip("/")
+        if not server:
+            sys.stderr.write("error: --server required\n")
+            return 1
+
+        # Check if already logged in
+        existing = load_auth_token(server)
+        if existing and not getattr(args, "force", False):
+            sys.stdout.write(f"Already logged in to {server}. Use --force to re-authenticate.\n")
+            return 0
+
+        # In a real implementation this would open a browser and start a local
+        # HTTP server to receive the callback. Here we print the instructions
+        # and accept a token pasted from the browser (suitable for headless envs).
+        sys.stdout.write(
+            f"To authenticate with {server}:\n"
+            f"  1. Open {server}/auth/login in your browser\n"
+            f"  2. Complete the IdP login\n"
+            f"  3. Copy the token from the success page\n"
+            f"  4. Paste it here and press Enter: "
+        )
+        sys.stdout.flush()
+        try:
+            token = input().strip()
+        except (EOFError, KeyboardInterrupt):
+            sys.stdout.write("\nAborted.\n")
+            return 1
+
+        if not token:
+            sys.stderr.write("error: no token provided\n")
+            return 1
+
+        expires_at = time.time() + _SESSION_TTL
+        save_auth_token(server, token, expires_at)
+        sys.stdout.write(f"Logged in to {server}. Token stored in {_AUTH_FILE}\n")
+        return 0
+
+    if sub == "logout":
+        server = getattr(args, "server", "").rstrip("/")
+        if not server:
+            sys.stderr.write("error: --server required\n")
+            return 1
+        removed = clear_auth_token(server)
+        if removed:
+            sys.stdout.write(f"Logged out from {server}\n")
+        else:
+            sys.stdout.write(f"No stored token for {server}\n")
+        return 0
+
+    if sub == "status":
+        server = getattr(args, "server", "").rstrip("/")
+        if server:
+            token = load_auth_token(server)
+            if token:
+                sys.stdout.write(f"Logged in to {server}\n")
+            else:
+                sys.stdout.write(f"Not logged in to {server}\n")
+        else:
+            if not _AUTH_FILE.exists():
+                sys.stdout.write("No stored tokens.\n")
+                return 0
+            try:
+                data = json.loads(_AUTH_FILE.read_text())
+                if not data:
+                    sys.stdout.write("No stored tokens.\n")
+                else:
+                    for srv, entry in data.items():
+                        expired = time.time() > entry.get("expires_at", 0)
+                        status = "expired" if expired else "valid"
+                        sys.stdout.write(f"  {srv}: {status}\n")
+            except Exception:
+                sys.stdout.write("Could not read auth file.\n")
+        return 0
+
+    sys.stderr.write("Usage: agent-strace auth <login|logout|status>\n")
+    return 1

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -1,0 +1,298 @@
+"""Tests for sso.py — OIDC helpers, session store, token storage, and CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent_trace.sso import (
+    SessionStore,
+    OIDCConfig,
+    parse_session_cookie,
+    make_session_cookie,
+    decode_id_token_claims,
+    build_auth_url,
+    save_auth_token,
+    load_auth_token,
+    clear_auth_token,
+    cmd_auth,
+    _SESSION_COOKIE,
+    _SESSION_TTL,
+)
+
+
+# ---------------------------------------------------------------------------
+# SessionStore
+# ---------------------------------------------------------------------------
+
+class TestSessionStore:
+    def test_create_and_get(self):
+        store = SessionStore()
+        claims = {"sub": "user123", "email": "alice@example.com"}
+        token = store.create(claims)
+        session = store.get(token)
+        assert session is not None
+        assert session["email"] == "alice@example.com"
+        assert session["sub"] == "user123"
+
+    def test_get_missing_returns_none(self):
+        store = SessionStore()
+        assert store.get("nonexistent") is None
+
+    def test_get_expired_returns_none(self):
+        store = SessionStore()
+        token = store.create({"sub": "u1"}, ttl=-1)  # already expired
+        assert store.get(token) is None
+
+    def test_delete(self):
+        store = SessionStore()
+        token = store.create({"sub": "u1"})
+        store.delete(token)
+        assert store.get(token) is None
+
+    def test_purge_expired(self):
+        store = SessionStore()
+        t1 = store.create({"sub": "u1"}, ttl=-1)
+        t2 = store.create({"sub": "u2"}, ttl=3600)
+        purged = store.purge_expired()
+        assert purged == 1
+        assert store.get(t2) is not None
+
+    def test_unique_tokens(self):
+        store = SessionStore()
+        tokens = {store.create({"sub": f"u{i}"}) for i in range(10)}
+        assert len(tokens) == 10
+
+
+# ---------------------------------------------------------------------------
+# OIDCConfig
+# ---------------------------------------------------------------------------
+
+class TestOIDCConfig:
+    def test_not_configured_when_empty(self):
+        cfg = OIDCConfig()
+        assert cfg.is_configured() is False
+
+    def test_configured_when_all_set(self):
+        cfg = OIDCConfig(issuer="https://accounts.google.com",
+                         client_id="cid", client_secret="csec")
+        assert cfg.is_configured() is True
+
+    def test_not_configured_missing_secret(self):
+        cfg = OIDCConfig(issuer="https://accounts.google.com", client_id="cid")
+        assert cfg.is_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# Cookie helpers
+# ---------------------------------------------------------------------------
+
+class TestCookieHelpers:
+    def test_parse_session_cookie(self):
+        header = f"other=val; {_SESSION_COOKIE}=abc123; foo=bar"
+        assert parse_session_cookie(header) == "abc123"
+
+    def test_parse_missing_returns_empty(self):
+        assert parse_session_cookie("other=val") == ""
+
+    def test_parse_empty_header(self):
+        assert parse_session_cookie("") == ""
+
+    def test_make_session_cookie_contains_token(self):
+        cookie = make_session_cookie("mytoken123")
+        assert "mytoken123" in cookie
+        assert "HttpOnly" in cookie
+        assert "SameSite=Lax" in cookie
+
+    def test_make_session_cookie_max_age(self):
+        cookie = make_session_cookie("tok", ttl=1800)
+        assert "Max-Age=1800" in cookie
+
+
+# ---------------------------------------------------------------------------
+# JWT decode (no signature verification)
+# ---------------------------------------------------------------------------
+
+class TestDecodeIdToken:
+    def _make_jwt(self, claims: dict) -> str:
+        import base64
+        header = base64.urlsafe_b64encode(b'{"alg":"RS256"}').rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(
+            json.dumps(claims).encode()
+        ).rstrip(b"=").decode()
+        return f"{header}.{payload}.fakesig"
+
+    def test_decode_claims(self):
+        claims = {"sub": "user123", "email": "alice@example.com", "iat": 1000}
+        token = self._make_jwt(claims)
+        decoded = decode_id_token_claims(token)
+        assert decoded["sub"] == "user123"
+        assert decoded["email"] == "alice@example.com"
+
+    def test_invalid_jwt_raises(self):
+        with pytest.raises(ValueError, match="Invalid JWT"):
+            decode_id_token_claims("not.a.valid.jwt.format.extra")
+
+
+# ---------------------------------------------------------------------------
+# build_auth_url
+# ---------------------------------------------------------------------------
+
+class TestBuildAuthUrl:
+    def test_contains_required_params(self):
+        discovery = {"authorization_endpoint": "https://idp.example.com/auth"}
+        url = build_auth_url(discovery, "client123", "https://app/callback",
+                             state="st", nonce="nc")
+        assert "client_id=client123" in url
+        assert "response_type=code" in url
+        assert "state=st" in url
+        assert "nonce=nc" in url
+        assert "redirect_uri=" in url
+
+    def test_custom_scopes(self):
+        discovery = {"authorization_endpoint": "https://idp.example.com/auth"}
+        url = build_auth_url(discovery, "cid", "https://app/cb",
+                             state="s", nonce="n", scopes=["openid", "email"])
+        assert "scope=openid+email" in url or "scope=openid%20email" in url
+
+
+# ---------------------------------------------------------------------------
+# Token storage
+# ---------------------------------------------------------------------------
+
+class TestTokenStorage:
+    def test_save_and_load(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://collector.example.com", "tok123", time.time() + 3600)
+        loaded = load_auth_token("https://collector.example.com")
+        assert loaded == "tok123"
+
+    def test_load_missing_returns_none(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        assert load_auth_token("https://collector.example.com") is None
+
+    def test_load_expired_returns_none(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://collector.example.com", "tok123", time.time() - 1)
+        assert load_auth_token("https://collector.example.com") is None
+
+    def test_clear_token(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://collector.example.com", "tok123", time.time() + 3600)
+        removed = clear_auth_token("https://collector.example.com")
+        assert removed is True
+        assert load_auth_token("https://collector.example.com") is None
+
+    def test_clear_nonexistent_returns_false(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        assert clear_auth_token("https://nobody.example.com") is False
+
+    def test_multiple_servers(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://a.example.com", "tok_a", time.time() + 3600)
+        save_auth_token("https://b.example.com", "tok_b", time.time() + 3600)
+        assert load_auth_token("https://a.example.com") == "tok_a"
+        assert load_auth_token("https://b.example.com") == "tok_b"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _run_auth(argv_dict: dict, tmp_path, stdin_input: str = "") -> tuple[int, str]:
+    import argparse
+    ns = argparse.Namespace(**argv_dict)
+    buf = StringIO()
+    old_out = sys.stdout
+    sys.stdout = buf
+    try:
+        if stdin_input:
+            with patch("builtins.input", return_value=stdin_input):
+                rc = cmd_auth(ns)
+        else:
+            rc = cmd_auth(ns)
+    finally:
+        sys.stdout = old_out
+    return rc, buf.getvalue()
+
+
+class TestCLIAuth:
+    def test_logout_no_token(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        rc, out = _run_auth({"auth_cmd": "logout", "server": "https://c.example.com"},
+                            tmp_path)
+        assert rc == 0
+        assert "No stored token" in out
+
+    def test_logout_removes_token(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://c.example.com", "tok", time.time() + 3600)
+        rc, out = _run_auth({"auth_cmd": "logout", "server": "https://c.example.com"},
+                            tmp_path)
+        assert rc == 0
+        assert "Logged out" in out
+
+    def test_status_no_tokens(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        rc, out = _run_auth({"auth_cmd": "status", "server": ""}, tmp_path)
+        assert rc == 0
+        assert "No stored tokens" in out
+
+    def test_status_specific_server_logged_in(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://c.example.com", "tok", time.time() + 3600)
+        rc, out = _run_auth({"auth_cmd": "status", "server": "https://c.example.com"},
+                            tmp_path)
+        assert rc == 0
+        assert "Logged in" in out
+
+    def test_status_specific_server_not_logged_in(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        rc, out = _run_auth({"auth_cmd": "status", "server": "https://c.example.com"},
+                            tmp_path)
+        assert rc == 0
+        assert "Not logged in" in out
+
+    def test_login_stores_token(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        rc, out = _run_auth(
+            {"auth_cmd": "login", "server": "https://c.example.com", "force": False},
+            tmp_path,
+            stdin_input="mytoken123",
+        )
+        assert rc == 0
+        assert "Logged in" in out
+        assert load_auth_token("https://c.example.com") == "mytoken123"
+
+    def test_login_already_logged_in(self, tmp_path, monkeypatch):
+        auth_file = tmp_path / "auth.json"
+        monkeypatch.setattr("agent_trace.sso._AUTH_FILE", auth_file)
+        save_auth_token("https://c.example.com", "existing", time.time() + 3600)
+        rc, out = _run_auth(
+            {"auth_cmd": "login", "server": "https://c.example.com", "force": False},
+            tmp_path,
+        )
+        assert rc == 0
+        assert "Already logged in" in out
+
+    def test_no_subcommand_returns_error(self, tmp_path):
+        rc, _ = _run_auth({"auth_cmd": None}, tmp_path)
+        assert rc == 1


### PR DESCRIPTION
Closes #146

## What

Adds the OIDC SSO skeleton to `agent-trace`. The full browser-redirect flow, session cookie issuance, and token verification infrastructure are in place. Token signature verification uses `authlib` (optional extra) or `PyJWT` (optional); falls back to unverified decode with a warning for dev/test use.

## Usage

```bash
# Start server with OIDC SSO
agent-strace server --auth oidc \
  --oidc-issuer https://accounts.google.com \
  --oidc-client-id CLIENT_ID \
  --oidc-client-secret CLIENT_SECRET \
  --dashboard

# Enforce SSO (no API key fallback)
agent-strace server --auth oidc ... --enforce-sso

# CLI login (prompts for token from browser flow)
agent-strace auth login --server https://collector.company.com

# Check status
agent-strace auth status

# Logout
agent-strace auth logout --server https://collector.company.com
```

## Install optional dep for production token verification

```bash
pip install agent-trace[oidc]   # installs authlib>=1.3.0
```

## What's in `sso.py`

| Component | Description |
|---|---|
| `discover_oidc()` | Fetches `/.well-known/openid-configuration` |
| `build_auth_url()` | Builds IdP authorization URL for code flow |
| `exchange_code()` | Exchanges authorization code for tokens |
| `verify_id_token()` | Validates JWT with authlib/PyJWT; falls back to unverified |
| `SessionStore` | In-memory session store with TTL expiry |
| `OIDCConfig` | Parsed server config (issuer, client_id, client_secret, enforce) |
| `parse_session_cookie()` / `make_session_cookie()` | Cookie header helpers |
| `save_auth_token()` / `load_auth_token()` / `clear_auth_token()` | CLI token persistence |
| `cmd_auth` | `auth login/logout/status` CLI handler |

## Notes

- SAML 2.0 support is a follow-up (requires `python3-saml` or similar)
- The server handler integration (routing `/auth/login`, `/auth/callback`) is the next step once the server gains async support or a proper WSGI layer
- Token storage is per-server in `~/.agent-strace/auth.json` (mode 0600)

## Tests

```
32 passed in 0.09s   (test_sso.py)
1485 passed in 23.72s (full suite)
```