### PR TITLE
fix: crash in export when session_id is omitted

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.4"
+__version__ = "0.64.5"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -273,7 +273,12 @@ def cmd_export(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
 
     session_id = args.session_id
-    if not store.session_exists(session_id):
+    if not session_id:
+        session_id = store.get_latest_session_id()
+        if not session_id:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+    elif not store.session_exists(session_id):
         found = store.find_session(session_id)
         if found:
             session_id = found


### PR DESCRIPTION
## What

`agent-strace export` with no session ID crashed:

```
TypeError: unsupported operand type(s) for /: 'PosixPath' and 'NoneType'
```

## Why

`session_id` is declared `nargs="?"` so it defaults to `None` when omitted. The code passed `None` directly to `store.session_exists()` → `_session_dir()` → `self.base_dir / None`.

## Fix

Add a `None` guard before the existence check: fall back to `store.get_latest_session_id()` when no session ID is provided, consistent with `replay`, `stats`, `explain`, and other commands that accept an optional session ID.

## Changes

- `src/agent_trace/cli.py`: None guard in `cmd_export`
- `src/agent_trace/__init__.py`: bump to `0.64.5`