### PR TITLE
feat: redact trace secrets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace apply`](docs/commands.md#apply) | Apply `.agent-strace.yaml` config to local store or collector |
 | [`agent-strace workspace new`](docs/commands.md#workspace) | Create an isolated workspace |
 | [`agent-strace compliance export`](docs/commands.md#compliance) | Export compliance reports (EU AI Act, SOC 2, HIPAA) |
-| [`agent-strace record --redact`](docs/commands.md#record) | Strip secrets from traces before storage |
+| [`agent-strace record`](docs/commands.md#record) | Strip secrets from traces before storage by default |
 | [`agent-strace export --anonymize`](docs/commands.md#export) | Remove PII at export time |
 
 ### Analyse across sessions

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,27 +8,28 @@ Full flag reference for every `agent-strace` command.
 
 ### `record`
 ```
-agent-strace record [--name NAME] [--redact] [--mask] -- <command>
+agent-strace record [--name NAME] [--no-redact] [--mask] -- <command>
 ```
 Capture an MCP stdio server session. Wraps `<command>` as a transparent proxy.
 
 | Flag | Description |
 |---|---|
 | `--name NAME` | Label for the session |
-| `--redact` | Strip secrets before writing to disk |
+| `--redact` | Strip secrets before writing to disk; kept for compatibility because this is now the default |
+| `--no-redact` | Disable automatic secret redaction |
 | `--mask` | Mask PII (email, phone, CC, SSN) |
 
 ### `record-http`
 ```
-agent-strace record-http <url> [--port N] [--redact] [--mask]
+agent-strace record-http <url> [--port N] [--no-redact] [--mask]
 ```
 Capture an MCP HTTP/SSE server session. Listens on `--port` (default: 3100) and proxies to `<url>`.
 
 ### `setup`
 ```
-agent-strace setup [--redact] [--global]
+agent-strace setup [--no-redact] [--global]
 ```
-Print Claude Code hooks config JSON for `~/.claude/settings.json`. Use `--global` to scope hooks to all projects (default scopes to the current project).
+Print Claude Code hooks config JSON for `~/.claude/settings.json`. Use `--global` to scope hooks to all projects (default scopes to the current project). Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
 
 ### `import`
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,15 +6,16 @@ agent-strace provides two complementary mechanisms for keeping sensitive data ou
 
 ## Secret redaction
 
-Strips API keys, tokens, and credentials before they hit disk. The original data is never stored.
+Strips API keys, tokens, and credentials before they hit disk. The original data is never stored. Redaction is enabled by default for all trace writes.
 
 ```bash
-# Enable redaction when capturing
-agent-strace record --redact -- npx -y @modelcontextprotocol/server-filesystem /tmp
-agent-strace record-http https://mcp.example.com --redact
+# Default: redact before writing traces
+agent-strace record -- npx -y @modelcontextprotocol/server-filesystem /tmp
+agent-strace record-http https://mcp.example.com
 
-# Or via setup (Claude Code hooks)
-agent-strace setup --redact
+# Trusted local traces only
+agent-strace record --no-redact -- npx -y @modelcontextprotocol/server-filesystem /tmp
+agent-strace setup --no-redact
 ```
 
 Detected patterns:
@@ -29,17 +30,12 @@ Detected patterns:
 | JWTs | Three base64 segments separated by `.` |
 | Bearer tokens | `Bearer [A-Za-z0-9+/=]{20,}` |
 | Connection strings | `postgres://`, `mysql://`, `mongodb://` |
+| Basic-auth URLs | `https://user:pass@example.com` |
 | Key-named values | Any value under keys: `password`, `secret`, `token`, `api_key`, `authorization` |
 | EKM shared secrets | 64-char hex strings |
 | Private keys | PEM blocks |
 
-Redacted values become `[REDACTED]`. See [ADR-0007](../ADRs/0007-heuristic-redaction.md) for design rationale.
-
-### Custom patterns
-
-```bash
-agent-strace setup --redact --redact-pattern "ATTESTATION_KEY=[A-Fa-f0-9]{64}"
-```
+Redacted values become typed markers such as `[REDACTED:openai-key]`, `[REDACTED:bearer-token]`, or `[REDACTED:sensitive]`. Events with redaction are marked with `"redacted": true`. See [ADR-0007](../ADRs/0007-heuristic-redaction.md) for design rationale.
 
 ---
 
