### PR TITLE
fix: always direct users to ~/.claude/settings.json in setup output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ uvx agent-strace replay
 **Option 1: Claude Code hooks** — captures everything (prompts, responses, every tool call)
 
 ```bash
-agent-strace setup   # prints hooks config — add to .claude/settings.json
+agent-strace setup   # prints hooks config — add to ~/.claude/settings.json
 agent-strace list    # list sessions
 agent-strace replay  # replay the latest
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ Capture an MCP HTTP/SSE server session. Listens on `--port` (default: 3100) and 
 ```
 agent-strace setup [--redact] [--global]
 ```
-Print Claude Code hooks config JSON. Add `--global` to write to `~/.claude/settings.json`.
+Print Claude Code hooks config JSON for `~/.claude/settings.json`. Use `--global` to scope hooks to all projects (default scopes to the current project).
 
 ### `import`
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,7 +19,7 @@ agent-strace setup --global
 agent-strace setup --redact
 ```
 
-`agent-strace setup` prints the hooks JSON. Add it to `.claude/settings.json`:
+`agent-strace setup` prints the hooks JSON. Add it to `~/.claude/settings.json` (user-level, applies to all projects):
 
 ```json
 {

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.0"
+__version__ = "0.64.1"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -462,10 +462,7 @@ def cmd_setup(args: argparse.Namespace) -> None:
 
     output = json.dumps(config, indent=2)
 
-    if args.global_config:
-        sys.stderr.write("Add this to ~/.claude/settings.json:\n\n")
-    else:
-        sys.stderr.write("Add this to .claude/settings.json:\n\n")
+    sys.stderr.write("Add this to ~/.claude/settings.json:\n\n")
 
     sys.stdout.write(output + "\n")
     sys.stderr.write(

--- a/src/agent_trace/mcp_server.py
+++ b/src/agent_trace/mcp_server.py
@@ -14,7 +14,7 @@ Usage:
   agent-strace mcp                  # stdio transport (default)
   agent-strace mcp --trace-dir DIR  # custom trace directory
 
-Claude Code config (.claude/settings.json):
+Claude Code config (~/.claude/settings.json):
   {
     "mcpServers": {
       "agent-trace": {


### PR DESCRIPTION
## What

`agent-strace setup` was printing `Add this to .claude/settings.json:` by default (repo-level), and only switching to `~/.claude/settings.json` when `--global` was explicitly passed.

## Why

Claude Code hooks configured in `.claude/settings.json` (repo-level) only apply within that specific project directory. The intended use case — capturing all agent sessions — requires the user-level `~/.claude/settings.json` so hooks fire across every project. Pointing users to the repo-level file by default was misleading and caused hooks to silently not apply in other projects.

## Changes

- `src/agent_trace/cli.py`: Remove the conditional branch; always emit `Add this to ~/.claude/settings.json:`
- `docs/setup.md`: Update the instruction to reference `~/.claude/settings.json` with a note that it applies to all projects
- `src/agent_trace/__init__.py`: Bump to `0.64.1`

The `--global` flag still works as before (it controls the scope of the generated config content), but the message is now consistent regardless of which flag is used.