### PR TITLE
Add first-class watch loop rule

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -147,7 +147,7 @@ Check token usage against model context limit.
 agent-strace watch [session-id] [--timeout DURATION] [--budget $N] [--on-violation ACTION]
                    [--on-death CMD] [--policy FILE] [--rules FILE_OR_BUILTINS] [--stream-to URL]
                    [--stream-batch-size N] [--stream-flush-interval S]
-                   [--max-context-pct N] [--dry-run]
+                   [--loop-threshold N] [--loop-window N] [--max-context-pct N] [--dry-run]
 ```
 Live session monitor with kill-switch rules.
 
@@ -155,10 +155,12 @@ Live session monitor with kill-switch rules.
 |---|---|
 | `--timeout DURATION` | Kill after duration (e.g. `30m`, `2h`) |
 | `--budget $N` | Kill when spend exceeds N dollars |
-| `--on-violation kill\|pause\|alert` | Action when a rule fires |
+| `--loop-threshold N` | Alert when the same tool call and arguments repeat N times; default is 3 |
+| `--loop-window N` | Number of recent events to scan for repeated identical tool calls; default is 10 |
+| `--on-violation terminal\|file\|kill` | Action when a rule fires |
 | `--on-death CMD` | Command to run after kill (receives `{post_mortem_path}`) |
 | `--policy FILE` | Scope policy file to enforce (default: `.agent-scope.json`) |
-| `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,budget:$5,timeout:30m` |
+| `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,loop:3/10,budget:$5,timeout:30m` |
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
 | `--dry-run` | Evaluate rules without acting |
 
@@ -171,6 +173,14 @@ Live session monitor with kill-switch rules.
     { "name": "large edit", "condition": "files_modified > 30", "action": "pause" }
   ]
 }
+```
+
+Built-in `loop` rule config:
+```yaml
+watchers:
+  loop:
+    identical_calls: 3
+    window: 10
 ```
 
 ### `mcp-scan`

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.69.0"
+__version__ = "0.70.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -922,6 +922,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument("--budget", type=float, metavar="DOLLARS",
                          help="token-cost ceiling in dollars before killing the agent; "
                               "alias for --max-cost")
+    p_watch.add_argument("--loop-threshold", type=int, metavar="N",
+                         help="alert when an identical tool call repeats N times (default: 3)")
+    p_watch.add_argument("--loop-window", type=int, metavar="N",
+                         help="events to scan for repeated identical tool calls (default: 10)")
     p_watch.add_argument("--on-death", dest="on_death", metavar="CMD",
                          help="command to run after the agent is killed; "
                               "{post_mortem_path} is substituted with the post-mortem JSON path")

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import hashlib
 import json
 import os
 import queue
@@ -321,6 +322,8 @@ class WatcherConfig:
     max_retries: int = 5
     max_cost_dollars: float = 10.0
     max_duration_seconds: float = 1800.0
+    loop_threshold: int = 3
+    loop_window: int = 10
     loop_sequence_length: int = 3
     loop_max_repeats: int = 3
     scope_policy: str = ".agent-scope.json"
@@ -360,6 +363,11 @@ class WatcherConfig:
             max_retries=int(retry_cfg.get("max", 5)),
             max_cost_dollars=float(cost_cfg.get("max_dollars", 10.0)),
             max_duration_seconds=float(dur_cfg.get("max_minutes", 30)) * 60,
+            loop_threshold=int(loop_cfg.get(
+                "identical_calls",
+                loop_cfg.get("threshold", loop_cfg.get("max_repeats", 3)),
+            )),
+            loop_window=int(loop_cfg.get("window", 10)),
             loop_sequence_length=int(loop_cfg.get("sequence_length", 3)),
             loop_max_repeats=int(loop_cfg.get("max_repeats", 3)),
             scope_policy=str(scope_cfg.get("policy", ".agent-scope.json")),
@@ -535,7 +543,7 @@ class WatchState:
     # Session start time
     start_time: float = field(default_factory=time.time)
     # Recent event sequence for loop detection (circular buffer)
-    recent_events: deque = field(default_factory=lambda: deque(maxlen=30))
+    recent_events: deque = field(default_factory=lambda: deque(maxlen=500))
     # Violations already fired (to avoid duplicate alerts)
     fired: set = field(default_factory=set)
     # Agent PID (from session meta, if available)
@@ -566,9 +574,37 @@ def _event_key(event: TraceEvent) -> str:
     if event.event_type == EventType.TOOL_CALL:
         name = event.data.get("tool_name", "?")
         args = event.data.get("arguments", {}) or {}