@@ -224,7 +220,7 @@ Or use the setup command:
 
 ```bash
 cd your-sensitive-repo
-agent-strace setup --redact
+agent-strace setup
 ```
 
 Combine with [agentic-authz](https://github.com/Siddhant-K-code/agentic-authz) to block agents from security-critical components entirely, and use agent-strace to audit everything they do access.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,8 +15,8 @@ agent-strace setup
 # For all projects (global config)
 agent-strace setup --global
 
-# With secret redaction enabled
-agent-strace setup --redact
+# Trusted local traces only: disable secret redaction
+agent-strace setup --no-redact
 ```
 
 `agent-strace setup` prints the hooks JSON. Add it to `~/.claude/settings.json` (user-level, applies to all projects):
@@ -122,7 +122,7 @@ Wraps your tool functions directly. No MCP required.
 ```python
 from agent_trace import trace_tool, trace_llm_call, start_session, end_session, log_decision
 
-start_session(name="my-agent")  # add redact=True to strip secrets
+start_session(name="my-agent")  # use redact=False only for trusted local traces
 
 @trace_tool
 def search_codebase(query: str) -> str:
@@ -153,15 +153,9 @@ For repos that handle secrets, attestation logic, or cryptographic material:
 
 ```bash
 cd your-sensitive-repo
-agent-strace setup --redact
+agent-strace setup
 ```
 
-This enables automatic redaction of API keys, tokens, and credentials before they hit disk. Detected patterns: OpenAI (`sk-*`), GitHub (`ghp_*`, `github_pat_*`), AWS (`AKIA*`), Anthropic (`sk-ant-*`), Slack (`xox*`), JWTs, Bearer tokens, connection strings, and any value under keys like `password`, `secret`, `token`, `api_key`, `authorization`.
-
-Add custom patterns:
-
-```bash
-agent-strace setup --redact --redact-pattern "ATTESTATION_KEY=[A-Fa-f0-9]{64}"
-```
+Secret redaction is enabled by default for all capture paths. It redacts API keys, tokens, credentials, private keys, basic-auth URLs, and connection strings before they hit disk. Detected patterns include OpenAI (`sk-*`), GitHub (`ghp_*`, `github_pat_*`), AWS (`AKIA*` and AWS credential key names), Anthropic (`sk-ant-*`), Slack (`xox*`), JWTs, Bearer tokens, and any value under keys like `password`, `secret`, `token`, `api_key`, or `authorization`.
 
 See [security.md](security.md) for the full security guide.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.64.7"
+__version__ = "0.65.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -1,9 +1,9 @@
 """CLI entry point.
 
 Usage:
-    agent-strace record [--redact] -- <server-command> [args...]
-    agent-strace record-http [--redact] --url <remote-url> [--port <local-port>]
-    agent-strace setup [--redact] [--global]
+    agent-strace record [--no-redact] -- <server-command> [args...]
+    agent-strace record-http [--no-redact] --url <remote-url> [--port <local-port>]
+    agent-strace setup [--no-redact] [--global]
     agent-strace hook <event>
     agent-strace replay [session-id]
     agent-strace list
@@ -80,9 +80,18 @@ def _print_live_event(event: TraceEvent) -> None:
     sys.stderr.flush()
 
 
+def _redact_setting(args: argparse.Namespace) -> bool | None:
+    """Return explicit redaction setting, or None to use env/defaults."""
+    if getattr(args, "no_redact", False):
+        return False
+    if getattr(args, "redact", False):
+        return True
+    return None
+
+
 def cmd_record(args: argparse.Namespace) -> int:
     """Record an MCP server session."""
-    store = TraceStore(args.trace_dir)
+    store = TraceStore(args.trace_dir, redact=_redact_setting(args))
 
     server_cmd = args.server_cmd
     # Strip leading '--' separator added by argparse REMAINDER
@@ -127,7 +136,7 @@ def cmd_record(args: argparse.Namespace) -> int:
 
 def cmd_record_http(args: argparse.Namespace) -> int:
     """Record a remote MCP server session over HTTP/SSE."""
-    store = TraceStore(args.trace_dir)
+    store = TraceStore(args.trace_dir, redact=_redact_setting(args))
 
     meta = SessionMeta(
         agent_name=args.name or "",
@@ -443,7 +452,9 @@ def cmd_stats(args: argparse.Namespace) -> int:
 def cmd_setup(args: argparse.Namespace) -> None:
     """Generate Claude Code hooks configuration."""
     redact_env = ""
-    if args.redact:
+    if args.no_redact:
+        redact_env = "AGENT_TRACE_NO_REDACT=1 "
+    elif args.redact:
         redact_env = "AGENT_TRACE_REDACT=1 "
 
     cmd_prefix = f"{redact_env}agent-strace hook"
@@ -507,7 +518,17 @@ def build_parser() -> argparse.ArgumentParser:
     # record
     p_record = sub.add_parser("record", help="record an MCP server session (stdio)")
     p_record.add_argument("--name", "-n", help="name for this agent/session")
-    p_record.add_argument("--redact", action="store_true", help="redact secrets from trace data")
+    record_redaction = p_record.add_mutually_exclusive_group()
+    record_redaction.add_argument(
+        "--redact",
+        action="store_true",
+        help="redact secrets from trace data (default)",
+    )
+    record_redaction.add_argument(
+        "--no-redact",
+        action="store_true",
+        help="disable automatic secret redaction",
+    )
     p_record.add_argument("--verbose", "-v", action="store_true", help="print events to stderr during recording")
     p_record.add_argument("--quiet", "-q", action="store_true", help="suppress all output except errors")
     p_record.add_argument("server_cmd", nargs=argparse.REMAINDER, help="MCP server command to run")
@@ -517,7 +538,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_record_http.add_argument("--url", "-u", required=True, help="remote MCP server URL")
     p_record_http.add_argument("--port", "-p", type=int, default=5100, help="local proxy port (default: 5100)")
     p_record_http.add_argument("--name", "-n", help="name for this agent/session")
-    p_record_http.add_argument("--redact", action="store_true", help="redact secrets from trace data")
+    record_http_redaction = p_record_http.add_mutually_exclusive_group()
+    record_http_redaction.add_argument(
+        "--redact",
+        action="store_true",
+        help="redact secrets from trace data (default)",
+    )
+    record_http_redaction.add_argument(
+        "--no-redact",
+        action="store_true",
+        help="disable automatic secret redaction",
+    )
     p_record_http.add_argument("--verbose", "-v", action="store_true", help="print events to stderr during recording")
     p_record_http.add_argument("--quiet", "-q", action="store_true", help="suppress all output except errors")
 
@@ -596,7 +627,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     # setup (generate Claude Code hooks config)
     p_setup = sub.add_parser("setup", help="generate Claude Code hooks configuration")
-    p_setup.add_argument("--redact", action="store_true", help="enable secret redaction")
+    setup_redaction = p_setup.add_mutually_exclusive_group()
+    setup_redaction.add_argument(
+        "--redact",
+        action="store_true",
+        help="enable secret redaction explicitly (default)",
+    )
+    setup_redaction.add_argument(
+        "--no-redact",
+        action="store_true",
+        help="disable automatic secret redaction in generated hooks",
+    )
     p_setup.add_argument("--global", dest="global_config", action="store_true", help="output config for ~/.claude/settings.json (all projects)")
 
     # import (Claude Code JSONL session logs)

--- a/src/agent_trace/decorator.py
+++ b/src/agent_trace/decorator.py
@@ -47,12 +47,12 @@ def _get_active_redact() -> bool:
 def start_session(
     name: str = "",
     trace_dir: str = ".agent-traces",
-    redact: bool = False,
+    redact: bool | None = None,
 ) -> str:
     """Start a new trace session. Returns the session ID."""
-    _local.store = TraceStore(trace_dir)
+    _local.store = TraceStore(trace_dir, redact=redact)
     _local.session = SessionMeta(agent_name=name)
-    _local.redact = redact
+    _local.redact = _local.store.redact
     _local.store.create_session(_local.session)
 
     event = TraceEvent(

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -47,7 +47,7 @@ from pathlib import Path
 
 from .models import EventType, SessionMeta, TraceEvent
 from .attribution import collect_attribution
-from .redact import redact_data
+from .redact import redact_data, redact_data_with_status, redaction_enabled
 from .store import TraceStore
 
 # Pending tool calls are tracked in a file so separate hook processes
@@ -79,6 +79,12 @@ def _write_event(store: TraceStore, session_id: str, event: TraceEvent) -> None:
     """Write an event to local store or remote collector, depending on env."""
     endpoint = _get_remote_endpoint()
     if endpoint:
+        if redaction_enabled():
+            event.data, changed = redact_data_with_status(event.data)
+            if changed:
+                if not event.redacted:
+                    sys.stderr.write("agent-strace: redacted secrets from trace event\n")
+                event.redacted = True
         from .server import send_event_to_endpoint
         send_event_to_endpoint(event, endpoint)
     else:
@@ -170,7 +176,10 @@ def _read_stdin() -> dict:
 
 
 def _should_redact() -> bool:
-    return os.environ.get("AGENT_TRACE_REDACT", "").lower() in ("1", "true", "yes")
+    return (
+        redaction_enabled()
+        and os.environ.get("AGENT_TRACE_REDACT", "").lower() in ("1", "true", "yes")
+    )
 
 
 def handle_session_start(input_data: dict) -> None:

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -55,10 +55,14 @@ class TraceEvent:
     data: dict[str, Any] = field(default_factory=dict)
     # SHA-256 hex digest of the previous event's JSON line (empty on first event)
     prev_hash: str = ""
+    # True when secret redaction changed or protected this event before write
+    redacted: bool = False
 
     def to_json(self) -> str:
         d = asdict(self)
         d["event_type"] = self.event_type.value
+        if not d.get("redacted"):
+            d.pop("redacted", None)
         # drop None values
         d = {k: v for k, v in d.items() if v is not None and v != ""}
         return json.dumps(d, separators=(",", ":"))
@@ -93,6 +97,8 @@ class SessionMeta:
     workspace_id: str = ""
     # Attribution (who/what started this session)
     attribution: dict = field(default_factory=dict)
+    # True when secret redaction changed or protected session metadata
+    redacted: bool = False
 
     def to_json(self) -> str:
         d = asdict(self)

--- a/src/agent_trace/redact.py
+++ b/src/agent_trace/redact.py
@@ -1,26 +1,29 @@
 """Secret redaction for trace events.
 
 Scans event data for values that look like secrets (API keys, tokens,
-passwords, connection strings) and replaces them with [REDACTED].
+passwords, connection strings) and replaces them with typed redaction
+markers such as [REDACTED:api-key].
 
 Patterns detected:
   - API keys: sk-*, ghp_*, gho_*, github_pat_*, xoxb-*, xoxp-*,
     AKIA*, key-*, Bearer *, token-*
