### PR TITLE
feat: add Gemini CLI hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ uvx agent-strace replay
 ```bash
 agent-strace setup             # Claude Code hooks for ~/.claude/settings.json
 agent-strace setup --cli codex # OpenAI Codex hooks for ~/.codex/hooks.json
+agent-strace setup --cli gemini # Gemini CLI extension under ~/.gemini/extensions
 agent-strace list              # list sessions
 agent-strace replay            # replay the latest
 ```
@@ -139,7 +140,7 @@ Install **agent-strace** from the [Extensions panel](https://open-vsx.org/extens
 
 ```bash
 pip install agent-strace   # 1. install
-agent-strace setup         # 2. add hooks to Claude Code or use --cli codex for Codex
+agent-strace setup         # 2. add hooks to Claude Code; use --cli codex or --cli gemini for other CLIs
 # 3. open project in VS Code — extension activates when .agent-traces/ exists
 # 4. start Claude Code — status bar appears immediately
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,9 +27,9 @@ Capture an MCP HTTP/SSE server session. Listens on `--port` (default: 3100) and 
 
 ### `setup`
 ```
-agent-strace setup [--cli claude|codex|all] [--no-redact] [--global]
+agent-strace setup [--cli claude|codex|gemini|all] [--no-redact] [--global]
 ```
-Print hooks config JSON for supported agent CLIs. `--cli claude` prints Claude Code settings JSON for `~/.claude/settings.json`; `--cli codex` prints OpenAI Codex hooks JSON for `~/.codex/hooks.json`; `--cli all` prints both. Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
+Print or install hooks config for supported agent CLIs. `--cli claude` prints Claude Code settings JSON for `~/.claude/settings.json`; `--cli codex` prints OpenAI Codex hooks JSON for `~/.codex/hooks.json`; `--cli gemini` writes a Gemini CLI extension under `$GEMINI_CONFIG_DIR/extensions/agent-strace` or `~/.gemini/extensions/agent-strace`; `--cli all` configures all supported CLIs. Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
 
 ### `import`
 ```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -56,8 +56,9 @@ Use setup-generated hooks when the agent CLI has its own lifecycle hook system.
 |---|---|---|
 | Claude Code | `agent-strace setup --cli claude` | Session start/end, user prompts, assistant responses, tool calls/results |
 | OpenAI Codex | `agent-strace setup --cli codex` | Session start, user prompts, assistant responses, `PreToolUse`/`PostToolUse` tools |
+| Gemini CLI | `agent-strace setup --cli gemini` | Session start/end, prompts, assistant responses, `BeforeTool`/`AfterTool` tools |
 
-Both paths write the same event stream under `.agent-traces/`, so replay, timeline, explain, why, watch, export, and audit commands work the same way after capture.
+All paths write the same event stream under `.agent-traces/`, so replay, timeline, explain, why, watch, export, and audit commands work the same way after capture.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,7 +15,10 @@ agent-strace setup
 # Generate OpenAI Codex hooks config
 agent-strace setup --cli codex
 
-# Generate both hook configs
+# Install Gemini CLI extension hooks
+agent-strace setup --cli gemini
+
+# Configure all supported hook integrations
 agent-strace setup --cli all
 
 # For all projects (global config)
@@ -66,6 +69,34 @@ agent-strace explain  # plain-English summary
 ```
 
 Codex sends one JSON object to each command hook on stdin. agent-strace records the common Codex fields (`session_id`, `turn_id`, `tool_use_id`, `tool_name`, `tool_input`, `tool_response`, `prompt`, and `last_assistant_message`) into the same `.agent-traces/` session store used by Claude Code.
+
+### Gemini CLI hooks
+
+`agent-strace setup --cli gemini` writes a Gemini CLI extension:
+
+```
+~/.gemini/extensions/agent-strace/
+├── gemini-extension.json
+└── hooks/
+    └── hooks.json
+```
+
+Set `GEMINI_CONFIG_DIR` to install into a different Gemini config directory. The generated `hooks.json` registers `SessionStart`, `BeforeAgent`, `BeforeTool`, `AfterTool`, `AfterAgent`, and `SessionEnd` command hooks:
+
+```json
+{
+  "hooks": {
+    "BeforeTool": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini pre-tool" }] }],
+    "AfterTool": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini post-tool" }] }],
+    "BeforeAgent": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini user-prompt" }] }],
+    "AfterAgent": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini stop" }] }],
+    "SessionStart": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini session-start" }] }],
+    "SessionEnd": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "agent-strace hook --provider gemini session-end" }] }]
+  }
+}
+```
+
+Gemini sends one JSON object to each command hook on stdin. agent-strace records `session_id`, `tool_name`, `tool_input`, `tool_response`, `prompt`, and `prompt_response` into the same `.agent-traces/` session store used by Claude Code and Codex.
 
 ### Import existing sessions
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.67.0"
+__version__ = "0.68.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
 import sys
 import time
+from pathlib import Path
 
 from . import __version__
 from .hooks import hook_main
@@ -534,6 +536,92 @@ def _codex_hooks_config(args: argparse.Namespace) -> dict:
     }
 
 
+def _gemini_hooks_config(args: argparse.Namespace) -> dict:
+    cmd_prefix = _hook_command_prefix(args, provider="gemini")
+    return {
+        "hooks": {
+            "SessionStart": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-session-start",
+                    "type": "command",
+                    "command": f"{cmd_prefix} session-start",
+                    "timeout": 5000,
+                }],
+            }],
+            "BeforeAgent": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-user-prompt",
+                    "type": "command",
+                    "command": f"{cmd_prefix} user-prompt",
+                    "timeout": 5000,
+                }],
+            }],
+            "BeforeTool": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-tool-call",
+                    "type": "command",
+                    "command": f"{cmd_prefix} pre-tool",
+                    "timeout": 5000,
+                }],
+            }],
+            "AfterTool": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-tool-result",
+                    "type": "command",
+                    "command": f"{cmd_prefix} post-tool",
+                    "timeout": 5000,
+                }],
+            }],
+            "AfterAgent": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-assistant-response",
+                    "type": "command",
+                    "command": f"{cmd_prefix} stop",
+                    "timeout": 5000,
+                }],
+            }],
+            "SessionEnd": [{
+                "matcher": "*",
+                "hooks": [{
+                    "name": "agent-strace-session-end",
+                    "type": "command",
+                    "command": f"{cmd_prefix} session-end",
+                    "timeout": 5000,
+                }],
+            }],
+        }
+    }
+
+
+def _gemini_extension_manifest() -> dict:
+    return {
+        "name": "agent-strace",
+        "version": __version__,
+        "description": "Capture and replay Gemini CLI sessions with agent-strace",
+    }
+
+
+def _gemini_config_dir() -> Path:
+    return Path(os.environ.get("GEMINI_CONFIG_DIR", "~/.gemini")).expanduser()
+
+
+def _write_gemini_extension(args: argparse.Namespace) -> tuple[Path, Path]:
+    extension_dir = _gemini_config_dir() / "extensions" / "agent-strace"
+    hooks_dir = extension_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = extension_dir / "gemini-extension.json"
+    hooks_path = hooks_dir / "hooks.json"
+    manifest_path.write_text(json.dumps(_gemini_extension_manifest(), indent=2) + "\n")
+    hooks_path.write_text(json.dumps(_gemini_hooks_config(args), indent=2) + "\n")
+    return manifest_path, hooks_path
+
+
 def cmd_setup(args: argparse.Namespace) -> None:
     """Generate hooks configuration for supported agent CLIs."""
     cli = getattr(args, "cli", "claude") or "claude"
@@ -543,12 +631,21 @@ def cmd_setup(args: argparse.Namespace) -> None:
         configs.append(("Claude Code", "~/.claude/settings.json", _claude_hooks_config(args)))
     if cli in ("codex", "all"):
         configs.append(("OpenAI Codex", "~/.codex/hooks.json", _codex_hooks_config(args)))
+    if cli in ("gemini", "all"):
+        manifest_path, hooks_path = _write_gemini_extension(args)
+        sys.stderr.write(
+            f"Wrote Gemini CLI extension manifest: {manifest_path}\n"
+            f"Wrote Gemini CLI hooks config: {hooks_path}\n"
+        )
 
     for idx, (name, path, config) in enumerate(configs):
         if idx:
             sys.stdout.write("\n")
         sys.stderr.write(f"Add this to {path} for {name}:\n\n")
         sys.stdout.write(json.dumps(config, indent=2) + "\n")
+
+    if cli == "gemini":
+        sys.stdout.write(json.dumps(_gemini_hooks_config(args), indent=2) + "\n")
 
     sys.stderr.write(
         "\nThis captures full agent sessions: user prompts, assistant "
@@ -679,7 +776,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # hook (called by agent CLI hooks systems)
     p_hook = sub.add_parser("hook", help="handle an agent CLI hook event (internal)")
-    p_hook.add_argument("--provider", choices=["claude", "codex"], default="claude",
+    p_hook.add_argument("--provider", choices=["claude", "codex", "gemini"], default="claude",
                         help="hook provider (default: claude)")
     p_hook.add_argument("event", nargs="?", help="hook event: session-start, session-end, pre-tool, post-tool, post-tool-failure")
 
@@ -697,7 +794,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="disable automatic secret redaction in generated hooks",
     )
     p_setup.add_argument("--global", dest="global_config", action="store_true", help="output config for ~/.claude/settings.json (all projects)")
-    p_setup.add_argument("--cli", choices=["claude", "codex", "all"], default="claude",
+    p_setup.add_argument("--cli", choices=["claude", "codex", "gemini", "all"], default="claude",
                          help="agent CLI to configure (default: claude)")
 
     # import (Claude Code JSONL session logs)

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -61,15 +61,18 @@ _PENDING_FILE = ".pending-calls.json"
 # agents sharing the same AGENT_TRACE_DIR from corrupting each other.
 _CLAUDE_SESSION_ID_ENV = "AGENT_TRACE_CLAUDE_SESSION_ID"
 _CODEX_SESSION_ID_ENV = "AGENT_TRACE_CODEX_SESSION_ID"
+_GEMINI_SESSION_ID_ENV = "AGENT_TRACE_GEMINI_SESSION_ID"
 
 _PROVIDER_ENV = {
     "claude": _CLAUDE_SESSION_ID_ENV,
     "codex": _CODEX_SESSION_ID_ENV,
+    "gemini": _GEMINI_SESSION_ID_ENV,
 }
 
 _PROVIDER_AGENT = {
     "claude": "claude-code",
     "codex": "openai-codex",
+    "gemini": "gemini-cli",
 }
 
 
@@ -200,7 +203,7 @@ def _should_redact() -> bool:
 def _normalise_payload(input_data: dict, provider: str, event: str) -> dict:
     """Map provider-specific hook payloads to the Claude-shaped fields."""
     data = dict(input_data)
-    if provider != "codex":
+    if provider not in ("codex", "gemini"):
         return data
 
     if event in {"pre-tool", "post-tool", "post-tool-failure"}:
@@ -211,6 +214,14 @@ def _normalise_payload(input_data: dict, provider: str, event: str) -> dict:
             data.setdefault("tool_output", tool.get("output") or tool.get("response") or "")
         data.setdefault("tool_input", data.get("input") or data.get("arguments") or {})
         data.setdefault("tool_output", data.get("tool_response", data.get("output", "")))
+
+    if provider == "gemini":
+        if event == "session-start":
+            data.setdefault("source", data.get("hook_event_name", "startup"))
+        if event == "user-prompt":
+            data.setdefault("prompt", data.get("user_prompt") or data.get("input", {}).get("prompt", ""))
+        if event == "stop":
+            data.setdefault("last_assistant_message", data.get("prompt_response", ""))
 
     if event == "stop" and data.get("last_assistant_message") is None:
         data["last_assistant_message"] = data.get("assistant_message") or data.get("message") or ""
@@ -408,7 +419,7 @@ def handle_post_tool(input_data: dict, failed: bool = False, provider: str = "cl
     tool_name = input_data.get("tool_name", "unknown")
     tool_output = input_data.get("tool_output", input_data.get("tool_response", ""))
 
-    if provider == "codex" and not failed:
+    if provider in ("codex", "gemini") and not failed:
         if isinstance(tool_output, dict):
             exit_code = tool_output.get("exit_code")
             failed = (
@@ -484,7 +495,7 @@ def hook_main(args: list[str]) -> None:
     if rest[:1] == ["--provider"] and len(rest) >= 2:
         provider = rest[1]
         rest = rest[2:]
-    elif rest and rest[0] in ("claude", "codex") and len(rest) >= 2:
+    elif rest and rest[0] in _PROVIDER_AGENT and len(rest) >= 2:
         provider = rest[0]
         rest = rest[1:]
 
@@ -498,10 +509,19 @@ def hook_main(args: list[str]) -> None:
         sys.exit(1)
 
     if not rest:
-        sys.stderr.write("Usage: agent-strace hook [--provider claude|codex] <event>\n")
+        sys.stderr.write("Usage: agent-strace hook [--provider claude|codex|gemini] <event>\n")
         sys.exit(1)
 
-    event = rest[0]
+    aliases = {
+        "before-tool": "pre-tool",
+        "before-tool-call": "pre-tool",
+        "after-tool": "post-tool",
+        "after-tool-call": "post-tool",
+        "before-agent": "user-prompt",
+        "before-prompt": "user-prompt",
+        "after-agent": "stop",
+    }
+    event = aliases.get(rest[0], rest[0])
     input_data = _normalise_payload(_read_stdin(), provider, event)
 
     handlers = {

--- a/tests/test_gemini_hooks.py
+++ b/tests/test_gemini_hooks.py
@@ -1,0 +1,229 @@
+"""Tests for Gemini CLI hooks integration."""
+
+import argparse
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.cli import cmd_setup
+from agent_trace.hooks import _read_active_session, hook_main
+from agent_trace.models import EventType
+from agent_trace.store import TraceStore
+
+
+class TestGeminiHooks(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["AGENT_TRACE_DIR"] = self.tmpdir
+        os.environ.pop("AGENT_TRACE_GEMINI_SESSION_ID", None)
+        os.environ.pop("AGENT_TRACE_REDACT", None)
+
+    def tearDown(self):
+        os.environ.pop("AGENT_TRACE_DIR", None)
+        os.environ.pop("AGENT_TRACE_GEMINI_SESSION_ID", None)
+
+    def _hook(self, event, payload):
+        with patch.object(sys, "stdin", io.StringIO(json.dumps(payload))):
+            hook_main(["--provider", "gemini", event])
+
+    def test_gemini_session_start_creates_session(self):
+        self._hook("session-start", {
+            "session_id": "geminisession123456789",
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+            "cwd": "/work/repo",
+        })
+
+        session_id = _read_active_session(provider="gemini")
+        store = TraceStore(self.tmpdir)
+        meta = store.load_meta(session_id)
+        events = store.load_events(session_id)
+
+        self.assertEqual(meta.agent_name, "gemini-cli")
+        self.assertIn("gemini-cli", meta.command)
+        self.assertEqual(events[0].event_type, EventType.SESSION_START)
+        self.assertEqual(events[0].data["provider"], "gemini")
+        self.assertEqual(events[0].data["mode"], "gemini-cli-hooks")
+        self.assertEqual(events[0].data["cwd"], "/work/repo")
+
+    def test_gemini_tool_call_and_result_are_linked(self):
+        self._hook("session-start", {"session_id": "geminitool123456", "source": "startup"})
+        session_id = _read_active_session(provider="gemini")
+
+        self._hook("pre-tool", {
+            "session_id": "geminitool123456",
+            "hook_event_name": "BeforeTool",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "pytest tests/"},
+        })
+        self._hook("post-tool", {
+            "session_id": "geminitool123456",
+            "hook_event_name": "AfterTool",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "pytest tests/"},
+            "tool_response": {"llmContent": "ok", "returnDisplay": "ok"},
+        })
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        calls = [e for e in events if e.event_type == EventType.TOOL_CALL]
+        results = [e for e in events if e.event_type == EventType.TOOL_RESULT]
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].data["tool_name"], "run_shell_command")
+        self.assertEqual(results[0].parent_id, calls[0].event_id)
+        self.assertIn("llmContent", results[0].data["result"])
+
+    def test_gemini_tool_error_increments_meta_errors(self):
+        self._hook("session-start", {"session_id": "geminifail123456", "source": "startup"})
+        session_id = _read_active_session(provider="gemini")
+
+        self._hook("pre-tool", {
+            "session_id": "geminifail123456",
+            "tool_name": "run_shell_command",
+            "tool_input": {"command": "false"},
+        })
+        self._hook("post-tool", {
+            "session_id": "geminifail123456",
+            "tool_name": "run_shell_command",
+            "tool_response": {"error": {"message": "command failed"}},
+        })
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        errors = [e for e in events if e.event_type == EventType.ERROR]
+        meta = store.load_meta(session_id)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("command failed", errors[0].data["error"])
+        self.assertEqual(meta.errors, 1)
+
+    def test_gemini_prompt_response_and_session_end(self):
+        self._hook("session-start", {"session_id": "geminiprompt123", "source": "startup"})
+        session_id = _read_active_session(provider="gemini")
+
+        self._hook("before-agent", {
+            "session_id": "geminiprompt123",
+            "hook_event_name": "BeforeAgent",
+            "prompt": "Fix the issue",
+        })
+        self._hook("after-agent", {
+            "session_id": "geminiprompt123",
+            "hook_event_name": "AfterAgent",
+            "prompt": "Fix the issue",
+            "prompt_response": "Done.",
+        })
+        self._hook("session-end", {
+            "session_id": "geminiprompt123",
+            "hook_event_name": "SessionEnd",
+            "reason": "exit",
+        })
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        meta = store.load_meta(session_id)
+
+        self.assertEqual([e.event_type for e in events], [
+            EventType.SESSION_START,
+            EventType.USER_PROMPT,
+            EventType.ASSISTANT_RESPONSE,
+            EventType.SESSION_END,
+        ])
+        self.assertEqual(events[1].data["prompt"], "Fix the issue")
+        self.assertEqual(events[2].data["text"], "Done.")
+        self.assertIsNotNone(meta.ended_at)
+
+    def test_legacy_gemini_aliases_are_supported(self):
+        self._hook("session-start", {"session_id": "geminialias1234", "source": "startup"})
+        session_id = _read_active_session(provider="gemini")
+
+        self._hook("before-tool-call", {
+            "session_id": "geminialias1234",
+            "tool_name": "read_file",
+            "tool_input": {"path": "README.md"},
+        })
+        self._hook("after-tool-call", {
+            "session_id": "geminialias1234",
+            "tool_name": "read_file",
+            "tool_response": {"llmContent": "readme"},
+        })
+        self._hook("before-prompt", {
+            "session_id": "geminialias1234",
+            "prompt": "Summarize",
+        })
+
+        store = TraceStore(self.tmpdir)
+        events = store.load_events(session_id)
+        self.assertEqual([e.event_type for e in events[1:]], [
+            EventType.TOOL_CALL,
+            EventType.TOOL_RESULT,
+            EventType.USER_PROMPT,
+        ])
+
+
+class TestGeminiSetup(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        os.environ["GEMINI_CONFIG_DIR"] = self.tmpdir
+
+    def tearDown(self):
+        os.environ.pop("GEMINI_CONFIG_DIR", None)
+
+    def test_setup_cli_gemini_writes_extension_files(self):
+        args = argparse.Namespace(
+            redact=False,
+            no_redact=False,
+            global_config=False,
+            cli="gemini",
+        )
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with patch.object(sys, "stdout", out), patch.object(sys, "stderr", err):
+            cmd_setup(args)
+
+        extension_dir = Path(self.tmpdir) / "extensions" / "agent-strace"
+        manifest = json.loads((extension_dir / "gemini-extension.json").read_text())
+        hooks = json.loads((extension_dir / "hooks" / "hooks.json").read_text())
+        printed_hooks = json.loads(out.getvalue())
+
+        self.assertEqual(manifest["name"], "agent-strace")
+        self.assertIn("BeforeTool", hooks["hooks"])
+        self.assertIn("AfterTool", hooks["hooks"])
+        self.assertIn("BeforeAgent", hooks["hooks"])
+        self.assertIn("AfterAgent", hooks["hooks"])
+        self.assertIn("SessionEnd", hooks["hooks"])
+        self.assertEqual(
+            hooks["hooks"]["BeforeTool"][0]["hooks"][0]["command"],
+            "agent-strace hook --provider gemini pre-tool",
+        )
+        self.assertEqual(printed_hooks, hooks)
+        self.assertIn("gemini-extension.json", err.getvalue())
+
+    def test_setup_cli_all_includes_gemini_extension(self):
+        args = argparse.Namespace(
+            redact=False,
+            no_redact=False,
+            global_config=False,
+            cli="all",
+        )
+
+        out = io.StringIO()
+        err = io.StringIO()
+        with patch.object(sys, "stdout", out), patch.object(sys, "stderr", err):
+            cmd_setup(args)
+
+        extension_dir = Path(self.tmpdir) / "extensions" / "agent-strace"
+        self.assertTrue((extension_dir / "gemini-extension.json").exists())
+        self.assertTrue((extension_dir / "hooks" / "hooks.json").exists())
+        self.assertIn("agent-strace hook --provider codex user-prompt", out.getvalue())
+        self.assertIn("Gemini CLI extension", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds native Gemini CLI hook support using the current Gemini extension and hook configuration format.

- adds `agent-strace setup --cli gemini`
- writes `gemini-extension.json` and `hooks/hooks.json` under `$GEMINI_CONFIG_DIR/extensions/agent-strace` or `~/.gemini/extensions/agent-strace`
- adds `agent-strace hook --provider gemini ...`
- captures Gemini `SessionStart`, `BeforeAgent`, `BeforeTool`, `AfterTool`, `AfterAgent`, and `SessionEnd`
- maps Gemini `prompt_response` to assistant responses and `tool_response.error` to trace errors
- keeps legacy aliases like `before-tool-call`, `after-tool-call`, and `before-prompt`
- updates README and docs for Gemini setup
- bumps the package version to `0.68.0`

Closes #165

## Verification

- `python3 -m pytest tests/test_hooks.py tests/test_codex_hooks.py tests/test_gemini_hooks.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `GEMINI_CONFIG_DIR=$(mktemp -d) python3 -m agent_trace.cli setup --cli gemini >/tmp/gemini-hooks.json && python3 -m json.tool /tmp/gemini-hooks.json`
- `python3 -m pytest tests/ -v`