### PR TITLE
feat: add OpenAI Codex hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ uvx agent-strace replay
 
 ## Quick start
 
-**Option 1: Claude Code hooks** — captures everything (prompts, responses, every tool call)
+**Option 1: CLI hooks** — captures prompts, responses, and hook-visible tool calls
 
 ```bash
-agent-strace setup   # prints hooks config — add to ~/.claude/settings.json
-agent-strace list    # list sessions
-agent-strace replay  # replay the latest
+agent-strace setup             # Claude Code hooks for ~/.claude/settings.json
+agent-strace setup --cli codex # OpenAI Codex hooks for ~/.codex/hooks.json
+agent-strace list              # list sessions
+agent-strace replay            # replay the latest
 ```
 
 Full config and JSON: [docs/setup.md](docs/setup.md)
@@ -138,7 +139,7 @@ Install **agent-strace** from the [Extensions panel](https://open-vsx.org/extens
 
 ```bash
 pip install agent-strace   # 1. install
-agent-strace setup         # 2. add hooks to Claude Code
+agent-strace setup         # 2. add hooks to Claude Code or use --cli codex for Codex
 # 3. open project in VS Code — extension activates when .agent-traces/ exists
 # 4. start Claude Code — status bar appears immediately
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,9 +27,9 @@ Capture an MCP HTTP/SSE server session. Listens on `--port` (default: 3100) and 
 
 ### `setup`
 ```
-agent-strace setup [--no-redact] [--global]
+agent-strace setup [--cli claude|codex|all] [--no-redact] [--global]
 ```
-Print Claude Code hooks config JSON for `~/.claude/settings.json`. Use `--global` to scope hooks to all projects (default scopes to the current project). Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
+Print hooks config JSON for supported agent CLIs. `--cli claude` prints Claude Code settings JSON for `~/.claude/settings.json`; `--cli codex` prints OpenAI Codex hooks JSON for `~/.codex/hooks.json`; `--cli all` prints both. Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
 
 ### `import`
 ```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -48,6 +48,19 @@ Each integration is an optional extra — the core package stays dependency-free
 
 ---
 
+## Agent CLI hooks
+
+Use setup-generated hooks when the agent CLI has its own lifecycle hook system.
+
+| CLI | Setup | What's traced |
+|---|---|---|
+| Claude Code | `agent-strace setup --cli claude` | Session start/end, user prompts, assistant responses, tool calls/results |
+| OpenAI Codex | `agent-strace setup --cli codex` | Session start, user prompts, assistant responses, `PreToolUse`/`PostToolUse` tools |
+
+Both paths write the same event stream under `.agent-traces/`, so replay, timeline, explain, why, watch, export, and audit commands work the same way after capture.
+
+---
+
 ## OpenAI Agents SDK
 
 ```python

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,13 +4,19 @@ Three ways to capture agent sessions. Pick the one that matches your agent.
 
 ---
 
-## Option 1: Claude Code hooks (recommended)
+## Option 1: CLI hooks (recommended)
 
 Captures everything: user prompts, assistant responses, and every tool call (Bash, Edit, Write, Read, Agent, Grep, Glob, WebFetch, WebSearch, all MCP tools).
 
 ```bash
-# Generate and apply hooks config
+# Generate Claude Code hooks config
 agent-strace setup
+
+# Generate OpenAI Codex hooks config
+agent-strace setup --cli codex
+
+# Generate both hook configs
+agent-strace setup --cli all
 
 # For all projects (global config)
 agent-strace setup --global
@@ -42,6 +48,24 @@ agent-strace list     # list sessions
 agent-strace replay   # replay the latest
 agent-strace explain  # plain-English summary
 ```
+
+### OpenAI Codex hooks
+
+`agent-strace setup --cli codex` prints hooks JSON for `~/.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{ "matcher": "startup|resume|clear|compact", "hooks": [{ "type": "command", "command": "agent-strace hook --provider codex session-start" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "agent-strace hook --provider codex user-prompt" }] }],
+    "PreToolUse": [{ "matcher": ".*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider codex pre-tool" }] }],
+    "PostToolUse": [{ "matcher": ".*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider codex post-tool" }] }],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "agent-strace hook --provider codex stop" }] }]
+  }
+}
+```
+
+Codex sends one JSON object to each command hook on stdin. agent-strace records the common Codex fields (`session_id`, `turn_id`, `tool_use_id`, `tool_name`, `tool_input`, `tool_response`, `prompt`, and `last_assistant_message`) into the same `.agent-traces/` session store used by Claude Code.
 
 ### Import existing sessions
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.66.0"
+__version__ = "0.67.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -450,16 +450,18 @@ def cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_setup(args: argparse.Namespace) -> None:
-    """Generate Claude Code hooks configuration."""
+def _hook_command_prefix(args: argparse.Namespace, provider: str = "claude") -> str:
     redact_env = ""
     if args.no_redact:
         redact_env = "AGENT_TRACE_NO_REDACT=1 "
     elif args.redact:
         redact_env = "AGENT_TRACE_REDACT=1 "
+    provider_arg = "" if provider == "claude" else f"--provider {provider} "
+    return f"{redact_env}agent-strace hook {provider_arg}".rstrip()
 
-    cmd_prefix = f"{redact_env}agent-strace hook"
 
+def _claude_hooks_config(args: argparse.Namespace) -> dict:
+    cmd_prefix = _hook_command_prefix(args, provider="claude")
     config = {
         "hooks": {
             "UserPromptSubmit": [{
@@ -488,16 +490,69 @@ def cmd_setup(args: argparse.Namespace) -> None:
             }],
         }
     }
+    return config
 
-    output = json.dumps(config, indent=2)
 
-    sys.stderr.write("Add this to ~/.claude/settings.json:\n\n")
+def _codex_hooks_config(args: argparse.Namespace) -> dict:
+    cmd_prefix = _hook_command_prefix(args, provider="codex")
+    return {
+        "hooks": {
+            "SessionStart": [{
+                "matcher": "startup|resume|clear|compact",
+                "hooks": [{
+                    "type": "command",
+                    "command": f"{cmd_prefix} session-start",
+                }],
+            }],
+            "UserPromptSubmit": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": f"{cmd_prefix} user-prompt",
+                }],
+            }],
+            "PreToolUse": [{
+                "matcher": ".*",
+                "hooks": [{
+                    "type": "command",
+                    "command": f"{cmd_prefix} pre-tool",
+                }],
+            }],
+            "PostToolUse": [{
+                "matcher": ".*",
+                "hooks": [{
+                    "type": "command",
+                    "command": f"{cmd_prefix} post-tool",
+                }],
+            }],
+            "Stop": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": f"{cmd_prefix} stop",
+                }],
+            }],
+        }
+    }
 
-    sys.stdout.write(output + "\n")
+
+def cmd_setup(args: argparse.Namespace) -> None:
+    """Generate hooks configuration for supported agent CLIs."""
+    cli = getattr(args, "cli", "claude") or "claude"
+
+    configs: list[tuple[str, str, dict]] = []
+    if cli in ("claude", "all"):
+        configs.append(("Claude Code", "~/.claude/settings.json", _claude_hooks_config(args)))
+    if cli in ("codex", "all"):
+        configs.append(("OpenAI Codex", "~/.codex/hooks.json", _codex_hooks_config(args)))
+
+    for idx, (name, path, config) in enumerate(configs):
+        if idx:
+            sys.stdout.write("\n")
+        sys.stderr.write(f"Add this to {path} for {name}:\n\n")
+        sys.stdout.write(json.dumps(config, indent=2) + "\n")
+
     sys.stderr.write(
-        "\nThis captures the full Claude Code session: user prompts, "
-        "assistant responses, and every tool call (Bash, Edit, Write, "
-        "Read, Agent, and all MCP tools).\n"
+        "\nThis captures full agent sessions: user prompts, assistant "
+        "responses, and hook-visible tool calls.\n"
         "Replay with: agent-strace replay\n"
     )
 
@@ -622,12 +677,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_stats.add_argument("--include-subagents", action="store_true",
                          help="roll up stats across all subagent sessions")
 
-    # hook (called by Claude Code hooks system)
-    p_hook = sub.add_parser("hook", help="handle a Claude Code hook event (internal)")
+    # hook (called by agent CLI hooks systems)
+    p_hook = sub.add_parser("hook", help="handle an agent CLI hook event (internal)")
+    p_hook.add_argument("--provider", choices=["claude", "codex"], default="claude",
+                        help="hook provider (default: claude)")
     p_hook.add_argument("event", nargs="?", help="hook event: session-start, session-end, pre-tool, post-tool, post-tool-failure")
 
-    # setup (generate Claude Code hooks config)
-    p_setup = sub.add_parser("setup", help="generate Claude Code hooks configuration")
+    # setup (generate agent CLI hooks config)
+    p_setup = sub.add_parser("setup", help="generate agent CLI hooks configuration")
     setup_redaction = p_setup.add_mutually_exclusive_group()
     setup_redaction.add_argument(
         "--redact",
@@ -640,6 +697,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="disable automatic secret redaction in generated hooks",
     )
     p_setup.add_argument("--global", dest="global_config", action="store_true", help="output config for ~/.claude/settings.json (all projects)")
+    p_setup.add_argument("--cli", choices=["claude", "codex", "all"], default="claude",
+                         help="agent CLI to configure (default: claude)")
 
     # import (Claude Code JSONL session logs)
     p_import = sub.add_parser("import", help="import a Claude Code JSONL session log")
@@ -1332,7 +1391,10 @@ def main() -> None:
 
     # hook subcommand is handled separately (reads stdin)
     if args.command == "hook":
-        hook_main([args.event] if args.event else [])
+        hook_args = ["--provider", getattr(args, "provider", "claude")]
+        if args.event:
+            hook_args.append(args.event)
+        hook_main(hook_args)
         sys.exit(0)
 
     if args.command == "setup":

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -1,8 +1,8 @@
-"""Claude Code hooks integration.
+"""Agent CLI hooks integration.
 
-Captures every tool call Claude Code makes — not just MCP calls.
-Uses Claude Code's hooks system (PreToolUse, PostToolUse, SessionStart,
-SessionEnd) to trace Bash, Edit, Write, Read, Agent, and all other tools.
+Captures every tool call supported CLIs make, not just MCP calls. Uses the
+Claude Code and OpenAI Codex hooks systems to trace Bash, Edit, Write, Read,
+Agent, apply_patch, and all other hook-visible tools.
 
 Usage:
     # In .claude/settings.json or ~/.claude/settings.json:
@@ -60,6 +60,17 @@ _PENDING_FILE = ".pending-calls.json"
 # session ID passed in the SessionStart payload.  This prevents concurrent
 # agents sharing the same AGENT_TRACE_DIR from corrupting each other.
 _CLAUDE_SESSION_ID_ENV = "AGENT_TRACE_CLAUDE_SESSION_ID"
+_CODEX_SESSION_ID_ENV = "AGENT_TRACE_CODEX_SESSION_ID"
+
+_PROVIDER_ENV = {
+    "claude": _CLAUDE_SESSION_ID_ENV,
+    "codex": _CODEX_SESSION_ID_ENV,
+}
+
+_PROVIDER_AGENT = {
+    "claude": "claude-code",
+    "codex": "openai-codex",
+}
 
 
 def _get_store_dir() -> str:
@@ -91,34 +102,38 @@ def _write_event(store: TraceStore, session_id: str, event: TraceEvent) -> None:
         store.append_event(session_id, event)
 
 
-def _state_suffix() -> str:
-    """Return a filename suffix scoped to the current Claude Code session.
+def _provider_env(provider: str = "claude") -> str:
+    return _PROVIDER_ENV.get(provider, _CLAUDE_SESSION_ID_ENV)
 
-    Claude Code sets AGENT_TRACE_CLAUDE_SESSION_ID (written by handle_session_start).
-    Using it as a suffix isolates concurrent agents that share AGENT_TRACE_DIR.
+
+def _state_suffix(provider: str = "claude") -> str:
+    """Return a filename suffix scoped to the current hook provider session.
+
+    Providers pass session_id on every hook payload. handle_session_start also
+    sets a provider-specific env var for same-process tests and manual use.
     """
-    sid = os.environ.get(_CLAUDE_SESSION_ID_ENV, "")
+    sid = os.environ.get(_provider_env(provider), "")
     return f".{sid}" if sid else ""
 
 
-def _active_session_path() -> Path:
-    return Path(_get_store_dir()) / f".active-session{_state_suffix()}"
+def _active_session_path(provider: str = "claude") -> Path:
+    return Path(_get_store_dir()) / f".active-session{_state_suffix(provider)}"
 
 
-def _pending_calls_path() -> Path:
-    suffix = _state_suffix()
+def _pending_calls_path(provider: str = "claude") -> Path:
+    suffix = _state_suffix(provider)
     name = _PENDING_FILE.replace(".json", f"{suffix}.json")
     return Path(_get_store_dir()) / name
 
 
-def _read_active_session() -> str | None:
-    path = _active_session_path()
+def _read_active_session(provider: str = "claude") -> str | None:
+    path = _active_session_path(provider)
     if path.exists():
         return path.read_text().strip()
     return None
 
 
-def _resolve_session_id(input_data: dict) -> str | None:
+def _resolve_session_id(input_data: dict, provider: str = "claude") -> str | None:
     """Return the agent-trace session ID for this hook invocation.
 
     Claude Code passes session_id in every hook payload. We derive our
@@ -133,23 +148,23 @@ def _resolve_session_id(input_data: dict) -> str | None:
     raw = input_data.get("session_id", "")
     if raw:
         return raw[:16]
-    return _read_active_session()
+    return _read_active_session(provider)
 
 
-def _write_active_session(session_id: str) -> None:
-    path = _active_session_path()
+def _write_active_session(session_id: str, provider: str = "claude") -> None:
+    path = _active_session_path(provider)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(session_id)
 
 
-def _clear_active_session() -> None:
-    path = _active_session_path()
+def _clear_active_session(provider: str = "claude") -> None:
+    path = _active_session_path(provider)
     if path.exists():
         path.unlink()
 
 
-def _read_pending_calls() -> dict:
-    path = _pending_calls_path()
+def _read_pending_calls(provider: str = "claude") -> dict:
+    path = _pending_calls_path(provider)
     if path.exists():
         try:
             return json.loads(path.read_text())
@@ -158,8 +173,8 @@ def _read_pending_calls() -> dict:
     return {}
 
 
-def _write_pending_calls(calls: dict) -> None:
-    path = _pending_calls_path()
+def _write_pending_calls(calls: dict, provider: str = "claude") -> None:
+    path = _pending_calls_path(provider)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(calls))
 
@@ -182,16 +197,38 @@ def _should_redact() -> bool:
     )
 
 
-def handle_session_start(input_data: dict) -> None:
+def _normalise_payload(input_data: dict, provider: str, event: str) -> dict:
+    """Map provider-specific hook payloads to the Claude-shaped fields."""
+    data = dict(input_data)
+    if provider != "codex":
+        return data
+
+    if event in {"pre-tool", "post-tool", "post-tool-failure"}:
+        tool = data.get("tool")
+        if isinstance(tool, dict):
+            data.setdefault("tool_name", tool.get("name") or tool.get("tool_name") or "")
+            data.setdefault("tool_input", tool.get("input") or tool.get("arguments") or {})
+            data.setdefault("tool_output", tool.get("output") or tool.get("response") or "")
+        data.setdefault("tool_input", data.get("input") or data.get("arguments") or {})
+        data.setdefault("tool_output", data.get("tool_response", data.get("output", "")))
+
+    if event == "stop" and data.get("last_assistant_message") is None:
+        data["last_assistant_message"] = data.get("assistant_message") or data.get("message") or ""
+
+    return data
+
+
+def handle_session_start(input_data: dict, provider: str = "claude") -> None:
     """Handle SessionStart hook event."""
     store = _get_store()
     redact = _should_redact()
 
     session_id = input_data.get("session_id", "")
+    agent_name = _PROVIDER_AGENT.get(provider, "agent-cli")
     attr = collect_attribution()
     meta = SessionMeta(
-        agent_name="claude-code",
-        command=f"claude-code ({input_data.get('source', 'startup')})",
+        agent_name=agent_name,
+        command=f"{agent_name} ({input_data.get('source', 'startup')})",
         attribution=attr.to_dict(),
     )
     # Use Claude Code's session ID as part of our session ID for correlation
@@ -201,16 +238,20 @@ def handle_session_start(input_data: dict) -> None:
     store.create_session(meta)
 
     if session_id:
-        os.environ[_CLAUDE_SESSION_ID_ENV] = session_id
+        os.environ[_provider_env(provider)] = session_id
 
-    _write_active_session(meta.session_id)
-    _write_pending_calls({})
+    _write_active_session(meta.session_id, provider=provider)
+    _write_pending_calls({}, provider=provider)
 
     event_data = {
-        "mode": "claude-code-hooks",
+        "mode": f"{agent_name}-hooks",
+        "provider": provider,
         "source": input_data.get("source", "startup"),
         "model": input_data.get("model", ""),
     }
+    for key in ("cwd", "transcript_path", "permission_mode"):
+        if input_data.get(key) not in (None, ""):
+            event_data[key] = input_data.get(key)
     if redact:
         event_data = redact_data(event_data)
 
@@ -224,10 +265,10 @@ def handle_session_start(input_data: dict) -> None:
     )
 
 
-def handle_session_end(input_data: dict) -> None:
+def handle_session_end(input_data: dict, provider: str = "claude") -> None:
     """Handle SessionEnd hook event."""
     store = _get_store()
-    session_id = _resolve_session_id(input_data)
+    session_id = _resolve_session_id(input_data, provider=provider)
     if not session_id:
         return
 
@@ -246,13 +287,13 @@ def handle_session_end(input_data: dict) -> None:
         )
         store.update_meta(meta)
 
-    _clear_active_session()
+    _clear_active_session(provider=provider)
 
 
-def handle_pre_tool(input_data: dict) -> None:
+def handle_pre_tool(input_data: dict, provider: str = "claude") -> None:
     """Handle PreToolUse hook event. Logs tool_call and tracks pending calls."""
     store = _get_store()
-    session_id = _resolve_session_id(input_data)
+    session_id = _resolve_session_id(input_data, provider=provider)
     if not session_id:
         return
 
@@ -264,6 +305,9 @@ def handle_pre_tool(input_data: dict) -> None:
         "tool_name": tool_name,
         "arguments": tool_input,
     }
+    for key in ("tool_use_id", "turn_id", "permission_mode"):
+        if input_data.get(key) not in (None, ""):
+            event_data[key] = input_data.get(key)
     if redact:
         event_data = redact_data(event_data)
 
@@ -283,18 +327,19 @@ def handle_pre_tool(input_data: dict) -> None:
     # Track pending call for latency measurement.
     # Keyed by event_id (not tool_name) so concurrent calls to the same
     # tool don't overwrite each other.
-    pending = _read_pending_calls()
+    pending = _read_pending_calls(provider=provider)
     pending[event.event_id] = {
         "tool_name": tool_name,
+        "tool_use_id": input_data.get("tool_use_id", ""),
         "timestamp": event.timestamp,
     }
-    _write_pending_calls(pending)
+    _write_pending_calls(pending, provider=provider)
 
 
-def handle_user_prompt(input_data: dict) -> None:
+def handle_user_prompt(input_data: dict, provider: str = "claude") -> None:
     """Handle UserPromptSubmit hook event. Logs the user's prompt."""
     store = _get_store()
-    session_id = _resolve_session_id(input_data)
+    session_id = _resolve_session_id(input_data, provider=provider)
     if not session_id:
         return
 
@@ -302,6 +347,9 @@ def handle_user_prompt(input_data: dict) -> None:
     prompt = input_data.get("prompt", "")
 
     event_data = {"prompt": prompt}
+    for key in ("turn_id", "permission_mode"):
+        if input_data.get(key) not in (None, ""):
+            event_data[key] = input_data.get(key)
     if redact:
         event_data = redact_data(event_data)
 
@@ -315,10 +363,10 @@ def handle_user_prompt(input_data: dict) -> None:
     )
 
 
-def handle_stop(input_data: dict) -> None:
+def handle_stop(input_data: dict, provider: str = "claude") -> None:
     """Handle Stop hook event. Logs the assistant's final response."""
     store = _get_store()
-    session_id = _resolve_session_id(input_data)
+    session_id = _resolve_session_id(input_data, provider=provider)
     if not session_id:
         return
 
@@ -333,6 +381,9 @@ def handle_stop(input_data: dict) -> None:
         return
 
     event_data = {"text": text}
+    for key in ("turn_id", "permission_mode"):
+        if input_data.get(key) not in (None, ""):
+            event_data[key] = input_data.get(key)
     if redact:
         event_data = redact_data(event_data)
 
@@ -346,16 +397,25 @@ def handle_stop(input_data: dict) -> None:
     )
 
 
-def handle_post_tool(input_data: dict, failed: bool = False) -> None:
+def handle_post_tool(input_data: dict, failed: bool = False, provider: str = "claude") -> None:
     """Handle PostToolUse / PostToolUseFailure hook event."""
     store = _get_store()
-    session_id = _resolve_session_id(input_data)
+    session_id = _resolve_session_id(input_data, provider=provider)
     if not session_id:
         return
 
     redact = _should_redact()
     tool_name = input_data.get("tool_name", "unknown")
-    tool_output = input_data.get("tool_output", "")
+    tool_output = input_data.get("tool_output", input_data.get("tool_response", ""))
+
+    if provider == "codex" and not failed:
+        if isinstance(tool_output, dict):
+            exit_code = tool_output.get("exit_code")
+            failed = (
+                bool(tool_output.get("error"))
+                or tool_output.get("success") is False
+                or (isinstance(exit_code, int) and exit_code != 0)
+            )
 
     if failed:
         event_type = EventType.ERROR
@@ -374,6 +434,9 @@ def handle_post_tool(input_data: dict, failed: bool = False) -> None:
             "tool_name": tool_name,
             "result": output_str,
         }
+    for key in ("tool_use_id", "turn_id", "permission_mode"):
+        if input_data.get(key) not in (None, ""):
+            event_data[key] = input_data.get(key)
 
     if redact:
         event_data = redact_data(event_data)
@@ -387,18 +450,22 @@ def handle_post_tool(input_data: dict, failed: bool = False) -> None:
     # Link to the earliest pending call for this tool name, then remove it.
     # Pending entries are keyed by event_id so concurrent same-tool calls
     # don't collide; we match by tool_name in the value and pick the oldest.
-    pending = _read_pending_calls()
+    pending = _read_pending_calls(provider=provider)
     match_id = None
     match_ts = float("inf")
+    tool_use_id = input_data.get("tool_use_id", "")
     for eid, info in pending.items():
-        if info.get("tool_name") == tool_name and info["timestamp"] < match_ts:
+        if tool_use_id and info.get("tool_use_id") == tool_use_id:
+            match_id = eid
+            break
+        if not tool_use_id and info.get("tool_name") == tool_name and info["timestamp"] < match_ts:
             match_id = eid
             match_ts = info["timestamp"]
     if match_id:
         call_info = pending.pop(match_id)
         event.parent_id = match_id
         event.duration_ms = (event.timestamp - call_info["timestamp"]) * 1000
-        _write_pending_calls(pending)
+        _write_pending_calls(pending, provider=provider)
 
     _write_event(store, session_id, event)
 
@@ -412,22 +479,39 @@ def handle_post_tool(input_data: dict, failed: bool = False) -> None:
 
 def hook_main(args: list[str]) -> None:
     """Entry point for `agent-strace hook <event>` CLI command."""
+    provider = "claude"
+    rest = list(args)
+    if rest[:1] == ["--provider"] and len(rest) >= 2:
+        provider = rest[1]
+        rest = rest[2:]
+    elif rest and rest[0] in ("claude", "codex") and len(rest) >= 2:
+        provider = rest[0]
+        rest = rest[1:]
+
     if not args:
         sys.stderr.write("Usage: agent-strace hook <event>\n")
         sys.stderr.write("Events: session-start, session-end, pre-tool, post-tool, post-tool-failure, user-prompt, stop\n")
         sys.exit(1)
 
-    event = args[0]
-    input_data = _read_stdin()
+    if provider not in _PROVIDER_AGENT:
+        sys.stderr.write(f"Unknown hook provider: {provider}\n")
+        sys.exit(1)
+
+    if not rest:
+        sys.stderr.write("Usage: agent-strace hook [--provider claude|codex] <event>\n")
+        sys.exit(1)
+
+    event = rest[0]
+    input_data = _normalise_payload(_read_stdin(), provider, event)
 
     handlers = {
-        "session-start": handle_session_start,
-        "session-end": handle_session_end,
-        "pre-tool": handle_pre_tool,
-        "post-tool": lambda d: handle_post_tool(d, failed=False),
-        "post-tool-failure": lambda d: handle_post_tool(d, failed=True),
-        "user-prompt": handle_user_prompt,
-        "stop": handle_stop,
+        "session-start": lambda d: handle_session_start(d, provider=provider),
+        "session-end": lambda d: handle_session_end(d, provider=provider),
+        "pre-tool": lambda d: handle_pre_tool(d, provider=provider),
+        "post-tool": lambda d: handle_post_tool(d, failed=False, provider=provider),
+        "post-tool-failure": lambda d: handle_post_tool(d, failed=True, provider=provider),
+        "user-prompt": lambda d: handle_user_prompt(d, provider=provider),
+        "stop": lambda d: handle_stop(d, provider=provider),
     }
 
     handler = handlers.get(event)

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -1,0 +1,207 @@
+"""Tests for OpenAI Codex hooks integration."""
+
+import argparse
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from agent_trace.cli import cmd_setup
+from agent_trace.hooks import (
+    _read_active_session,
+    handle_post_tool,
+    handle_pre_tool,
+    handle_session_start,
+    handle_stop,
+    handle_user_prompt,
+    hook_main,
+)
+from agent_trace.models import EventType
+from agent_trace.store import TraceStore
+
+
+class TestCodexHooks(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["AGENT_TRACE_DIR"] = self.tmpdir
+        os.environ.pop("AGENT_TRACE_CODEX_SESSION_ID", None)
+        os.environ.pop("AGENT_TRACE_REDACT", None)
+
+    def tearDown(self):
+        os.environ.pop("AGENT_TRACE_DIR", None)
+        os.environ.pop("AGENT_TRACE_CODEX_SESSION_ID", None)
+
+    def test_session_start_creates_codex_session(self):
+        handle_session_start({
+            "session_id": "codexsession123456789",
+            "source": "startup",
+            "model": "gpt-5-codex",
+            "cwd": "/work/repo",
+            "permission_mode": "default",
+        }, provider="codex")
+
+        session_id = _read_active_session(provider="codex")
+        store = TraceStore(self.tmpdir)
+        meta = store.load_meta(session_id)
+        events = store.load_events(session_id)
+
+        self.assertEqual(meta.agent_name, "openai-codex")
+        self.assertIn("openai-codex", meta.command)
+        self.assertEqual(events[0].event_type, EventType.SESSION_START)
+        self.assertEqual(events[0].data["mode"], "openai-codex-hooks")
+        self.assertEqual(events[0].data["provider"], "codex")
+        self.assertEqual(events[0].data["cwd"], "/work/repo")
+
+    def test_codex_tool_call_and_result_are_linked_by_tool_use_id(self):
+        handle_session_start({"session_id": "codextool1234567", "source": "startup"}, provider="codex")
+        session_id = _read_active_session(provider="codex")
+
+        handle_pre_tool({
+            "session_id": "codextool1234567",
+            "tool_name": "Bash",
+            "tool_use_id": "call_1",
+            "tool_input": {"command": "pytest tests/"},
+            "turn_id": "turn_1",
+        }, provider="codex")
+        handle_post_tool({
+            "session_id": "codextool1234567",
+            "tool_name": "Bash",
+            "tool_use_id": "call_1",
+            "tool_response": {"exit_code": 0, "output": "ok"},
+        }, provider="codex")
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+        results = [e for e in events if e.event_type == EventType.TOOL_RESULT]
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].data["tool_use_id"], "call_1")
+        self.assertEqual(calls[0].data["turn_id"], "turn_1")
+        self.assertEqual(results[0].parent_id, calls[0].event_id)
+        self.assertIn("exit_code", results[0].data["result"])
+
+    def test_codex_user_prompt_and_stop_payloads(self):
+        handle_session_start({"session_id": "codexprompt12345", "source": "startup"}, provider="codex")
+        session_id = _read_active_session(provider="codex")
+
+        handle_user_prompt({
+            "session_id": "codexprompt12345",
+            "prompt": "Fix the flaky test",
+            "turn_id": "turn_2",
+        }, provider="codex")
+        handle_stop({
+            "session_id": "codexprompt12345",
+            "last_assistant_message": "Fixed the flaky test.",
+            "turn_id": "turn_2",
+        }, provider="codex")
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+
+        prompts = [e for e in events if e.event_type == EventType.USER_PROMPT]
+        responses = [e for e in events if e.event_type == EventType.ASSISTANT_RESPONSE]
+        self.assertEqual(prompts[0].data["prompt"], "Fix the flaky test")
+        self.assertEqual(prompts[0].data["turn_id"], "turn_2")
+        self.assertIn("Fixed", responses[0].data["text"])
+
+    def test_codex_nonzero_tool_response_records_error(self):
+        handle_session_start({"session_id": "codexfail1234567", "source": "startup"}, provider="codex")
+        session_id = _read_active_session(provider="codex")
+
+        handle_pre_tool({
+            "session_id": "codexfail1234567",
+            "tool_name": "Bash",
+            "tool_use_id": "call_fail",
+            "tool_input": {"command": "false"},
+        }, provider="codex")
+        handle_post_tool({
+            "session_id": "codexfail1234567",
+            "tool_name": "Bash",
+            "tool_use_id": "call_fail",
+            "tool_response": {"exit_code": 1, "output": "failed"},
+        }, provider="codex")
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        errors = [e for e in events if e.event_type == EventType.ERROR]
+        meta = store.load_meta(session_id)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("failed", errors[0].data["error"])
+        self.assertEqual(meta.errors, 1)
+
+    def test_hook_main_accepts_codex_provider(self):
+        payload = json.dumps({
+            "session_id": "codexmain1234567",
+            "source": "startup",
+            "model": "gpt-5-codex",
+        })
+        with patch.object(sys, "stdin", io.StringIO(payload)):
+            hook_main(["--provider", "codex", "session-start"])
+
+        store = TraceStore(self.tmpdir)
+        meta = store.load_meta("codexmain1234567")
+        self.assertEqual(meta.agent_name, "openai-codex")
+
+    def test_hook_main_requires_event_after_provider(self):
+        err = io.StringIO()
+        with patch.object(sys, "stderr", err):
+            with self.assertRaises(SystemExit) as raised:
+                hook_main(["--provider", "codex"])
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("Usage:", err.getvalue())
+
+
+class TestCodexSetup(unittest.TestCase):
+    def test_setup_cli_codex_outputs_hooks_json(self):
+        args = argparse.Namespace(
+            redact=False,
+            no_redact=False,
+            global_config=False,
+            cli="codex",
+        )
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with patch.object(sys, "stdout", out), patch.object(sys, "stderr", err):
+            cmd_setup(args)
+
+        config = json.loads(out.getvalue())
+        self.assertIn("~/.codex/hooks.json", err.getvalue())
+        self.assertIn("SessionStart", config["hooks"])
+        self.assertEqual(
+            config["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "agent-strace hook --provider codex pre-tool",
+        )
+        self.assertEqual(
+            config["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+            "agent-strace hook --provider codex post-tool",
+        )
+
+    def test_setup_cli_all_outputs_claude_and_codex_sections(self):
+        args = argparse.Namespace(
+            redact=False,
+            no_redact=False,
+            global_config=False,
+            cli="all",
+        )
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with patch.object(sys, "stdout", out), patch.object(sys, "stderr", err):
+            cmd_setup(args)
+
+        text = out.getvalue()
+        self.assertIn("agent-strace hook user-prompt", text)
+        self.assertIn("agent-strace hook --provider codex user-prompt", text)
+        self.assertIn("~/.claude/settings.json", err.getvalue())
+        self.assertIn("~/.codex/hooks.json", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds OpenAI Codex support through the existing hook capture path.

- adds `agent-strace setup --cli codex` and `--cli all`
- adds `agent-strace hook --provider codex ...`
- captures Codex `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `Stop` events
- links tool results to calls by `tool_use_id`
- records Codex tool failures from non-zero/error `tool_response` payloads
- updates README and docs for Codex hook setup
- bumps the package version to `0.67.0`

Closes #191

## Verification

- `python3 -m pytest tests/test_hooks.py tests/test_codex_hooks.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m pytest tests/ -v`