### PR TITLE
fix: add usage hints to server startup output

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.5"
+__version__ = "0.64.6"

--- a/src/agent_trace/server.py
+++ b/src/agent_trace/server.py
@@ -387,6 +387,13 @@ def run_server(
         f"[agent-strace server] listening on {host}:{port}{auth_note}\n"
         f"[agent-strace server] storage: {Path(storage_dir).resolve()}\n"
         f"[agent-strace server] health: http://{host}:{port}/health{dash_note}\n"
+        f"\n"
+        f"[agent-strace server] purpose : collect traces from remote agents\n"
+        f"[agent-strace server] usage   : set AGENT_STRACE_ENDPOINT=http://<this-host>:{port} on each agent machine\n"
+        f"[agent-strace server] api     : POST /events  POST /sessions  GET /sessions  GET /sessions/<id>/events\n"
+        f"[agent-strace server] inspect : agent-strace list / replay / export  (reads the same storage dir)\n"
+        f"[agent-strace server] html    : agent-strace replay --format html    (shareable single-file viewer)\n"
+        f"[agent-strace server] otlp    : agent-strace export --format otlp --endpoint <collector-url>\n"
     )
     try:
         server.serve_forever()


### PR DESCRIPTION
## What

`agent-strace server` startup only printed host/port/storage/health, leaving users unclear on what the server is for and how to connect agents to it.

## Change

Add a concise hint block immediately after the existing startup lines:

```
[agent-strace server] purpose : collect traces from remote agents
[agent-strace server] usage   : set AGENT_STRACE_ENDPOINT=http://<this-host>:4317 on each agent machine
[agent-strace server] api     : POST /events  POST /sessions  GET /sessions  GET /sessions/<id>/events
[agent-strace server] inspect : agent-strace list / replay / export  (reads the same storage dir)
[agent-strace server] html    : agent-strace replay --format html    (shareable single-file viewer)
[agent-strace server] otlp    : agent-strace export --format otlp --endpoint <collector-url>
```

## Changes

- `src/agent_trace/server.py`: extend startup stderr output
- `src/agent_trace/__init__.py`: bump to `0.64.6`