-  - Passwords: any value for keys containing "password", "secret",
-    "token", "key", "auth", "credential", "api_key", "apikey"
+  - Passwords and credentials in sensitive key names
   - Connection strings: postgres://, mysql://, mongodb://, redis://
-  - Base64-encoded long strings (likely tokens)
-  - AWS access keys, JWT tokens
+  - Private key blocks, basic-auth URLs, AWS access keys, JWT tokens
 
 Works on nested dicts and lists. Redacts values, not keys.
 """
 
 from __future__ import annotations
 
+import os
 import re
+from dataclasses import dataclass
 from typing import Any
 
 REDACTED = "[REDACTED]"
+
+_NO_REDACT_ENV_VARS = ("AGENT_TRACE_NO_REDACT", "AGENT_STRACE_NO_REDACT")
 
 # Keys whose values should always be redacted (case-insensitive)
 SENSITIVE_KEYS = {
@@ -43,44 +46,72 @@ SENSITIVE_KEYS = {
     "connection_string",
     "database_url",
     "db_url",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
 }
 
-# Regex patterns that match secret-looking values
+
+@dataclass(frozen=True)
+class SecretPattern:
+    kind: str
+    pattern: re.Pattern[str]
+
+
+def redaction_marker(kind: str) -> str:
+    """Return a typed redaction marker."""
+    return f"[REDACTED:{kind}]"
+
+
+# Regex patterns that match secret-looking values.
 SECRET_PATTERNS = [
-    # OpenAI
-    re.compile(r"sk-[a-zA-Z0-9]{20,}"),
-    # GitHub tokens
-    re.compile(r"gh[ps]_[a-zA-Z0-9]{36,}"),
-    re.compile(r"github_pat_[a-zA-Z0-9_]{22,}"),
-    # Slack tokens
-    re.compile(r"xox[bpras]-[a-zA-Z0-9\-]{10,}"),
-    # AWS access keys
-    re.compile(r"AKIA[0-9A-Z]{16}"),
-    # Bearer tokens
-    re.compile(r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*"),
-    # Connection strings
-    re.compile(r"(postgres|mysql|mongodb|redis|amqp)://[^\s]+"),
-    # Generic key-* and token-* prefixes
-    re.compile(r"key-[a-zA-Z0-9]{16,}"),
-    re.compile(r"token-[a-zA-Z0-9]{16,}"),
-    # JWT tokens (three base64 segments separated by dots)
-    re.compile(r"eyJ[a-zA-Z0-9_-]{10,}\.eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}"),
-    # Anthropic keys
-    re.compile(r"sk-ant-[a-zA-Z0-9\-]{20,}"),
-    # Generic long hex strings (40+ chars, likely tokens)
-    re.compile(r"[0-9a-f]{40,}"),
+    SecretPattern(
+        "private-key",
+        re.compile(
+            r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+            r"[\s\S]*?"
+            r"-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+        ),
+    ),
+    SecretPattern("anthropic-key", re.compile(r"sk-ant-[a-zA-Z0-9\-]{20,}")),
+    SecretPattern("openai-key", re.compile(r"sk-[a-zA-Z0-9]{20,}")),
+    SecretPattern("github-token", re.compile(r"gh[ps]_[a-zA-Z0-9]{36,}")),
+    SecretPattern("github-token", re.compile(r"github_pat_[a-zA-Z0-9_]{22,}")),
+    SecretPattern("slack-token", re.compile(r"xox[bpras]-[a-zA-Z0-9\-]{10,}")),
+    SecretPattern("aws-access-key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    SecretPattern("bearer-token", re.compile(r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*")),
+    SecretPattern(
+        "connection-string",
+        re.compile(r"(postgres|mysql|mongodb|redis|amqp)://[^\s]+"),
+    ),
+    SecretPattern(
+        "basic-auth",
+        re.compile(r"\b([a-zA-Z][a-zA-Z0-9+.-]*://)([^/\s:@]+:[^/\s@]+)@"),
+    ),
+    SecretPattern("api-key", re.compile(r"key-[a-zA-Z0-9]{16,}")),
+    SecretPattern("token", re.compile(r"token-[a-zA-Z0-9]{16,}")),
+    SecretPattern(
+        "jwt",
+        re.compile(
+            r"eyJ[a-zA-Z0-9_-]{10,}\."
+            r"eyJ[a-zA-Z0-9_-]{10,}\."
+            r"[a-zA-Z0-9_-]{10,}"
+        ),
+    ),
+    SecretPattern("hex-token", re.compile(r"[0-9a-f]{40,}")),
 ]
 
 
 def _is_sensitive_key(key: str) -> bool:
     """Check if a key name suggests its value is a secret."""
-    return key.lower().strip() in SENSITIVE_KEYS
+    normalized = key.lower().strip().replace("-", "_")
+    return normalized in SENSITIVE_KEYS
 
 
 def _contains_secret(value: str) -> bool:
     """Check if a string value matches any secret pattern."""
-    for pattern in SECRET_PATTERNS:
-        if pattern.search(value):
+    for secret in SECRET_PATTERNS:
+        if secret.pattern.search(value):
             return True
     return False
 
@@ -88,12 +119,18 @@ def _contains_secret(value: str) -> bool:
 def redact_value(value: str) -> str:
     """Redact secrets from a string value.
 
