### PR TITLE
Add team cost attribution report

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 |---|---|
 | [`agent-strace dashboard`](docs/commands.md#dashboard) | Multi-session overview |
 | [`agent-strace budget-report`](docs/commands.md#budget-report) | Weekly spend digest |
+| [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |
 | [`agent-strace drift`](docs/commands.md#drift) | Detect behavioural drift over time |
 | [`agent-strace standup`](docs/commands.md#standup) | Plain-English summary of yesterday's sessions |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -351,6 +351,20 @@ agent-strace budget-report [--since DATE] [--until DATE] [--format text|markdown
 ```
 Weekly spend digest: total cost, top sessions, cost by tool, watchdog savings.
 
+### `team-report`
+```
+agent-strace team-report [--since DATE] [--until DATE] [--by author|branch|pr] [--export text|csv|json] [--outlier-threshold N]
+```
+Team cost attribution across recorded sessions. By default it groups spend by git author, using the last author of modified files when git is available. If git is unavailable or a file has no history, it falls back to session attribution and the local user.
+
+| Flag | Description |
+|---|---|
+| `--since DATE` | Start of reporting window. Accepts ISO dates or durations like `7d`; default is 7 days ago |
+| `--until DATE` | End of reporting window. Accepts ISO dates or durations like `7d`; default is now |
+| `--by author|branch|pr` | Group by git author, active branch, or PR inferred from branch names like `pr-123` |
+| `--export text|csv|json` | Output format. `csv` is intended for spreadsheets and finance workflows |
+| `--outlier-threshold N` | Flag sessions whose cost is above `N` times the report average; default is `2.0` |
+
 ### `standup`
 ```
 agent-strace standup [--session SESSION_ID]

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.68.0"
+__version__ = "0.69.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -58,6 +58,7 @@ from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
+from .team_report import cmd_team_report
 from .compare import cmd_compare
 from .timeline import cmd_timeline
 from .config_watch import cmd_config_watch
@@ -1388,6 +1389,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_budget.add_argument("--endpoint", metavar="URL",
                           help="remote collector endpoint (not yet implemented)")
 
+    # team-report
+    p_team_report = sub.add_parser("team-report", help="cost attribution by git author, branch, or PR")
+    p_team_report.add_argument("--since", metavar="DATE",
+                               help="start of window (ISO date or duration like 7d; default: 7 days ago)")
+    p_team_report.add_argument("--until", metavar="DATE",
+                               help="end of window (ISO date or duration like 7d; default: now)")
+    p_team_report.add_argument("--by", choices=["author", "branch", "pr"], default="author",
+                               help="group by git author, branch, or PR (default: author)")
+    p_team_report.add_argument("--export", choices=["text", "csv", "json"], default="text",
+                               help="output format (default: text)")
+    p_team_report.add_argument("--outlier-threshold", type=float, default=2.0,
+                               help="flag sessions above N times average cost (default: 2.0)")
+
     # lint
     p_lint = sub.add_parser("lint", help="analyse a session for bad behaviour patterns")
     p_lint.add_argument("session_id", nargs="?",
@@ -1543,6 +1557,7 @@ def main() -> None:
         "mcp": cmd_mcp,
         "auto": cmd_auto,
         "budget-report": cmd_budget_report,
+        "team-report": cmd_team_report,
         "compare": cmd_compare,
         "config-watch": cmd_config_watch,
         "lint": cmd_lint,

--- a/src/agent_trace/team_report.py
+++ b/src/agent_trace/team_report.py
@@ -1,0 +1,394 @@
+"""Team cost attribution report.
+
+Aggregates session spend by git author, branch, or pull request. The report is
+best-effort: when git metadata is missing or git is unavailable, it falls back
+to session attribution and the local user.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time as _time
+from dataclasses import dataclass, field
+from io import StringIO
+from typing import TextIO
+
+from .budget_report import _parse_date
+from .cost import estimate_cost
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+@dataclass
+class SessionAttribution:
+    session_id: str
+    started_at: float
+    branch: str
+    author: str
+    cost: float
+    tool_calls: int
+    files: list[str] = field(default_factory=list)
+    shares: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class TeamReport:
+    group_by: str
+    window_start: float
+    window_end: float
+    rows: dict[str, dict]
+    sessions: list[SessionAttribution]
+    outlier_threshold: float = 2.0
+
+    @property
+    def total_cost(self) -> float:
+        return sum(row["cost"] for row in self.rows.values())
+
+    @property
+    def total_sessions(self) -> float:
+        return sum(row["sessions"] for row in self.rows.values())
+
+    @property
+    def total_tool_calls(self) -> float:
+        return sum(row["tool_calls"] for row in self.rows.values())
+
+    @property
+    def avg_cost(self) -> float:
+        return self.total_cost / max(1.0, self.total_sessions)
+
+    @property
+    def outliers(self) -> list[SessionAttribution]:
+        limit = self.avg_cost * self.outlier_threshold
+        if limit <= 0:
+            return []
+        return sorted(
+            [s for s in self.sessions if s.cost > limit],
+            key=lambda s: s.cost,
+            reverse=True,
+        )
+
+
+def _git(cwd: str, *args: str) -> str:
+    if not shutil.which("git"):
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _meta_attr(meta: SessionMeta) -> dict:
+    attr = getattr(meta, "attribution", {}) or {}
+    return attr if isinstance(attr, dict) else {}
+
+
+def _working_dir(meta: SessionMeta) -> str:
+    attr = _meta_attr(meta)
+    wd = attr.get("working_dir") or os.getcwd()
+    return str(wd)
+
+
+def _fallback_author(meta: SessionMeta) -> str:
+    attr = _meta_attr(meta)
+    cwd = _working_dir(meta)
+    return (
+        _git(cwd, "config", "user.email")
+        or attr.get("os_user", "")
+        or os.environ.get("USER", "")
+        or os.environ.get("USERNAME", "")
+        or "(unknown)"
+    )
+
+
+def _branch(meta: SessionMeta) -> str:
+    attr = _meta_attr(meta)
+    branch = attr.get("git_branch") or ""
+    if branch:
+        return str(branch)
+    # Imported Claude sessions store the branch in the command string.
+    match = re.search(r"branch:\s*([^,)]+)", getattr(meta, "command", "") or "")
+    if match:
+        return match.group(1).strip()
+    return "(unknown)"
+
+
+def _pr_from_branch(branch: str) -> str:
+    if not branch or branch == "(unknown)":
+        return "(unknown)"
+    match = re.search(r"(?:^|[/_-])(?:pr|pull|gh)[/_-]?(\d+)(?:$|[/_-])", branch, re.I)
+    if not match:
+        match = re.search(r"#(\d+)", branch)
+    if match:
+        return f"#{match.group(1)}"
+    return branch
+
+
+def _modified_files(events: list[TraceEvent]) -> list[str]:
+    files: list[str] = []
+    seen: set[str] = set()
+    write_tools = {"write", "edit", "multiedit", "write_file", "edit_file", "replace"}
+    for ev in events:
+        path = ""
+        if ev.event_type == EventType.FILE_WRITE:
+            path = str(ev.data.get("path") or ev.data.get("file_path") or "")
+        elif ev.event_type == EventType.TOOL_CALL:
+            tool = str(ev.data.get("tool_name", "")).lower()
+            args = ev.data.get("arguments", {})
+            if isinstance(args, dict) and (tool in write_tools or "write" in tool or "edit" in tool):
+                path = str(args.get("file_path") or args.get("path") or "")
+        if path and path not in seen:
+            seen.add(path)
+            files.append(path)
+    return files
+
+
+def _author_for_file(path: str, cwd: str) -> str:
+    return _git(cwd, "log", "-1", "--format=%ae", "--", path)
+
+
+def _author_shares(meta: SessionMeta, files: list[str]) -> dict[str, float]:
+    fallback = _fallback_author(meta)
+    if not files:
+        return {fallback: 1.0}
+
+    cwd = _working_dir(meta)
+    counts: dict[str, int] = {}
+    for path in files:
+        author = _author_for_file(path, cwd) or fallback
+        counts[author] = counts.get(author, 0) + 1
+    total = sum(counts.values()) or 1
+    return {author: count / total for author, count in counts.items()}
+
+
+def _session_cost(store: TraceStore, session_id: str) -> float:
+    try:
+        return estimate_cost(store, session_id).total_cost
+    except Exception:
+        return 0.0
+
+
+def _session_tool_calls(events: list[TraceEvent], meta: SessionMeta) -> int:
+    count = sum(1 for ev in events if ev.event_type == EventType.TOOL_CALL)
+    return count or getattr(meta, "tool_calls", 0) or 0
+
+
+def _primary_author(shares: dict[str, float]) -> str:
+    if not shares:
+        return "(unknown)"
+    return sorted(shares.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _row_key(group_by: str, session: SessionAttribution, author: str) -> str:
+    if group_by == "author":
+        return author
+    if group_by == "branch":
+        return session.branch
+    if group_by == "pr":
+        return _pr_from_branch(session.branch)
+    return author
+
+
+def build_team_report(
+    store: TraceStore,
+    window_start: float,
+    window_end: float,
+    group_by: str = "author",
+    outlier_threshold: float = 2.0,
+) -> TeamReport:
+    rows: dict[str, dict] = {}
+    sessions: list[SessionAttribution] = []
+
+    for meta in store.list_sessions():
+        if not (window_start <= meta.started_at < window_end):
+            continue
+        try:
+            events = store.load_events(meta.session_id)
+        except Exception:
+            events = []
+        files = _modified_files(events)
+        shares = _author_shares(meta, files)
+        cost = _session_cost(store, meta.session_id)
+        tool_calls = _session_tool_calls(events, meta)
+        session = SessionAttribution(
+            session_id=meta.session_id,
+            started_at=meta.started_at,
+            branch=_branch(meta),
+            author=_primary_author(shares),
+            cost=cost,
+            tool_calls=tool_calls,
+            files=files,
+            shares=shares,
+        )
+        sessions.append(session)
+
+        for author, share in shares.items():
+            key = _row_key(group_by, session, author)
+            if key not in rows:
+                rows[key] = {
+                    "group": key,
+                    "sessions": 0.0,
+                    "tool_calls": 0.0,
+                    "cost": 0.0,
+                    "authors": set(),
+                    "branches": set(),
+                }
+            rows[key]["sessions"] += share
+            rows[key]["tool_calls"] += tool_calls * share
+            rows[key]["cost"] += cost * share
+            rows[key]["authors"].add(author)
+            rows[key]["branches"].add(session.branch)
+
+    for row in rows.values():
+        row["avg_session"] = row["cost"] / max(1e-9, row["sessions"])
+        row["authors"] = sorted(row["authors"])
+        row["branches"] = sorted(row["branches"])
+
+    rows = dict(sorted(rows.items(), key=lambda item: item[1]["cost"], reverse=True))
+    return TeamReport(
+        group_by=group_by,
+        window_start=window_start,
+        window_end=window_end,
+        rows=rows,
+        sessions=sessions,
+        outlier_threshold=outlier_threshold,
+    )
+
+
+def _fmt_date(ts: float) -> str:
+    import datetime
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+
+def _fmt_count(value: float) -> str:
+    if abs(value - round(value)) < 0.01:
+        return str(int(round(value)))
+    return f"{value:.1f}"
+
+
+def format_team_report_text(report: TeamReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    start = _fmt_date(report.window_start)
+    end = _fmt_date(report.window_end)
+    label = report.group_by.title()
+    w(f"Team Agent Cost Report - {start} to {end}\n\n")
+    if not report.rows:
+        w("No sessions in this period.\n")
+        return
+
+    w(f"{label:<28}  Sessions  Tool calls  Cost      Avg/session\n")
+    w("-" * 72 + "\n")
+    for row in report.rows.values():
+        w(
+            f"{row['group']:<28}  {_fmt_count(row['sessions']):>8}  "
+            f"{_fmt_count(row['tool_calls']):>10}  ${row['cost']:>7.2f}  "
+            f"${row['avg_session']:.2f}\n"
+        )
+    w("-" * 72 + "\n")
+    w(
+        f"{'Total':<28}  {_fmt_count(report.total_sessions):>8}  "
+        f"{_fmt_count(report.total_tool_calls):>10}  ${report.total_cost:>7.2f}  "
+        f"${report.avg_cost:.2f}\n"
+    )
+
+    if report.group_by != "branch":
+        top_branches: dict[str, dict] = {}
+        for session in report.sessions:
+            key = session.branch
+            if key not in top_branches:
+                top_branches[key] = {"cost": 0.0, "sessions": 0}
+            top_branches[key]["cost"] += session.cost
+            top_branches[key]["sessions"] += 1
+        if top_branches:
+            w("\nTop cost drivers by branch:\n")
+            for branch, stats in sorted(top_branches.items(), key=lambda item: item[1]["cost"], reverse=True)[:5]:
+                pct = stats["cost"] / (report.total_cost or 1e-9) * 100
+                w(f"  {branch:<28}  ${stats['cost']:.2f}  ({pct:.0f}%)  {stats['sessions']} sessions\n")
+
+    if report.outliers:
+        w(f"\nEfficiency outliers (cost > {report.outlier_threshold:g}x average):\n")
+        for session in report.outliers[:5]:
+            w(
+                f"  {session.session_id[:12]}  ${session.cost:.2f}  "
+                f"{session.author}  {session.branch}  {_fmt_date(session.started_at)}\n"
+            )
+        w("  Run `agent-strace lint <id>` to check for waste patterns.\n")
+
+
+def format_team_report_csv(report: TeamReport) -> str:
+    out = StringIO()
+    writer = csv.writer(out)
+    writer.writerow(["group_by", "group", "sessions", "tool_calls", "cost", "avg_session", "authors", "branches"])
+    for row in report.rows.values():
+        writer.writerow([
+            report.group_by,
+            row["group"],
+            f"{row['sessions']:.3f}",
+            f"{row['tool_calls']:.3f}",
+            f"{row['cost']:.6f}",
+            f"{row['avg_session']:.6f}",
+            ";".join(row["authors"]),
+            ";".join(row["branches"]),
+        ])
+    return out.getvalue()
+
+
+def format_team_report_json(report: TeamReport) -> str:
+    return json.dumps({
+        "group_by": report.group_by,
+        "window_start": report.window_start,
+        "window_end": report.window_end,
+        "total_cost": report.total_cost,
+        "total_sessions": report.total_sessions,
+        "total_tool_calls": report.total_tool_calls,
+        "rows": list(report.rows.values()),
+        "outliers": [
+            {
+                "session_id": s.session_id,
+                "started_at": s.started_at,
+                "author": s.author,
+                "branch": s.branch,
+                "cost": s.cost,
+                "tool_calls": s.tool_calls,
+            }
+            for s in report.outliers
+        ],
+    }, indent=2)
+
+
+def cmd_team_report(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    now = _time.time()
+    until = _parse_date(args.until) if getattr(args, "until", None) else now
+    since = _parse_date(args.since) if getattr(args, "since", None) else until - 7 * 86400
+    group_by = getattr(args, "by", "author") or "author"
+    outlier_threshold = float(getattr(args, "outlier_threshold", 2.0) or 2.0)
+
+    report = build_team_report(
+        store,
+        since,
+        until,
+        group_by=group_by,
+        outlier_threshold=outlier_threshold,
+    )
+
+    fmt = getattr(args, "export", "text") or "text"
+    if fmt == "csv":
+        sys.stdout.write(format_team_report_csv(report))
+    elif fmt == "json":
+        sys.stdout.write(format_team_report_json(report) + "\n")
+    else:
+        format_team_report_text(report, sys.stdout)
+    return 0

--- a/tests/test_team_report.py
+++ b/tests/test_team_report.py
@@ -1,0 +1,246 @@
+"""Tests for team cost attribution reports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.cli import build_parser
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+from agent_trace.team_report import (
+    build_team_report,
+    cmd_team_report,
+    format_team_report_csv,
+    format_team_report_json,
+    format_team_report_text,
+)
+
+
+def _make_store() -> tuple[TraceStore, str]:
+    tmp = tempfile.mkdtemp()
+    return TraceStore(Path(tmp)), tmp
+
+
+def _add_session(
+    store: TraceStore,
+    started_at: float,
+    branch: str = "main",
+    files: list[str] | None = None,
+    prompt_size: int = 2000,
+    fallback_user: str = "local-user",
+) -> str:
+    meta = SessionMeta(agent_name="agent", command="agent")
+    meta.started_at = started_at
+    meta.attribution = {
+        "git_branch": branch,
+        "working_dir": str(store.base_dir),
+        "os_user": fallback_user,
+    }
+    store.create_session(meta)
+    store.update_meta(meta)
+    sid = meta.session_id
+
+    events = [
+        TraceEvent(
+            event_type=EventType.SESSION_START,
+            timestamp=started_at,
+            session_id=sid,
+            data={},
+        ),
+        TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            timestamp=started_at + 1,
+            session_id=sid,
+            data={"prompt": "x" * prompt_size},
+        ),
+    ]
+    for i, path in enumerate(files or []):
+        events.append(TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            timestamp=started_at + 2 + i,
+            session_id=sid,
+            data={"tool_name": "Write", "arguments": {"file_path": path}},
+        ))
+    events.append(TraceEvent(
+        event_type=EventType.ASSISTANT_RESPONSE,
+        timestamp=started_at + 20,
+        session_id=sid,
+        data={"text": "y" * prompt_size},
+    ))
+    events.append(TraceEvent(
+        event_type=EventType.SESSION_END,
+        timestamp=started_at + 30,
+        session_id=sid,
+        data={},
+    ))
+    for ev in events:
+        store.append_event(sid, ev)
+    return sid
+
+
+def _fake_git(author_by_file: dict[str, str], fallback_email: str = "fallback@example.com"):
+    def fake(cwd, *args):
+        if args == ("config", "user.email"):
+            return fallback_email
+        if len(args) >= 5 and args[:3] == ("log", "-1", "--format=%ae"):
+            return author_by_file.get(args[-1], "")
+        return ""
+    return fake
+
+
+class TestBuildTeamReport(unittest.TestCase):
+    def test_groups_cost_by_git_author_with_file_shares(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, files=["a.py", "b.py", "c.py"])
+
+        with patch("agent_trace.team_report._git", _fake_git({
+            "a.py": "alice@example.com",
+            "b.py": "bob@example.com",
+            "c.py": "alice@example.com",
+        })):
+            report = build_team_report(store, now - 86400, now)
+
+        self.assertIn("alice@example.com", report.rows)
+        self.assertIn("bob@example.com", report.rows)
+        self.assertAlmostEqual(report.rows["alice@example.com"]["sessions"], 2 / 3)
+        self.assertAlmostEqual(report.rows["bob@example.com"]["sessions"], 1 / 3)
+        self.assertGreater(report.rows["alice@example.com"]["cost"], report.rows["bob@example.com"]["cost"])
+
+    def test_groups_by_branch(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, branch="feat/payments", files=["a.py"])
+
+        with patch("agent_trace.team_report._git", _fake_git({"a.py": "alice@example.com"})):
+            report = build_team_report(store, now - 86400, now, group_by="branch")
+
+        self.assertIn("feat/payments", report.rows)
+
+    def test_groups_by_pr_from_branch_name(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, branch="feature/pr-412-payments", files=["a.py"])
+
+        with patch("agent_trace.team_report._git", _fake_git({"a.py": "alice@example.com"})):
+            report = build_team_report(store, now - 86400, now, group_by="pr")
+
+        self.assertIn("#412", report.rows)
+
+    def test_date_filter_excludes_old_sessions(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, files=["new.py"])
+        _add_session(store, now - 10 * 86400, files=["old.py"])
+
+        with patch("agent_trace.team_report._git", _fake_git({
+            "new.py": "new@example.com",
+            "old.py": "old@example.com",
+        })):
+            report = build_team_report(store, now - 86400, now)
+
+        self.assertIn("new@example.com", report.rows)
+        self.assertNotIn("old@example.com", report.rows)
+
+    def test_falls_back_when_git_has_no_author(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, files=["a.py"], fallback_user="local-user")
+
+        with patch("agent_trace.team_report._git", _fake_git({}, fallback_email="")):
+            report = build_team_report(store, now - 86400, now)
+
+        self.assertIn("local-user", report.rows)
+
+    def test_outliers_use_threshold(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, files=["small.py"], prompt_size=200)
+        _add_session(store, now - 1800, files=["large.py"], prompt_size=20000)
+
+        with patch("agent_trace.team_report._git", _fake_git({
+            "small.py": "alice@example.com",
+            "large.py": "alice@example.com",
+        })):
+            report = build_team_report(store, now - 86400, now, outlier_threshold=1.2)
+
+        self.assertEqual(len(report.outliers), 1)
+
+
+class TestFormatTeamReport(unittest.TestCase):
+    def _report(self):
+        store, _ = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, branch="feat/pr-99", files=["a.py"], prompt_size=20000)
+        _add_session(store, now - 1800, branch="main", files=["b.py"], prompt_size=200)
+        with patch("agent_trace.team_report._git", _fake_git({
+            "a.py": "alice@example.com",
+            "b.py": "bob@example.com",
+        })):
+            return build_team_report(store, now - 86400, now, outlier_threshold=1.2)
+
+    def test_text_contains_table_and_outlier_hint(self):
+        report = self._report()
+        out = io.StringIO()
+        format_team_report_text(report, out)
+        text = out.getvalue()
+        self.assertIn("Team Agent Cost Report", text)
+        self.assertIn("alice@example.com", text)
+        self.assertIn("agent-strace lint", text)
+
+    def test_csv_output_has_rows(self):
+        report = self._report()
+        rows = list(csv.DictReader(io.StringIO(format_team_report_csv(report))))
+        self.assertEqual(rows[0]["group_by"], "author")
+        self.assertIn(rows[0]["group"], {"alice@example.com", "bob@example.com"})
+
+    def test_json_output_is_valid(self):
+        report = self._report()
+        data = json.loads(format_team_report_json(report))
+        self.assertEqual(data["group_by"], "author")
+        self.assertIn("rows", data)
+
+
+class TestTeamReportCLI(unittest.TestCase):
+    def _args(self, trace_dir, by="author", export="text", since=None, until=None):
+        return argparse.Namespace(
+            trace_dir=str(trace_dir),
+            by=by,
+            export=export,
+            since=since,
+            until=until,
+            outlier_threshold=2.0,
+        )
+
+    def test_cmd_team_report_csv(self):
+        store, tmp = _make_store()
+        now = time.time()
+        _add_session(store, now - 3600, files=["a.py"])
+        args = self._args(tmp, export="csv")
+
+        captured = io.StringIO()
+        with patch("agent_trace.team_report._git", _fake_git({"a.py": "alice@example.com"})):
+            with patch("sys.stdout", captured):
+                result = cmd_team_report(args)
+
+        self.assertEqual(result, 0)
+        self.assertIn("group_by,group,sessions", captured.getvalue())
+
+    def test_parser_registers_team_report(self):
+        parser = build_parser()
+        args = parser.parse_args(["team-report", "--by", "branch", "--export", "csv"])
+        self.assertEqual(args.command, "team-report")
+        self.assertEqual(args.by, "branch")
+        self.assertEqual(args.export, "csv")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `agent-strace team-report` for team cost attribution by author, branch, or PR
- support `--since`, `--until`, `--export csv|json|text`, and configurable outlier detection
- document the command and bump the package version to `0.69.0`

Closes #166.

## Verification
- `python3 -m pytest tests/test_team_report.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m pytest tests/ -v`