### PR TITLE
fix: resolve TypeError in record/auto commands and 0.0s duration in list

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.1"
+__version__ = "0.64.2"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -84,22 +84,27 @@ def cmd_record(args: argparse.Namespace) -> int:
     """Record an MCP server session."""
     store = TraceStore(args.trace_dir)
 
+    server_cmd = args.server_cmd
+    # Strip leading '--' separator added by argparse REMAINDER
+    if server_cmd and server_cmd[0] == "--":
+        server_cmd = server_cmd[1:]
+
     meta = SessionMeta(
         agent_name=args.name or "",
-        command=" ".join(args.command),
+        command=" ".join(server_cmd),
     )
     store.create_session(meta)
 
     if not args.quiet:
         sys.stderr.write(
             f"agent-strace: recording session {meta.session_id}\n"
-            f"agent-strace: command: {' '.join(args.command)}\n"
+            f"agent-strace: command: {' '.join(server_cmd)}\n"
         )
 
     on_event = _print_live_event if args.verbose else None
 
     proxy = MCPProxy(
-        server_command=args.command,
+        server_command=server_cmd,
         store=store,
         session_meta=meta,
         on_event=on_event,
@@ -493,7 +498,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_record.add_argument("--redact", action="store_true", help="redact secrets from trace data")
     p_record.add_argument("--verbose", "-v", action="store_true", help="print events to stderr during recording")
     p_record.add_argument("--quiet", "-q", action="store_true", help="suppress all output except errors")
-    p_record.add_argument("command", nargs=argparse.REMAINDER, help="MCP server command to run")
+    p_record.add_argument("server_cmd", nargs=argparse.REMAINDER, help="MCP server command to run")
 
     # record-http
     p_record_http = sub.add_parser("record-http", help="record a remote MCP server session (HTTP/SSE)")
@@ -1048,7 +1053,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_auto.add_argument("--detect", action="store_true",
                         help="auto-detect and instrument all installed frameworks")
-    p_auto.add_argument("command", nargs=argparse.REMAINDER,
+    p_auto.add_argument("server_cmd", nargs=argparse.REMAINDER,
                         help="command to run with instrumentation")
 
     # server (event collector)
@@ -1207,7 +1212,7 @@ def cmd_auto(args: argparse.Namespace) -> int:
     import subprocess
     import os
 
-    command = getattr(args, "command", [])
+    command = getattr(args, "server_cmd", [])
     # Strip leading '--' separator
     if command and command[0] == "--":
         command = command[1:]

--- a/src/agent_trace/replay.py
+++ b/src/agent_trace/replay.py
@@ -296,7 +296,14 @@ def format_event(event: TraceEvent, base_ts: float | None = None) -> str:
 def format_summary(meta: SessionMeta) -> str:
     """Format session summary."""
     started = datetime.fromtimestamp(meta.started_at, tz=timezone.utc)
-    duration = meta.total_duration_ms / 1000 if meta.total_duration_ms else 0
+    if meta.total_duration_ms:
+        duration_s = meta.total_duration_ms / 1000
+    elif meta.ended_at:
+        duration_s = meta.ended_at - meta.started_at
+    else:
+        duration_s = None
+
+    duration_str = f"{duration_s:.2f}s" if duration_s is not None else "—"
 
     lines = [
         f"",
@@ -304,7 +311,7 @@ def format_summary(meta: SessionMeta) -> str:
         f"{C.GRAY}{'─' * 50}{C.RESET}",
         f"  Session:    {meta.session_id}",
         f"  Started:    {started.strftime('%Y-%m-%d %H:%M:%S UTC')}",
-        f"  Duration:   {duration:.2f}s",
+        f"  Duration:   {duration_str}",
         f"  Tool calls: {meta.tool_calls}",
         f"  LLM reqs:   {meta.llm_requests}",
         f"  Errors:     {meta.errors}",
@@ -414,13 +421,22 @@ def list_sessions(store: TraceStore, out: TextIO = sys.stdout) -> None:
 
     for meta in sessions:
         started = datetime.fromtimestamp(meta.started_at, tz=timezone.utc)
-        duration = meta.total_duration_ms / 1000 if meta.total_duration_ms else 0
+
+        # Prefer explicit total_duration_ms; fall back to ended_at - started_at;
+        # show "—" for sessions that never completed (crashed / still running).
+        if meta.total_duration_ms:
+            duration_str = f"{meta.total_duration_ms / 1000:>9.1f}s"
+        elif meta.ended_at:
+            duration_str = f"{meta.ended_at - meta.started_at:>9.1f}s"
+        else:
+            duration_str = f"{C.DIM}{'—':>9} {C.RESET}"
+
         err_color = C.RED if meta.errors > 0 else C.DIM
 
         out.write(
             f"  {meta.session_id:<18} "
             f"{started.strftime('%Y-%m-%d %H:%M:%S'):<22} "
-            f"{duration:>9.1f}s "
+            f"{duration_str} "
             f"{meta.tool_calls:>6} "
             f"{meta.llm_requests:>5} "
             f"{err_color}{meta.errors:>4}{C.RESET}\n"

--- a/src/agent_trace/replay.py
+++ b/src/agent_trace/replay.py
@@ -443,7 +443,12 @@ def list_sessions(store: TraceStore, out: TextIO = sys.stdout) -> None:
         )
 
     out.write(f"{C.GRAY}{'─' * 70}{C.RESET}\n")
-    out.write(f"  {len(sessions)} session(s)\n\n")
+    out.write(f"  {len(sessions)} session(s)\n")
+    out.write(
+        f"  {C.DIM}Tools = MCP tool calls  "
+        f"LLM = sampling/createMessage or @trace_llm_call  "
+        f"Err = protocol errors{C.RESET}\n\n"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes

### 1. `TypeError: unhashable type: 'list'` on `record` and `auto`

`agent-strace record -- npx -y @modelcontextprotocol/server-filesystem /tmp` crashed at `handler = handlers.get(args.command)`.

**Root cause:** both `record` and `auto` subparsers defined a positional argument named `command` with `nargs=REMAINDER`. Argparse uses `dest="command"` internally to store the active subcommand name, so parsing `record -- npx ...` overwrote the string `"record"` with the list `['--', 'npx', ...]` — making it unhashable as a dict key.

**Fix:** rename the positional to `server_cmd` in both subparsers; update `cmd_record` and `cmd_auto` to read `args.server_cmd`. Also moves the `--` separator strip into `cmd_record` (already present in `cmd_auto`).

---

### 2. Duration shows `0.0s` in `list` for incomplete sessions

Sessions that crashed or were interrupted never had `total_duration_ms` written, so `list` always showed `0.0s`.

**Fix:** in `list_sessions` and `format_summary`, fall back to `ended_at - started_at` when `total_duration_ms` is absent, and show `—` for sessions with no end time at all (hard crash / still running).

## Changes

- `src/agent_trace/cli.py`: rename positional arg in `record` + `auto` subparsers; update both handler functions
- `src/agent_trace/replay.py`: duration fallback in `list_sessions` and `format_summary`
- `src/agent_trace/__init__.py`: bump to `0.64.2`