-    Replaces matched patterns with [REDACTED] inline.
-    If the entire string is a secret, returns [REDACTED].
+    Replaces matched patterns with typed redaction markers inline.
     """
     redacted = value
-    for pattern in SECRET_PATTERNS:
-        redacted = pattern.sub(REDACTED, redacted)
+    for secret in SECRET_PATTERNS:
+        marker = redaction_marker(secret.kind)
+        if secret.kind == "basic-auth":
+            redacted = secret.pattern.sub(
+                lambda m: f"{m.group(1)}{marker}@",
+                redacted,
+            )
+        else:
+            redacted = secret.pattern.sub(marker, redacted)
     return redacted
 
 
@@ -106,7 +143,7 @@ def redact_data(data: Any, parent_key: str = "") -> Any:
         result = {}
         for k, v in data.items():
             if isinstance(v, str) and _is_sensitive_key(k):
-                result[k] = REDACTED
+                result[k] = redaction_marker("sensitive")
             else:
                 result[k] = redact_data(v, parent_key=k)
         return result
@@ -116,9 +153,34 @@ def redact_data(data: Any, parent_key: str = "") -> Any:
 
     if isinstance(data, str):
         if _is_sensitive_key(parent_key):
-            return REDACTED
+            return redaction_marker("sensitive")
         if _contains_secret(data):
             return redact_value(data)
         return data
 
     return data
+
+
+def contains_redaction_marker(data: Any) -> bool:
+    """Return True when data contains an existing redaction marker."""
+    if isinstance(data, dict):
+        return any(contains_redaction_marker(v) for v in data.values())
+    if isinstance(data, list):
+        return any(contains_redaction_marker(item) for item in data)
+    if isinstance(data, str):
+        return "[REDACTED" in data
+    return False
+
+
+def redact_data_with_status(data: Any) -> tuple[Any, bool]:
+    """Return redacted data and whether redaction is present."""
+    redacted = redact_data(data)
+    return redacted, redacted != data or contains_redaction_marker(redacted)
+
+
+def redaction_enabled(default: bool = True) -> bool:
+    """Return whether automatic secret redaction should run."""
+    for name in _NO_REDACT_ENV_VARS:
+        if os.environ.get(name, "").lower() in ("1", "true", "yes"):
+            return False
+    return default

--- a/src/agent_trace/store.py
+++ b/src/agent_trace/store.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 from .models import EventType, SessionMeta, TraceEvent
+from .redact import redact_data_with_status, redaction_enabled
 
 DEFAULT_TRACE_DIR = ".agent-traces"
 
@@ -38,8 +40,12 @@ def _workspace_base(base_dir: str | Path, workspace_id: str) -> Path:
 
 
 class TraceStore:
-    def __init__(self, base_dir: str | Path = DEFAULT_TRACE_DIR,
-                 workspace_id: str = ""):
+    def __init__(
+        self,
+        base_dir: str | Path = DEFAULT_TRACE_DIR,
+        workspace_id: str = "",
+        redact: bool | None = None,
+    ):
         """Create a TraceStore.
 
         workspace_id scopes all reads/writes to a subdirectory:
