### PR TITLE
fix: save OTLP export to file by default + Jaeger demo docs

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -1,5 +1,24 @@
 # Production tracing (OTLP export)
 
+## Quick demo (no signup required)
+
+Spin up Jaeger locally — one Docker command, full trace UI in the browser:
+
+```bash
+# Start Jaeger (OTLP on 4318, UI on 16686)
+docker run --rm -d --name jaeger \
+  -p 16686:16686 -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+
+# Export your session
+agent-strace export --format otlp-genai --endpoint http://localhost:4318
+
+# Open the UI
+open http://localhost:16686
+```
+
+Select service `agent-trace` in the Jaeger UI to see the full trace.
+
 Export sessions as OpenTelemetry spans to your existing observability stack. Sessions become traces. Tool calls become spans with duration and inputs. Errors get exception events. No new dependencies.
 
 ---

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.6"
+__version__ = "0.64.7"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -322,13 +322,20 @@ def cmd_export(args: argparse.Namespace) -> int:
             use_genai = False  # explicit --format otlp keeps legacy behaviour
 
         if not endpoint:
-            # No endpoint: dump OTLP JSON to stdout
+            # No endpoint: write OTLP JSON to --output file or stdout
             meta = store.load_meta(session_id)
             if use_genai:
                 payload = session_to_otlp_genai(meta, events, service_name=args.service_name)
             else:
                 payload = session_to_otlp(meta, events, service_name=args.service_name)
-            sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+            output_path = getattr(args, "output", "") or ""
+            if not output_path:
+                fmt_suffix = "otlp-genai" if use_genai else "otlp"
+                output_path = f"trace-{session_id[:12]}-{fmt_suffix}.json"
+            with open(output_path, "w") as f:
+                f.write(json.dumps(payload, indent=2) + "\n")
+            sys.stderr.write(f"OTLP payload written to {output_path}\n")
+            sys.stderr.write(f"Send to a collector: agent-strace export --format {args.format} --endpoint <url>\n")
             return 0
 
         # Build headers from --header flags


### PR DESCRIPTION
## What

Two improvements for the OTLP demo story:

### 1. `export --format otlp` saves to a file by default

Previously, `export --format otlp` with no `--endpoint` dumped JSON to stdout — easy to accidentally mix with other output and not obvious how to save it.

Now it writes to `trace-<session-id>-otlp-genai.json` by default (or `--output <path>` to override) and prints the filename to stderr:

```
OTLP payload written to trace-abc123def456-otlp-genai.json
Send to a collector: agent-strace export --format otlp-genai --endpoint <url>
```

### 2. Zero-signup Jaeger demo in docs

Added a "Quick demo" section at the top of `docs/production.md` — one Docker command to get a full trace UI running locally, no account needed:

```bash
docker run --rm -d --name jaeger \
  -p 16686:16686 -p 4318:4318 \
  jaegertracing/all-in-one:latest

agent-strace export --format otlp-genai --endpoint http://localhost:4318
open http://localhost:16686
```

## Changes

- `src/agent_trace/cli.py`: write OTLP to file when no `--endpoint` given
- `docs/production.md`: Jaeger quick-demo section at the top
- `src/agent_trace/__init__.py`: bump to `0.64.7`