### PR TITLE
Add behavioral fingerprint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |
 | [`agent-strace drift`](docs/commands.md#drift) | Detect behavioural drift over time |
+| [`agent-strace fingerprint`](docs/commands.md#fingerprint) | Baseline an agent's behavioural profile |
 | [`agent-strace standup`](docs/commands.md#standup) | Plain-English summary of yesterday's sessions |
 | [`agent-strace eval <id>`](docs/commands.md#eval) | Score a session against behavioural baselines |
 | [`agent-strace eval ci`](docs/commands.md#eval) | Fail CI on behavioural regression |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -329,6 +329,13 @@ agent-strace drift [--since DURATION] [--baseline FILE] [--save-baseline FILE]
 ```
 Detect behavioral drift across sessions. Exits non-zero when drift score exceeds `--threshold` (default: 0.20).
 
+### `fingerprint`
+```
+agent-strace fingerprint [--sessions N] [--output FILE] [--format text|json]
+agent-strace fingerprint --compare A.json B.json [--threshold N] [--format text|json]
+```
+Characterize an agent's recent behavior: tool mix, error rate, retry rate, file touch radius, duration, and decision depth. Saved JSON fingerprints can be used as drift baselines or compared directly.
+
 ### `lint`
 ```
 agent-strace lint [session-id] [--all] [--since DURATION] [--strict] [--format text|json]

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.70.0"
+__version__ = "0.71.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -33,7 +33,7 @@ from .iac import cmd_apply, cmd_config_diff
 from .sso import cmd_auth
 from .baseline import cmd_baseline
 from .compliance import cmd_compliance
-from .drift import cmd_drift
+from .drift import cmd_drift, cmd_fingerprint
 from .identity import cmd_identity
 from .workspace import cmd_workspace
 from .langfuse_export import cmd_export_scores
@@ -1231,6 +1231,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_drift.add_argument("--format", choices=["table", "json"], default="table",
                          help="output format (default: table)")
 
+    # fingerprint (behavioral profile)
+    p_fingerprint = sub.add_parser("fingerprint", help="characterize an agent's behavioral profile")
+    p_fingerprint.add_argument("--sessions", type=int, default=20, metavar="N",
+                               help="number of recent sessions to analyze (default: 20)")
+    p_fingerprint.add_argument("--output", "-o", metavar="FILE",
+                               help="write fingerprint JSON to FILE")
+    p_fingerprint.add_argument("--id", default="", metavar="ID",
+                               help="fingerprint ID to store in JSON")
+    p_fingerprint.add_argument("--compare", nargs=2, metavar=("A.json", "B.json"),
+                               help="compare two saved fingerprint JSON files")
+    p_fingerprint.add_argument("--threshold", type=float, default=0.20,
+                               help="comparison score above which to alert (default: 0.20)")
+    p_fingerprint.add_argument("--format", choices=["text", "json"], default="text",
+                               help="output format (default: text)")
+
     # optimize (propose AGENTS.md / skill file improvements from trace failures)
     p_opt = sub.add_parser("optimize", help="propose instruction file improvements from trace failures")
     p_opt.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
@@ -1546,6 +1561,7 @@ def main() -> None:
         "a2a-tree": cmd_a2a_tree,
         "baseline": cmd_baseline,
         "drift": cmd_drift,
+        "fingerprint": cmd_fingerprint,
         "identity": cmd_identity,
         "workspace": cmd_workspace,
         "compliance": cmd_compliance,

--- a/src/agent_trace/drift.py
+++ b/src/agent_trace/drift.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
+from .cost import estimate_cost
 from .models import EventType, TraceEvent
 from .store import TraceStore
 
@@ -49,6 +50,8 @@ class BehavioralFingerprint:
     # Per-session distributions
     error_rate: DistStats = field(default_factory=DistStats)
     retry_rate: DistStats = field(default_factory=DistStats)
+    tool_calls: DistStats = field(default_factory=DistStats)
+    cost_usd: DistStats = field(default_factory=DistStats)
     blast_radius: DistStats = field(default_factory=DistStats)
     session_duration_s: DistStats = field(default_factory=DistStats)
     decision_depth: DistStats = field(default_factory=DistStats)
@@ -61,6 +64,8 @@ class BehavioralFingerprint:
             "tool_mix": {k: round(v, 4) for k, v in self.tool_mix.items()},
             "error_rate": self.error_rate.to_dict(),
             "retry_rate": self.retry_rate.to_dict(),
+            "tool_calls": self.tool_calls.to_dict(),
+            "cost_usd": self.cost_usd.to_dict(),
             "blast_radius": self.blast_radius.to_dict(),
             "session_duration_s": self.session_duration_s.to_dict(),
             "decision_depth": self.decision_depth.to_dict(),
@@ -79,7 +84,15 @@ class BehavioralFingerprint:
             period_end=d.get("period", {}).get("end", ""),
             tool_mix=d.get("tool_mix", {}),
         )
-        for attr in ("error_rate", "retry_rate", "blast_radius", "session_duration_s", "decision_depth"):
+        for attr in (
+            "error_rate",
+            "retry_rate",
+            "tool_calls",
+            "cost_usd",
+            "blast_radius",
+            "session_duration_s",
+            "decision_depth",
+        ):
             raw = d.get(attr, {})
             setattr(fp, attr, DistStats(
                 mean=raw.get("mean", 0.0),
@@ -210,11 +223,17 @@ class SessionMetrics:
     error_count: int
     total_tool_calls: int
     retry_count: int
+    cost_usd: float
     blast_radius: int          # distinct files written
     decision_count: int
 
 
-def _extract_metrics(session_id: str, events: list[TraceEvent], meta_started: float) -> SessionMetrics:
+def _extract_metrics(
+    session_id: str,
+    events: list[TraceEvent],
+    meta_started: float,
+    cost_usd: float = 0.0,
+) -> SessionMetrics:
     tool_mix: dict[str, int] = {}
     error_count = 0
     total_tool_calls = 0
@@ -262,9 +281,17 @@ def _extract_metrics(session_id: str, events: list[TraceEvent], meta_started: fl
         error_count=error_count,
         total_tool_calls=total_tool_calls,
         retry_count=retry_count,
+        cost_usd=cost_usd,
         blast_radius=len(files_written),
         decision_count=decision_count,
     )
+
+
+def _session_cost(store: TraceStore, session_id: str) -> float:
+    try:
+        return estimate_cost(store, session_id).total_cost
+    except Exception:
+        return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +313,7 @@ def compute_fingerprint(
         try:
             meta = store.load_meta(sid)
             events = store.load_events(sid)
-            m = _extract_metrics(sid, events, meta.started_at)
+            m = _extract_metrics(sid, events, meta.started_at, _session_cost(store, sid))
             all_metrics.append(m)
             timestamps.append(meta.started_at)
         except Exception:
@@ -310,6 +337,8 @@ def compute_fingerprint(
     retry_rates = [
         m.retry_count / max(m.total_tool_calls, 1) for m in all_metrics
     ]
+    tool_calls = [float(m.total_tool_calls) for m in all_metrics]
+    costs = [m.cost_usd for m in all_metrics]
     blast_radii = [float(m.blast_radius) for m in all_metrics]
     durations = [m.duration_s for m in all_metrics]
     decisions = [float(m.decision_count) for m in all_metrics]
@@ -325,6 +354,8 @@ def compute_fingerprint(
         tool_mix=tool_mix_frac,
         error_rate=_dist_stats(error_rates),
         retry_rate=_dist_stats(retry_rates),
+        tool_calls=_dist_stats(tool_calls),
+        cost_usd=_dist_stats(costs),
         blast_radius=_dist_stats(blast_radii),
         session_duration_s=_dist_stats(durations),
         decision_depth=_dist_stats(decisions),
@@ -356,6 +387,8 @@ def compute_drift(
     for attr, label in [
         ("error_rate", "error_rate"),
         ("retry_rate", "retry_rate"),
+        ("tool_calls", "tool_calls"),
+        ("cost_usd", "cost_usd"),
         ("blast_radius", "blast_radius"),
         ("session_duration_s", "session_duration"),
         ("decision_depth", "decision_depth"),
@@ -372,7 +405,7 @@ def compute_drift(
         ))
 
     # Weighted average (tool_mix weighted 2x, others 1x)
-    weights = [2.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    weights = [2.0] + [1.0] * (len(dimensions) - 1)
     overall = sum(d.score * w for d, w in zip(dimensions, weights)) / sum(weights)
 
     return DriftReport(
@@ -392,6 +425,58 @@ def _top_tools(tool_mix: dict[str, float], n: int = 3) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Fingerprint terminal output
+# ---------------------------------------------------------------------------
+
+def _fmt_seconds(seconds: float) -> str:
+    if seconds >= 3600:
+        return f"{seconds / 3600:.1f}h"
+    if seconds >= 60:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds:.1f}s"
+
+
+def print_fingerprint(fp: BehavioralFingerprint, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    w("\nBehavioral fingerprint\n")
+    w(f"ID:       {fp.fingerprint_id or '(none)'}\n")
+    w(f"Period:   {fp.period_start or '-'} to {fp.period_end or '-'}\n")
+    w(f"Sessions: {fp.sessions}\n")
+    w("─" * 70 + "\n")
+
+    if fp.sessions == 0:
+        w("No sessions available for fingerprinting.\n\n")
+        return
+
+    w("Tool call profile:\n")
+    if fp.tool_mix:
+        for tool, frac in sorted(fp.tool_mix.items(), key=lambda item: item[1], reverse=True):
+            w(f"  {tool:<22} {frac:>6.0%}\n")
+    else:
+        w("  (no tool calls)\n")
+
+    w("\nSession profile (per session):\n")
+    w(f"  {'Metric':<22} {'Median':>10} {'P95':>10} {'Mean':>10}\n")
+    w("  " + "-" * 46 + "\n")
+    w(
+        f"  {'duration':<22} "
+        f"{_fmt_seconds(fp.session_duration_s.p50):>10} "
+        f"{_fmt_seconds(fp.session_duration_s.p95):>10} "
+        f"{_fmt_seconds(fp.session_duration_s.mean):>10}\n"
+    )
+    for label, stats in [
+        ("tool calls", fp.tool_calls),
+        ("cost usd", fp.cost_usd),
+        ("error rate", fp.error_rate),
+        ("retry rate", fp.retry_rate),
+        ("file touch radius", fp.blast_radius),
+        ("decision depth", fp.decision_depth),
+    ]:
+        w(f"  {label:<22} {stats.p50:>10.2f} {stats.p95:>10.2f} {stats.mean:>10.2f}\n")
+    w("\n")
+
+
+# ---------------------------------------------------------------------------
 # Session filtering helpers
 # ---------------------------------------------------------------------------
 
@@ -403,6 +488,10 @@ def _sessions_in_window(store: TraceStore, since_days: float) -> list[str]:
         if meta.started_at >= cutoff:
             result.append(meta.session_id)
     return result
+
+
+def _latest_sessions(store: TraceStore, limit: int) -> list[str]:
+    return [meta.session_id for meta in store.list_sessions()[:max(0, limit)]]
 
 
 def _sessions_in_range(store: TraceStore, start_ts: float, end_ts: float) -> list[str]:
@@ -540,3 +629,66 @@ def cmd_drift(args: argparse.Namespace) -> int:
         print_report(report)
 
     return 1 if report.exceeded else 0
+
+
+def cmd_fingerprint(args: argparse.Namespace) -> int:
+    compare_paths = getattr(args, "compare", None) or []
+    fmt = getattr(args, "format", "text") or "text"
+
+    if compare_paths:
+        if len(compare_paths) != 2:
+            sys.stderr.write("Specify exactly two fingerprint files with --compare.\n")
+            return 1
+        try:
+            first = BehavioralFingerprint.from_json(Path(compare_paths[0]).read_text())
+            second = BehavioralFingerprint.from_json(Path(compare_paths[1]).read_text())
+        except Exception as exc:
+            sys.stderr.write(f"Could not read fingerprint file: {exc}\n")
+            return 1
+        report = compute_drift(first, second, threshold=getattr(args, "threshold", 0.20))
+        if fmt == "json":
+            data = {
+                "overall_score": report.overall_score,
+                "threshold": report.threshold,
+                "exceeded": report.exceeded,
+                "label": report.label,
+                "baseline_sessions": report.baseline_sessions,
+                "current_sessions": report.current_sessions,
+                "dimensions": [
+                    {
+                        "name": d.name,
+                        "score": d.score,
+                        "label": d.label,
+                        "first": d.baseline_summary,
+                        "second": d.current_summary,
+                    }
+                    for d in report.dimensions
+                ],
+            }
+            sys.stdout.write(json.dumps(data, indent=2) + "\n")
+        else:
+            print_report(report)
+        return 1 if report.exceeded else 0
+
+    store = TraceStore(args.trace_dir)
+    sessions = int(getattr(args, "sessions", 20) or 20)
+    session_ids = _latest_sessions(store, sessions)
+    fp = compute_fingerprint(store, session_ids, fingerprint_id=getattr(args, "id", "") or "")
+
+    output = getattr(args, "output", None)
+    if output:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(fp.to_json() + "\n")
+        message = f"Behavioral fingerprint saved to {out_path}\n"
+        if fmt == "json":
+            sys.stderr.write(message)
+        else:
+            sys.stdout.write(message)
+
+    if fmt == "json":
+        sys.stdout.write(fp.to_json() + "\n")
+    elif not output:
+        print_fingerprint(fp)
+
+    return 0 if fp.sessions > 0 else 1

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,20 +1,26 @@
 """Tests for behavioral drift detection."""
 
 import json
+import argparse
+import io
 import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+from agent_trace.cli import build_parser
 from agent_trace.drift import (
     BehavioralFingerprint,
     DistStats,
     SessionMetrics,
+    cmd_fingerprint,
     _dist_stats,
     _js_divergence,
     _stats_divergence,
     compute_drift,
     compute_fingerprint,
+    print_fingerprint,
     print_report,
 )
 from agent_trace.models import EventType, SessionMeta, TraceEvent
@@ -240,7 +246,16 @@ class TestComputeDrift(unittest.TestCase):
         fp = self._make_fp({"Bash": 1.0})
         report = compute_drift(fp, fp)
         names = {d.name for d in report.dimensions}
-        expected = {"tool_mix", "error_rate", "retry_rate", "blast_radius", "session_duration_s", "decision_depth"}
+        expected = {
+            "tool_mix",
+            "error_rate",
+            "retry_rate",
+            "tool_calls",
+            "cost_usd",
+            "blast_radius",
+            "session_duration_s",
+            "decision_depth",
+        }
         self.assertEqual(names, expected)
 
 
@@ -304,6 +319,112 @@ class TestDriftEndToEnd(unittest.TestCase):
         loaded = BehavioralFingerprint.from_json(Path(path).read_text())
         self.assertEqual(loaded.fingerprint_id, "saved_fp")
         self.assertEqual(loaded.sessions, 3)
+
+
+class TestFingerprintCommand(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = _make_store(self.tmp)
+
+    def _args(self, **kwargs):
+        defaults = dict(
+            trace_dir=self.tmp,
+            sessions=20,
+            output=None,
+            id="",
+            compare=None,
+            threshold=0.20,
+            format="text",
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_print_fingerprint_contains_profile(self):
+        now = time.time()
+        _add_session(self.store, "fp_print", [_tool_call("Bash", now)], started_at=now)
+        fp = compute_fingerprint(self.store, ["fp_print"], fingerprint_id="fp")
+        out = io.StringIO()
+        print_fingerprint(fp, out)
+        text = out.getvalue()
+        self.assertIn("Behavioral fingerprint", text)
+        self.assertIn("Tool call profile", text)
+        self.assertIn("Bash", text)
+
+    def test_cmd_fingerprint_json(self):
+        now = time.time()
+        _add_session(self.store, "fp_json", [_tool_call("Read", now)], started_at=now)
+        captured = io.StringIO()
+
+        with patch("sys.stdout", captured):
+            result = cmd_fingerprint(self._args(format="json"))
+
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["sessions"], 1)
+        self.assertIn("Read", data["tool_mix"])
+        self.assertIn("tool_calls", data)
+        self.assertIn("cost_usd", data)
+
+    def test_cmd_fingerprint_writes_output(self):
+        now = time.time()
+        _add_session(self.store, "fp_out", [_tool_call("Write", now)], started_at=now)
+        output = Path(self.tmp) / "fingerprint.json"
+
+        result = cmd_fingerprint(self._args(output=str(output), id="saved"))
+
+        self.assertEqual(result, 0)
+        data = json.loads(output.read_text())
+        self.assertEqual(data["fingerprint_id"], "saved")
+        self.assertEqual(data["sessions"], 1)
+
+    def test_cmd_fingerprint_json_with_output_keeps_stdout_parseable(self):
+        now = time.time()
+        _add_session(self.store, "fp_json_out", [_tool_call("Read", now)], started_at=now)
+        output = Path(self.tmp) / "fingerprint.json"
+        captured = io.StringIO()
+
+        with patch("sys.stdout", captured):
+            result = cmd_fingerprint(self._args(output=str(output), format="json"))
+
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["sessions"], 1)
+        self.assertTrue(output.exists())
+
+    def test_cmd_fingerprint_compare_json(self):
+        first = BehavioralFingerprint(
+            fingerprint_id="a",
+            sessions=2,
+            period_start="2026-01-01",
+            period_end="2026-01-02",
+            tool_mix={"Bash": 1.0},
+        )
+        second = BehavioralFingerprint(
+            fingerprint_id="b",
+            sessions=2,
+            period_start="2026-01-03",
+            period_end="2026-01-04",
+            tool_mix={"Read": 1.0},
+        )
+        a_path = Path(self.tmp) / "a.json"
+        b_path = Path(self.tmp) / "b.json"
+        a_path.write_text(first.to_json())
+        b_path.write_text(second.to_json())
+        captured = io.StringIO()
+
+        with patch("sys.stdout", captured):
+            result = cmd_fingerprint(self._args(compare=[str(a_path), str(b_path)], format="json"))
+
+        self.assertEqual(result, 1)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["label"], "high")
+
+    def test_parser_registers_fingerprint(self):
+        parser = build_parser()
+        args = parser.parse_args(["fingerprint", "--sessions", "5", "--output", "fp.json"])
+        self.assertEqual(args.command, "fingerprint")
+        self.assertEqual(args.sessions, 5)
+        self.assertEqual(args.output, "fp.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `agent-strace fingerprint` for behavioral profiles from recent sessions
- support JSON/file output and direct comparison of saved fingerprints
- extend fingerprints with tool-call and cost profiles
- document the command and bump version to `0.71.0`

Closes #179

## Verification
- `python3 -m pytest tests/test_drift.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m pytest tests/ -v`