@@ -55,6 +61,37 @@ class TraceStore:
         else:
             self.base_dir = Path(base_dir)
             self.workspace_id = ""
+        self.redact = redaction_enabled() if redact is None else redact
+
+    def _warn_redacted(self, item: str) -> None:
+        sys.stderr.write(f"agent-strace: redacted secrets from {item}\n")
+
+    def _redact_event(self, event: TraceEvent) -> None:
+        if not self.redact:
+            return
+        redacted_data, changed = redact_data_with_status(event.data)
+        if changed:
+            event.data = redacted_data
+            if not event.redacted:
+                self._warn_redacted("trace event")
+            event.redacted = True
+
+    def _redact_meta(self, meta: SessionMeta) -> None:
+        if not self.redact:
+            return
+        redacted, changed = redact_data_with_status({
+            "agent_name": meta.agent_name,
+            "command": meta.command,
+            "attribution": meta.attribution,
+        })
+        if changed:
+            already_redacted = meta.redacted
+            meta.agent_name = redacted.get("agent_name", meta.agent_name)
+            meta.command = redacted.get("command", meta.command)
+            meta.attribution = redacted.get("attribution", meta.attribution)
+            meta.redacted = True
+            if not already_redacted:
+                self._warn_redacted("session metadata")
 
     def _session_dir(self, session_id: str) -> Path:
         return self.base_dir / session_id