-        cmd = str(args.get("command", args.get("file_path", "")))[:40]
-        return f"{name}:{cmd}"
+        arg_text = json.dumps(args, sort_keys=True, default=str)
+        arg_hash = hashlib.sha256(arg_text.encode("utf-8")).hexdigest()[:12]
+        preview = str(
+            args.get("command")
+            or args.get("file_path")
+            or args.get("path")
+            or args.get("url")
+            or ""
+        )[:40]
+        return f"{name}:{preview}:{arg_hash}"
     return event.event_type.value
+
+
+def _detect_spin_loop(
+    recent: deque,
+    threshold: int,
+    window: int,
+) -> str | None:
+    """Detect repeated identical tool calls within the last window events."""
+    threshold = max(2, int(threshold))
+    window = max(threshold, int(window))
+    items = [item for item in list(recent)[-window:] if ":" in str(item)]
+    if len(items) < threshold:
+        return None
+
+    counts = Counter(items)
+    key, count = counts.most_common(1)[0]
+    if count >= threshold:
+        display = str(key).rsplit(":", 1)[0]
+        return f"identical tool call repeated {count} times in last {window} events ({display})"
+    return None
 
 
 def _detect_loop(
@@ -851,7 +887,19 @@ def check_event(
                 f"DurationWatcher: {elapsed:.0f}s elapsed (threshold: {config.max_duration_seconds:.0f}s)"
             )
 
-    # --- Loop detection ---
+    # --- Spin loop detection: repeated identical tool calls in a window ---
+    spin_msg = _detect_spin_loop(
+        state.recent_events,
+        config.loop_threshold,
+        config.loop_window,
+    )
+    if spin_msg:
+        key_id = f"spin-loop:{spin_msg.rsplit('(', 1)[-1][:80]}"
+        if key_id not in state.fired:
+            state.fired.add(key_id)
+            violations.append(f"LoopWatcher: {spin_msg}")
+
+    # --- Sequence loop detection: repeated event sequence ---
     loop_msg = _detect_loop(
         state.recent_events,
         config.loop_sequence_length,
@@ -1132,15 +1180,24 @@ def cmd_watch(args: argparse.Namespace) -> int:
                 sys.stderr.write(f"[watch] invalid --budget value: {budget_str!r}\n")
                 return 1
 
+        loop_threshold = getattr(args, "loop_threshold", None)
+        loop_window = getattr(args, "loop_window", None)
+
         config = WatcherConfig(
             max_retries=getattr(args, "max_retries", 5),
             max_cost_dollars=max_cost,
             max_duration_seconds=max_duration,
+            loop_threshold=3 if loop_threshold is None else int(loop_threshold),
+            loop_window=10 if loop_window is None else int(loop_window),
             on_violation=getattr(args, "on_violation", "terminal"),
             webhook_url=getattr(args, "webhook", "") or "",
             on_death_cmd=getattr(args, "on_death", "") or "",
             scope_policy=getattr(args, "policy", None) or ".agent-scope.json",
         )
+    if getattr(args, "loop_threshold", None) is not None:
+        config.loop_threshold = int(getattr(args, "loop_threshold"))
+    if getattr(args, "loop_window", None) is not None:
+        config.loop_window = int(getattr(args, "loop_window"))
 
     # Load nanny rules if --rules provided
     nanny_rules: list[NannyRule] | None = None
@@ -1198,6 +1255,22 @@ def _apply_builtin_rules_spec(spec: str, config: WatcherConfig) -> list[str]:
             continue
         if item == "mcp-poisoning":
             config.built_in_rules.add("mcp-poisoning")
+            continue
+        if item == "loop":
+            config.built_in_rules.add("loop")
+            continue
+        if item.startswith("loop:"):
+            value = item.split(":", 1)[1].strip()
+            try:
+                if "/" in value:
+                    threshold, window = value.split("/", 1)
+                    config.loop_threshold = int(threshold)
+                    config.loop_window = int(window)
+                else:
+                    config.loop_threshold = int(value)
+                config.built_in_rules.add("loop")
+            except ValueError:
+                warnings.append(f"invalid loop rule {item!r}")
             continue
         if item.startswith("budget:"):
             value = item.split(":", 1)[1].strip().lstrip("$")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -10,6 +10,7 @@ from collections import deque
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from agent_trace.cli import build_parser
 from agent_trace.models import EventType, SessionMeta, TraceEvent
 from agent_trace.store import TraceStore
 from agent_trace.watch import (
@@ -20,6 +21,7 @@ from agent_trace.watch import (
     _alert_file,
     _apply_builtin_rules_spec,
     _detect_loop,
+    _detect_spin_loop,
     _event_key,
 )
 
@@ -41,6 +43,8 @@ def _default_config(**kwargs) -> WatcherConfig:
         max_retries=3,
         max_cost_dollars=10.0,
         max_duration_seconds=3600.0,
+        loop_threshold=99,
+        loop_window=10,
         loop_sequence_length=3,
         loop_max_repeats=3,
         on_violation="terminal",
@@ -151,6 +155,31 @@ class TestDurationLimit(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestLoopDetection(unittest.TestCase):
+    def test_detects_identical_tool_call_spin_loop(self):
+        recent = deque([
+            _event_key(_bash_event("pytest")),
+            "user_prompt",
+            _event_key(_bash_event("pytest")),
+            _event_key(_bash_event("pytest")),
+        ], maxlen=30)
+        result = _detect_spin_loop(recent, threshold=3, window=10)
+        self.assertIsNotNone(result)
+        self.assertIn("identical tool call repeated 3 times", result)
+
+    def test_spin_loop_respects_window(self):
+        repeated = _event_key(_bash_event("pytest"))
+        recent = deque([repeated, repeated, "user_prompt", "assistant_response", repeated], maxlen=30)
+        result = _detect_spin_loop(recent, threshold=3, window=3)
+        self.assertIsNone(result)
+
+    def test_check_event_reports_spin_loop(self):
+        config = _default_config(loop_threshold=3, loop_window=10)
+        state = WatchState()
+        violations = []
+        for _ in range(3):
+            violations.extend(check_event(_bash_event("pytest"), config, state))
+        self.assertTrue(any("LoopWatcher" in v for v in violations))
+
     def test_no_loop_with_varied_events(self):
         recent = deque(["a", "b", "c", "d", "e", "f"], maxlen=30)
         result = _detect_loop(recent, seq_len=3, max_repeats=3)
@@ -229,6 +258,7 @@ class TestWatcherConfigLoad(unittest.TestCase):
                 "retry": {"max": 2, "alert": "terminal"},
                 "cost": {"max_dollars": 5.0},
                 "duration": {"max_minutes": 10},
+                "loop": {"identical_calls": 4, "window": 12},
             }
         }
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
@@ -239,6 +269,8 @@ class TestWatcherConfigLoad(unittest.TestCase):
             self.assertEqual(config.max_retries, 2)
             self.assertAlmostEqual(config.max_cost_dollars, 5.0)
             self.assertAlmostEqual(config.max_duration_seconds, 600.0)
+            self.assertEqual(config.loop_threshold, 4)
+            self.assertEqual(config.loop_window, 12)
         finally:
             os.unlink(path)
 
@@ -247,12 +279,22 @@ class TestBuiltInRules(unittest.TestCase):
     def test_builtin_rules_spec_enables_mcp_poisoning_and_limits(self):
         config = WatcherConfig()
 
-        warnings = _apply_builtin_rules_spec("mcp-poisoning,budget:$5,timeout:30m", config)
+        warnings = _apply_builtin_rules_spec("mcp-poisoning,loop:4/12,budget:$5,timeout:30m", config)
 
         self.assertEqual(warnings, [])
         self.assertIn("mcp-poisoning", config.built_in_rules)
+        self.assertIn("loop", config.built_in_rules)
+        self.assertEqual(config.loop_threshold, 4)
+        self.assertEqual(config.loop_window, 12)
         self.assertEqual(config.max_cost_dollars, 5.0)
         self.assertEqual(config.max_duration_seconds, 1800.0)
+
+    def test_watch_parser_registers_loop_flags(self):
+        parser = build_parser()
+        args = parser.parse_args(["watch", "--loop-threshold", "4", "--loop-window", "12"])
+        self.assertEqual(args.command, "watch")
+        self.assertEqual(args.loop_threshold, 4)
+        self.assertEqual(args.loop_window, 12)
 
     def test_mcp_poisoning_rule_alerts_on_exfil_sequence(self):
         config = WatcherConfig(built_in_rules={"mcp-poisoning"})


### PR DESCRIPTION
## Summary
- add first-class spin-loop detection for repeated identical tool calls in `agent-strace watch`
- expose `--loop-threshold` and `--loop-window`, plus `watchers.loop` config and `--rules loop:3/10`
- document the watch loop rule and bump the package version to `0.70.0`

Closes #178.

## Verification
- `python3 -m pytest tests/test_watch.py tests/test_watchdog.py tests/test_watch_nanny.py tests/test_watch_operations.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m pytest tests/ -v`