### PR TITLE
Add tool-call regression fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |
 | [`agent-strace drift`](docs/commands.md#drift) | Detect behavioural drift over time |
 | [`agent-strace fingerprint`](docs/commands.md#fingerprint) | Baseline an agent's behavioural profile |
+| [`agent-strace freeze`](docs/commands.md#freeze) | Freeze a tool-call sequence for regression checks |
 | [`agent-strace standup`](docs/commands.md#standup) | Plain-English summary of yesterday's sessions |
 | [`agent-strace eval <id>`](docs/commands.md#eval) | Score a session against behavioural baselines |
 | [`agent-strace eval ci`](docs/commands.md#eval) | Fail CI on behavioural regression |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -336,6 +336,13 @@ agent-strace fingerprint --compare A.json B.json [--threshold N] [--format text|
 ```
 Characterize an agent's recent behavior: tool mix, error rate, retry rate, file touch radius, duration, and decision depth. Saved JSON fingerprints can be used as drift baselines or compared directly.
 
+### `freeze`
+```
+agent-strace freeze [session-id] [--output FILE] [--task TEXT] [--format text|json]
+agent-strace regression <fixture-file> [session-id] [--threshold N] [--format text|json]
+```
+Freeze a session's tool-call sequence as a JSON fixture containing tool names and stable input hashes, not raw tool inputs. `regression` compares a later session against the fixture and exits non-zero when structural divergence exceeds `--threshold` (default: `0.0`).
+
 ### `lint`
 ```
 agent-strace lint [session-id] [--all] [--since DURATION] [--strict] [--format text|json]

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.71.0"
+__version__ = "0.72.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -60,6 +60,7 @@ from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
 from .team_report import cmd_team_report
 from .compare import cmd_compare
+from .freeze import cmd_freeze, cmd_regression
 from .timeline import cmd_timeline
 from .config_watch import cmd_config_watch
 from .lint import cmd_lint
@@ -1246,6 +1247,23 @@ def build_parser() -> argparse.ArgumentParser:
     p_fingerprint.add_argument("--format", choices=["text", "json"], default="text",
                                help="output format (default: text)")
 
+    # freeze/regression (tool-call sequence fixtures)
+    p_freeze = sub.add_parser("freeze", help="freeze a session's tool-call sequence as a fixture")
+    p_freeze.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_freeze.add_argument("--output", "-o", metavar="FILE",
+                          help="write fixture JSON to FILE")
+    p_freeze.add_argument("--task", default="", help="task description to store in the fixture")
+    p_freeze.add_argument("--format", choices=["text", "json"], default="text",
+                          help="output format (default: text)")
+
+    p_regression = sub.add_parser("regression", help="compare a session against a frozen fixture")
+    p_regression.add_argument("fixture_file", help="fixture JSON written by agent-strace freeze")
+    p_regression.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_regression.add_argument("--threshold", type=float, default=0.0,
+                              help="allowed divergence before failing (default: 0.0)")
+    p_regression.add_argument("--format", choices=["text", "json"], default="text",
+                              help="output format (default: text)")
+
     # optimize (propose AGENTS.md / skill file improvements from trace failures)
     p_opt = sub.add_parser("optimize", help="propose instruction file improvements from trace failures")
     p_opt.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
@@ -1579,6 +1597,8 @@ def main() -> None:
         "budget-report": cmd_budget_report,
         "team-report": cmd_team_report,
         "compare": cmd_compare,
+        "freeze": cmd_freeze,
+        "regression": cmd_regression,
         "config-watch": cmd_config_watch,
         "lint": cmd_lint,
         "retention": cmd_retention,

--- a/src/agent_trace/freeze.py
+++ b/src/agent_trace/freeze.py
@@ -1,0 +1,402 @@
+"""Behavioral regression fixtures for tool-call sequences."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+from .models import EventType, TraceEvent
+from .store import TraceStore
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class FrozenStep:
+    seq: int
+    tool: str
+    input_hash: str
+
+    @property
+    def signature(self) -> tuple[str, str]:
+        return (self.tool, self.input_hash)
+
+
+@dataclass
+class RegressionFixture:
+    session: str
+    task: str
+    steps: list[FrozenStep]
+    schema_version: int = SCHEMA_VERSION
+    created_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "session": self.session,
+            "task": self.task,
+            "created_at": self.created_at,
+            "steps": [asdict(step) for step in self.steps],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> "RegressionFixture":
+        raw = json.loads(text)
+        return cls(
+            schema_version=int(raw.get("schema_version", SCHEMA_VERSION)),
+            session=str(raw.get("session", "")),
+            task=str(raw.get("task", "")),
+            created_at=float(raw.get("created_at", 0.0) or 0.0),
+            steps=[
+                FrozenStep(
+                    seq=int(step.get("seq", index + 1)),
+                    tool=str(step.get("tool", "")),
+                    input_hash=str(step.get("input_hash", "")),
+                )
+                for index, step in enumerate(raw.get("steps", []))
+            ],
+        )
+
+
+@dataclass
+class RegressionChange:
+    kind: str
+    expected_seq: int | None = None
+    actual_seq: int | None = None
+    tool: str = ""
+    expected_hash: str = ""
+    actual_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v not in (None, "")}
+
+
+@dataclass
+class RegressionReport:
+    fixture: str
+    actual: str
+    expected_steps: int
+    actual_steps: int
+    edit_distance: int
+    divergence_score: float
+    threshold: float
+    exceeded: bool
+    changes: list[RegressionChange]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fixture": self.fixture,
+            "actual": self.actual,
+            "expected_steps": self.expected_steps,
+            "actual_steps": self.actual_steps,
+            "edit_distance": self.edit_distance,
+            "divergence_score": self.divergence_score,
+            "threshold": self.threshold,
+            "exceeded": self.exceeded,
+            "changes": [change.to_dict() for change in self.changes],
+        }
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _input_hash(value: Any) -> str:
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def _tool_name(event: TraceEvent) -> str:
+    return str(
+        event.data.get("tool_name")
+        or event.data.get("name")
+        or event.data.get("tool")
+        or "unknown"
+    )
+
+
+def _tool_input(event: TraceEvent) -> Any:
+    if "arguments" in event.data:
+        return event.data["arguments"]
+    if "input" in event.data:
+        return event.data["input"]
+    if "args" in event.data:
+        return event.data["args"]
+    return {}
+
+
+def extract_steps(events: list[TraceEvent]) -> list[FrozenStep]:
+    steps: list[FrozenStep] = []
+    for event in events:
+        if event.event_type != EventType.TOOL_CALL:
+            continue
+        steps.append(
+            FrozenStep(
+                seq=len(steps) + 1,
+                tool=_tool_name(event),
+                input_hash=_input_hash(_tool_input(event)),
+            )
+        )
+    return steps
+
+
+def _session_task(events: list[TraceEvent], fallback: str = "") -> str:
+    for event in events:
+        if event.event_type != EventType.USER_PROMPT:
+            continue
+        task = (
+            event.data.get("prompt")
+            or event.data.get("content")
+            or event.data.get("text")
+            or ""
+        )
+        if task:
+            return str(task)
+    return fallback
+
+
+def freeze_session(
+    store: TraceStore,
+    session_id: str,
+    task: str = "",
+) -> RegressionFixture:
+    meta = store.load_meta(session_id)
+    events = store.load_events(session_id)
+    return RegressionFixture(
+        session=session_id,
+        task=task or _session_task(events, meta.command or meta.agent_name),
+        created_at=time.time(),
+        steps=extract_steps(events),
+    )
+
+
+def _edit_distance(a: list[tuple[str, str]], b: list[tuple[str, str]]) -> int:
+    m, n = len(a), len(b)
+    if m == 0:
+        return n
+    if n == 0:
+        return m
+    dp = list(range(n + 1))
+    for i in range(1, m + 1):
+        prev = dp[0]
+        dp[0] = i
+        for j in range(1, n + 1):
+            temp = dp[j]
+            if a[i - 1] == b[j - 1]:
+                dp[j] = prev
+            else:
+                dp[j] = 1 + min(prev, dp[j], dp[j - 1])
+            prev = temp
+    return dp[n]
+
+
+def _signature_positions(steps: list[FrozenStep]) -> dict[tuple[str, str], int]:
+    positions: dict[tuple[str, str], int] = {}
+    for step in steps:
+        positions.setdefault(step.signature, step.seq)
+    return positions
+
+
+def _find_matching_tool(step: FrozenStep, candidates: list[FrozenStep]) -> FrozenStep | None:
+    for candidate in candidates:
+        if candidate.tool == step.tool:
+            return candidate
+    return None
+
+
+def compare_fixtures(
+    expected: RegressionFixture,
+    actual: RegressionFixture,
+    threshold: float = 0.0,
+) -> RegressionReport:
+    expected_signatures = [step.signature for step in expected.steps]
+    actual_signatures = [step.signature for step in actual.steps]
+    edit_distance = _edit_distance(expected_signatures, actual_signatures)
+    denominator = max(len(expected.steps), len(actual.steps), 1)
+    score = round(edit_distance / denominator, 3)
+
+    expected_positions = _signature_positions(expected.steps)
+    actual_positions = _signature_positions(actual.steps)
+    changes: list[RegressionChange] = []
+
+    for step in expected.steps:
+        actual_seq = actual_positions.get(step.signature)
+        if actual_seq is not None and actual_seq != step.seq:
+            changes.append(
+                RegressionChange(
+                    kind="reordered",
+                    expected_seq=step.seq,
+                    actual_seq=actual_seq,
+                    tool=step.tool,
+                    expected_hash=step.input_hash,
+                    actual_hash=step.input_hash,
+                )
+            )
+
+    for step in expected.steps:
+        if step.signature in actual_positions:
+            continue
+        match = _find_matching_tool(
+            step,
+            [candidate for candidate in actual.steps if candidate.signature not in expected_positions],
+        )
+        if match:
+            changes.append(
+                RegressionChange(
+                    kind="changed_input",
+                    expected_seq=step.seq,
+                    actual_seq=match.seq,
+                    tool=step.tool,
+                    expected_hash=step.input_hash,
+                    actual_hash=match.input_hash,
+                )
+            )
+        else:
+            changes.append(
+                RegressionChange(
+                    kind="removed",
+                    expected_seq=step.seq,
+                    tool=step.tool,
+                    expected_hash=step.input_hash,
+                )
+            )
+
+    for step in actual.steps:
+        if step.signature in expected_positions:
+            continue
+        match = _find_matching_tool(
+            step,
+            [candidate for candidate in expected.steps if candidate.signature not in actual_positions],
+        )
+        if match:
+            continue
+        changes.append(
+            RegressionChange(
+                kind="added",
+                actual_seq=step.seq,
+                tool=step.tool,
+                actual_hash=step.input_hash,
+            )
+        )
+
+    return RegressionReport(
+        fixture=expected.session,
+        actual=actual.session,
+        expected_steps=len(expected.steps),
+        actual_steps=len(actual.steps),
+        edit_distance=edit_distance,
+        divergence_score=score,
+        threshold=threshold,
+        exceeded=score > threshold,
+        changes=changes,
+    )
+
+
+def print_regression_report(report: RegressionReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    status = "FAIL" if report.exceeded else "PASS"
+    w("\nTool-call regression report\n")
+    w(f"Status:    {status}\n")
+    w(f"Fixture:   {report.fixture}\n")
+    w(f"Actual:    {report.actual}\n")
+    w(f"Steps:     {report.expected_steps} expected, {report.actual_steps} actual\n")
+    w(f"Divergence: {report.divergence_score:.3f} (threshold {report.threshold:.3f})\n")
+    if not report.changes:
+        w("Changes:   none\n\n")
+        return
+    w("Changes:\n")
+    for change in report.changes:
+        if change.kind == "reordered":
+            w(f"  reordered: {change.tool} expected #{change.expected_seq}, actual #{change.actual_seq}\n")
+        elif change.kind == "changed_input":
+            w(f"  changed input: {change.tool} expected #{change.expected_seq}, actual #{change.actual_seq}\n")
+        elif change.kind == "removed":
+            w(f"  removed: {change.tool} expected #{change.expected_seq}\n")
+        elif change.kind == "added":
+            w(f"  added: {change.tool} actual #{change.actual_seq}\n")
+    w("\n")
+
+
+def _resolve_session(store: TraceStore, raw: str | None) -> str | None:
+    if raw:
+        return store.find_session(raw)
+    latest = store.get_latest_session()
+    return latest.session_id if latest else None
+
+
+def _default_fixture_path(session_id: str) -> Path:
+    return Path(".agent-strace-fixtures") / f"{session_id}.json"
+
+
+def cmd_freeze(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    session_id = _resolve_session(store, getattr(args, "session_id", None))
+    if not session_id:
+        sys.stderr.write(f"Session not found: {getattr(args, 'session_id', '')}\n")
+        return 1
+
+    try:
+        fixture = freeze_session(store, session_id, task=getattr(args, "task", "") or "")
+    except Exception as exc:
+        sys.stderr.write(f"Could not freeze session {session_id}: {exc}\n")
+        return 1
+
+    fmt = getattr(args, "format", "text")
+    output = getattr(args, "output", None)
+    if output is None and fmt == "text":
+        output = str(_default_fixture_path(session_id))
+
+    if output:
+        out_path = Path(output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(fixture.to_json() + "\n")
+        message = f"Frozen fixture written to {out_path}\n"
+        if fmt == "json":
+            sys.stderr.write(message)
+        else:
+            sys.stdout.write(message)
+
+    if fmt == "json":
+        sys.stdout.write(fixture.to_json() + "\n")
+    elif not output:
+        sys.stdout.write(fixture.to_json() + "\n")
+
+    return 0
+
+
+def cmd_regression(args: argparse.Namespace) -> int:
+    fixture_path = Path(args.fixture_file)
+    try:
+        expected = RegressionFixture.from_json(fixture_path.read_text())
+    except Exception as exc:
+        sys.stderr.write(f"Could not read fixture {fixture_path}: {exc}\n")
+        return 1
+
+    store = TraceStore(args.trace_dir)
+    session_id = _resolve_session(store, getattr(args, "session_id", None))
+    if not session_id:
+        sys.stderr.write("Session not found. Provide a session ID or record a session first.\n")
+        return 1
+
+    try:
+        actual = freeze_session(store, session_id)
+    except Exception as exc:
+        sys.stderr.write(f"Could not load session {session_id}: {exc}\n")
+        return 1
+
+    threshold = float(getattr(args, "threshold", 0.0) or 0.0)
+    report = compare_fixtures(expected, actual, threshold=threshold)
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n")
+    else:
+        print_regression_report(report)
+    return 1 if report.exceeded else 0

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,0 +1,218 @@
+"""Tests for freeze/regression fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.cli import build_parser
+from agent_trace.freeze import (
+    RegressionFixture,
+    cmd_freeze,
+    cmd_regression,
+    compare_fixtures,
+    extract_steps,
+    freeze_session,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _make_store() -> TraceStore:
+    return TraceStore(tempfile.mkdtemp())
+
+
+def _add_session(
+    store: TraceStore,
+    session_id: str,
+    tools: list[tuple[str, dict]],
+    prompt: str = "fix auth",
+) -> str:
+    meta = SessionMeta(session_id=session_id, command=prompt)
+    store.create_session(meta)
+    store.append_event(
+        session_id,
+        TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            session_id=session_id,
+            data={"prompt": prompt},
+        ),
+    )
+    for tool, arguments in tools:
+        store.append_event(
+            session_id,
+            TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                session_id=session_id,
+                data={"tool_name": tool, "arguments": arguments},
+            ),
+        )
+    return session_id
+
+
+class TestFreezeHelpers(unittest.TestCase):
+    def test_extract_steps_hashes_inputs(self):
+        events = [
+            TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                data={"tool_name": "Bash", "arguments": {"command": "pytest"}},
+            )
+        ]
+        steps = extract_steps(events)
+        self.assertEqual(len(steps), 1)
+        self.assertEqual(steps[0].tool, "Bash")
+        self.assertEqual(len(steps[0].input_hash), 64)
+
+    def test_freeze_does_not_store_raw_arguments(self):
+        store = _make_store()
+        sid = _add_session(
+            store,
+            "abc123",
+            [("Bash", {"command": "echo secret-token"})],
+        )
+        fixture = freeze_session(store, sid)
+        text = fixture.to_json()
+        self.assertIn("input_hash", text)
+        self.assertNotIn("secret-token", text)
+
+    def test_fixture_round_trip(self):
+        store = _make_store()
+        sid = _add_session(store, "abc123", [("Read", {"file_path": "a.py"})])
+        fixture = freeze_session(store, sid, task="custom task")
+        loaded = RegressionFixture.from_json(fixture.to_json())
+        self.assertEqual(loaded.session, sid)
+        self.assertEqual(loaded.task, "custom task")
+        self.assertEqual(loaded.steps[0].tool, "Read")
+
+
+class TestRegressionCompare(unittest.TestCase):
+    def _fixture(self, store: TraceStore, sid: str, tools: list[tuple[str, dict]]) -> RegressionFixture:
+        _add_session(store, sid, tools)
+        return freeze_session(store, sid)
+
+    def test_identical_sequence_passes(self):
+        store = _make_store()
+        expected = self._fixture(store, "a", [("Read", {"file_path": "a.py"})])
+        actual = self._fixture(store, "b", [("Read", {"file_path": "a.py"})])
+        report = compare_fixtures(expected, actual)
+        self.assertFalse(report.exceeded)
+        self.assertEqual(report.divergence_score, 0.0)
+        self.assertEqual(report.changes, [])
+
+    def test_changed_input_fails(self):
+        store = _make_store()
+        expected = self._fixture(store, "a", [("Read", {"file_path": "a.py"})])
+        actual = self._fixture(store, "b", [("Read", {"file_path": "b.py"})])
+        report = compare_fixtures(expected, actual)
+        self.assertTrue(report.exceeded)
+        self.assertEqual(report.changes[0].kind, "changed_input")
+
+    def test_added_step_reported(self):
+        store = _make_store()
+        expected = self._fixture(store, "a", [("Read", {"file_path": "a.py"})])
+        actual = self._fixture(
+            store,
+            "b",
+            [("Read", {"file_path": "a.py"}), ("Bash", {"command": "pytest"})],
+        )
+        report = compare_fixtures(expected, actual)
+        self.assertTrue(report.exceeded)
+        self.assertIn("added", {change.kind for change in report.changes})
+
+    def test_reordered_step_reported(self):
+        store = _make_store()
+        expected = self._fixture(
+            store,
+            "a",
+            [("Read", {"file_path": "a.py"}), ("Bash", {"command": "pytest"})],
+        )
+        actual = self._fixture(
+            store,
+            "b",
+            [("Bash", {"command": "pytest"}), ("Read", {"file_path": "a.py"})],
+        )
+        report = compare_fixtures(expected, actual)
+        self.assertTrue(report.exceeded)
+        self.assertIn("reordered", {change.kind for change in report.changes})
+
+
+class TestFreezeCommands(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmp)
+        _add_session(self.store, "abc123", [("Read", {"file_path": "a.py"})])
+
+    def _freeze_args(self, **kwargs):
+        defaults = dict(
+            trace_dir=self.tmp,
+            session_id="abc",
+            output=None,
+            task="",
+            format="text",
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def _regression_args(self, **kwargs):
+        defaults = dict(
+            trace_dir=self.tmp,
+            fixture_file="",
+            session_id="abc",
+            threshold=0.0,
+            format="text",
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_cmd_freeze_writes_output(self):
+        output = Path(self.tmp) / "fixture.json"
+        result = cmd_freeze(self._freeze_args(output=str(output), task="stored task"))
+        self.assertEqual(result, 0)
+        data = json.loads(output.read_text())
+        self.assertEqual(data["task"], "stored task")
+        self.assertEqual(data["steps"][0]["tool"], "Read")
+
+    def test_cmd_freeze_json_stdout_parseable_with_output(self):
+        output = Path(self.tmp) / "fixture.json"
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            result = cmd_freeze(self._freeze_args(output=str(output), format="json"))
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["session"], "abc123")
+
+    def test_cmd_regression_json_fails_on_divergence(self):
+        fixture_path = Path(self.tmp) / "fixture.json"
+        fixture_path.write_text(freeze_session(self.store, "abc123").to_json())
+        _add_session(self.store, "def456", [("Bash", {"command": "pytest"})])
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            result = cmd_regression(
+                self._regression_args(
+                    fixture_file=str(fixture_path),
+                    session_id="def",
+                    format="json",
+                )
+            )
+        self.assertEqual(result, 1)
+        data = json.loads(captured.getvalue())
+        self.assertTrue(data["exceeded"])
+
+    def test_parser_registers_commands(self):
+        parser = build_parser()
+        freeze_args = parser.parse_args(["freeze", "abc", "--output", "fixture.json"])
+        self.assertEqual(freeze_args.command, "freeze")
+        self.assertEqual(freeze_args.output, "fixture.json")
+
+        regression_args = parser.parse_args(["regression", "fixture.json", "abc", "--threshold", "0.25"])
+        self.assertEqual(regression_args.command, "regression")
+        self.assertEqual(regression_args.threshold, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `agent-strace freeze` to save a session's tool-call sequence as a JSON fixture
- add `agent-strace regression` to compare a later session against a frozen fixture
- store stable tool input hashes instead of raw tool arguments
- document the commands and bump version to `0.72.0`

Closes #175

## Verification
- `python3 -m pytest tests/test_freeze.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m agent_trace.cli freeze --help`
- `python3 -m agent_trace.cli regression --help`
- `python3 -m pytest tests/ -v`