@@ -63,6 +100,7 @@ class TraceStore:
         # Stamp workspace_id onto meta so it's visible in exports/reports
         if self.workspace_id and not getattr(meta, "workspace_id", ""):
             meta.workspace_id = self.workspace_id
+        self._redact_meta(meta)
         d = self._session_dir(meta.session_id)
         d.mkdir(parents=True, exist_ok=True)
         (d / "meta.json").write_text(meta.to_json())
@@ -72,6 +110,7 @@ class TraceStore:
 
     def append_event(self, session_id: str, event: TraceEvent) -> None:
         f = self._session_dir(session_id) / "events.ndjson"
+        self._redact_event(event)
         # Compute hash chain: SHA-256 of the last line in the file
         if not event.prev_hash:
             try:
@@ -86,6 +125,7 @@ class TraceStore:
 
     def update_meta(self, meta: SessionMeta) -> None:
         f = self._session_dir(meta.session_id) / "meta.json"
+        self._redact_meta(meta)
         f.write_text(meta.to_json())
 
     def load_meta(self, session_id: str) -> SessionMeta:

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -6,47 +6,56 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from agent_trace.redact import REDACTED, redact_data, redact_value
+from agent_trace.redact import redact_data, redact_data_with_status, redact_value, redaction_marker
 
 
 class TestRedactValue(unittest.TestCase):
     def test_openai_key(self):
         result = redact_value("sk-abc123def456ghi789jkl012mno345pqr678")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("openai-key"))
 
     def test_github_token(self):
         result = redact_value("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("github-token"))
 
     def test_github_pat(self):
         result = redact_value("github_pat_ABCDEFGHIJKLMNOPQRSTUV_1234567890")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("github-token"))
 
     def test_aws_key(self):
         result = redact_value("AKIAIOSFODNN7EXAMPLE")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("aws-access-key"))
 
     def test_bearer_token(self):
         result = redact_value("Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test")
-        self.assertIn(REDACTED, result)
+        self.assertIn(redaction_marker("bearer-token"), result)
 
     def test_connection_string(self):
         result = redact_value("postgres://user:pass@host:5432/db")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("connection-string"))
 
     def test_jwt(self):
         jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
         result = redact_value(jwt)
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("jwt"))
 
     def test_anthropic_key(self):
         result = redact_value("sk-ant-api03-abcdefghijklmnopqrstuvwxyz")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("anthropic-key"))
 
     def test_slack_token(self):
         # Use a clearly fake token that still matches the xox[bpras]-... pattern
         result = redact_value("xoxb-fake-test-token-value")
-        self.assertEqual(result, REDACTED)
+        self.assertEqual(result, redaction_marker("slack-token"))
+
+    def test_private_key(self):
+        key = "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----"
+        result = redact_value(key)
+        self.assertEqual(result, redaction_marker("private-key"))
+
+    def test_basic_auth_url(self):
+        result = redact_value("https://alice:secret@example.com/path")
+        self.assertEqual(result, f"https://{redaction_marker('basic-auth')}@example.com/path")
 
     def test_safe_string_unchanged(self):
         result = redact_value("hello world")
@@ -58,7 +67,7 @@ class TestRedactValue(unittest.TestCase):
 
     def test_inline_redaction(self):
         result = redact_value("Authorization: Bearer sk-abc123def456ghi789jkl012mno345pqr678")
-        self.assertIn(REDACTED, result)
+        self.assertIn("[REDACTED:", result)
         self.assertNotIn("sk-abc", result)
 
 
@@ -67,17 +76,17 @@ class TestRedactData(unittest.TestCase):
         data = {"username": "alice", "password": "secret123"}
         result = redact_data(data)
         self.assertEqual(result["username"], "alice")
-        self.assertEqual(result["password"], REDACTED)
+        self.assertEqual(result["password"], redaction_marker("sensitive"))
 
     def test_redact_api_key(self):
         data = {"api_key": "sk-abc123def456ghi789jkl012mno345pqr678"}
         result = redact_data(data)
-        self.assertEqual(result["api_key"], REDACTED)
+        self.assertEqual(result["api_key"], redaction_marker("sensitive"))
 
     def test_redact_token_key(self):
         data = {"token": "some-secret-value", "name": "test"}
         result = redact_data(data)
-        self.assertEqual(result["token"], REDACTED)
+        self.assertEqual(result["token"], redaction_marker("sensitive"))
         self.assertEqual(result["name"], "test")
 
     def test_redact_nested_dict(self):
@@ -88,7 +97,7 @@ class TestRedactData(unittest.TestCase):
             }
         }
         result = redact_data(data)
-        self.assertEqual(result["config"]["database_url"], REDACTED)
+        self.assertEqual(result["config"]["database_url"], redaction_marker("sensitive"))
         self.assertEqual(result["config"]["name"], "myapp")
 
     def test_redact_list_values(self):
@@ -109,7 +118,7 @@ class TestRedactData(unittest.TestCase):
             }
         }
         result = redact_data(data)
-        self.assertEqual(result["arguments"]["url"], REDACTED)
+        self.assertEqual(result["arguments"]["url"], redaction_marker("connection-string"))
         self.assertEqual(result["arguments"]["query"], "SELECT * FROM users")
 
     def test_non_string_values_unchanged(self):
@@ -127,7 +136,13 @@ class TestRedactData(unittest.TestCase):
         # keys are checked lowercase
         result = redact_data(data)
         # "Password" lowered is "password" which is in SENSITIVE_KEYS
-        self.assertEqual(result["Password"], REDACTED)
+        self.assertEqual(result["Password"], redaction_marker("sensitive"))
+
+    def test_aws_env_var_key_names(self):
+        data = {"AWS_SECRET_ACCESS_KEY": "secret", "AWS_SESSION_TOKEN": "token"}
+        result = redact_data(data)
+        self.assertEqual(result["AWS_SECRET_ACCESS_KEY"], redaction_marker("sensitive"))
+        self.assertEqual(result["AWS_SESSION_TOKEN"], redaction_marker("sensitive"))
 
     def test_tool_call_with_secrets(self):
         """Simulate a real tool call event data with secrets."""
@@ -145,8 +160,14 @@ class TestRedactData(unittest.TestCase):
         result = redact_data(data)
         self.assertEqual(result["tool_name"], "http_request")
         self.assertEqual(result["arguments"]["url"], "https://api.example.com/data")
-        self.assertIn(REDACTED, result["arguments"]["headers"]["Authorization"])
-        self.assertEqual(result["arguments"]["api_key"], REDACTED)
+        self.assertIn("[REDACTED:", result["arguments"]["headers"]["Authorization"])
+        self.assertEqual(result["arguments"]["api_key"], redaction_marker("sensitive"))
+
+    def test_redact_data_with_status(self):
+        data = {"text": "hello sk-abc123def456ghi789jkl012mno345pqr678"}
+        result, changed = redact_data_with_status(data)
+        self.assertTrue(changed)
+        self.assertNotIn("sk-abc123", str(result))
 
 
 if __name__ == "__main__":

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,8 +13,12 @@ from agent_trace.store import TraceStore
 
 class TestTraceStore(unittest.TestCase):
     def setUp(self):
+        os.environ.pop("AGENT_TRACE_NO_REDACT", None)
         self.tmpdir = tempfile.mkdtemp()
         self.store = TraceStore(self.tmpdir)
+
+    def tearDown(self):
+        os.environ.pop("AGENT_TRACE_NO_REDACT", None)
 
     def test_create_and_load_session(self):
         meta = SessionMeta(agent_name="test-agent")
@@ -150,6 +154,74 @@ class TestTraceStore(unittest.TestCase):
 
         events = self.store.load_events(meta.session_id)
         self.assertEqual(events, [])
+
+    def test_append_event_redacts_secrets_by_default(self):
+        meta = SessionMeta()
+        self.store.create_session(meta)
+
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=meta.session_id,
+            data={
+                "tool_name": "http_request",
+                "arguments": {
+                    "headers": {
+                        "Authorization": "Bearer sk-abc123def456ghi789jkl012mno345pqr678",
+                    },
+                },
+            },
+        )
+
+        self.store.append_event(meta.session_id, event)
+
+        events = self.store.load_events(meta.session_id)
+        self.assertTrue(events[0].redacted)
+        self.assertNotIn("sk-abc123", str(events[0].data))
+        self.assertIn("[REDACTED:", str(events[0].data))
+
+    def test_append_event_allows_redaction_opt_out(self):
+        store = TraceStore(self.tmpdir, redact=False)
+        meta = SessionMeta()
+        store.create_session(meta)
+
+        event = TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            session_id=meta.session_id,
+            data={"prompt": "use sk-abc123def456ghi789jkl012mno345pqr678"},
+        )
+        store.append_event(meta.session_id, event)
+
+        events = store.load_events(meta.session_id)
+        self.assertFalse(events[0].redacted)
+        self.assertIn("sk-abc123", str(events[0].data))
+
+    def test_append_event_respects_no_redact_env(self):
+        os.environ["AGENT_TRACE_NO_REDACT"] = "1"
+        store = TraceStore(self.tmpdir)
+        meta = SessionMeta()
+        store.create_session(meta)
+
+        event = TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            session_id=meta.session_id,
+            data={"prompt": "use sk-abc123def456ghi789jkl012mno345pqr678"},
+        )
+        store.append_event(meta.session_id, event)
+
+        events = store.load_events(meta.session_id)
+        self.assertFalse(events[0].redacted)
+        self.assertIn("sk-abc123", str(events[0].data))
+
+    def test_create_session_redacts_metadata_by_default(self):
+        meta = SessionMeta(
+            agent_name="test-agent",
+            command="run --api-key sk-abc123def456ghi789jkl012mno345pqr678",
+        )
+        self.store.create_session(meta)
+
+        loaded = self.store.load_meta(meta.session_id)
+        self.assertTrue(loaded.redacted)
+        self.assertNotIn("sk-abc123", loaded.command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #176.

- moves secret redaction to the trace storage boundary so trace events and session metadata are scrubbed before disk writes by default
- adds `--no-redact` and `AGENT_TRACE_NO_REDACT` / `AGENT_STRACE_NO_REDACT` opt-outs while keeping `--redact` as a compatibility flag
- adds typed redaction markers and `redacted: true` audit markers on protected events/metadata
- expands stdlib-only patterns for private keys, basic-auth URLs, AWS credential key names, and existing token/key formats
- updates setup, command, security docs, README, and bumps version to `0.65.0`

## Prioritization

I reviewed the open issues and prioritized #176 first because it is security-labeled, independent, and reduces credential leakage risk across all capture paths without adding dependencies or changing existing session storage semantics beyond additive fields.

## Verification

- `python3 -m pytest tests/test_redact.py tests/test_store.py tests/test_hooks.py tests/test_decorator.py -v`
- `python3 -m pytest tests/ -v` (`1493 passed`)
- `git diff --check`