### PR TITLE
Add first-class session tree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |
 | [`agent-strace drift`](docs/commands.md#drift) | Detect behavioural drift over time |
 | [`agent-strace fingerprint`](docs/commands.md#fingerprint) | Baseline an agent's behavioural profile |
+| [`agent-strace tree`](docs/commands.md#tree) | Show parent/child session hierarchy |
 | [`agent-strace freeze`](docs/commands.md#freeze) | Freeze a tool-call sequence for regression checks |
 | [`agent-strace standup`](docs/commands.md#standup) | Plain-English summary of yesterday's sessions |
 | [`agent-strace eval <id>`](docs/commands.md#eval) | Score a session against behavioural baselines |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,20 +8,23 @@ Full flag reference for every `agent-strace` command.
 
 ### `record`
 ```
-agent-strace record [--name NAME] [--no-redact] [--mask] -- <command>
+agent-strace record [--name NAME] [--parent SESSION] [--no-redact] [--mask] -- <command>
 ```
 Capture an MCP stdio server session. Wraps `<command>` as a transparent proxy.
 
 | Flag | Description |
 |---|---|
 | `--name NAME` | Label for the session |
+| `--parent SESSION` | Link this session as a child of a parent session |
 | `--redact` | Strip secrets before writing to disk; kept for compatibility because this is now the default |
 | `--no-redact` | Disable automatic secret redaction |
 | `--mask` | Mask PII (email, phone, CC, SSN) |
 
+`AGENT_STRACE_PARENT_SESSION` can also be set by orchestrators that spawn child agents.
+
 ### `record-http`
 ```
-agent-strace record-http <url> [--port N] [--no-redact] [--mask]
+agent-strace record-http <url> [--port N] [--parent SESSION] [--no-redact] [--mask]
 ```
 Capture an MCP HTTP/SSE server session. Listens on `--port` (default: 3100) and proxies to `<url>`.
 
@@ -57,6 +60,12 @@ agent-strace replay [session-id] [--format terminal|html] [--live] [--speed N]
 | `--limit N` | Cap at N events |
 | `--expand-subagents` | Inline subagent sessions under parent tool_call |
 | `--tree` | Show session hierarchy without full replay |
+
+### `tree`
+```
+agent-strace tree [session-id] [--format text|json]
+```
+Show the parent/child session hierarchy for a root session, including per-node cost, tool calls, status, and duration. Parent links come from `record --parent`, `AGENT_STRACE_PARENT_SESSION`, A2A trace propagation, or imported trace metadata.
 
 ### `list`
 ```

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.72.0"
+__version__ = "0.73.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -74,7 +74,7 @@ from .models import EventType, SessionMeta, TraceEvent
 from .proxy import MCPProxy
 from .replay import format_event, format_summary, list_sessions, replay_session
 from .store import TraceStore
-from .subagent import cmd_replay_tree, cmd_stats_tree
+from .subagent import cmd_replay_tree, cmd_stats_tree, cmd_tree
 from .why import cmd_why
 
 
@@ -94,6 +94,34 @@ def _redact_setting(args: argparse.Namespace) -> bool | None:
     return None
 
 
+def _parent_session_id(args: argparse.Namespace) -> str:
+    return (
+        getattr(args, "parent", None)
+        or os.environ.get("AGENT_STRACE_PARENT_SESSION", "")
+    )
+
+
+def _resolve_parent_session_id(store: TraceStore, args: argparse.Namespace) -> str:
+    raw = _parent_session_id(args)
+    if not raw:
+        return ""
+    return store.find_session(raw) or raw
+
+
+def _parent_event_id() -> str:
+    return os.environ.get("AGENT_STRACE_PARENT_EVENT", "")
+
+
+def _parent_depth(store: TraceStore, parent_session_id: str) -> int:
+    if not parent_session_id:
+        return 0
+    try:
+        parent_meta = store.load_meta(parent_session_id)
+        return parent_meta.depth + 1
+    except Exception:
+        return 1
+
+
 def cmd_record(args: argparse.Namespace) -> int:
     """Record an MCP server session."""
     store = TraceStore(args.trace_dir, redact=_redact_setting(args))
@@ -103,9 +131,13 @@ def cmd_record(args: argparse.Namespace) -> int:
     if server_cmd and server_cmd[0] == "--":
         server_cmd = server_cmd[1:]
 
+    parent_session_id = _resolve_parent_session_id(store, args)
     meta = SessionMeta(
         agent_name=args.name or "",
         command=" ".join(server_cmd),
+        parent_session_id=parent_session_id,
+        parent_event_id=_parent_event_id(),
+        depth=_parent_depth(store, parent_session_id),
     )
     store.create_session(meta)
 
@@ -143,9 +175,13 @@ def cmd_record_http(args: argparse.Namespace) -> int:
     """Record a remote MCP server session over HTTP/SSE."""
     store = TraceStore(args.trace_dir, redact=_redact_setting(args))
 
+    parent_session_id = _resolve_parent_session_id(store, args)
     meta = SessionMeta(
         agent_name=args.name or "",
         command=f"http-proxy -> {args.url}",
+        parent_session_id=parent_session_id,
+        parent_event_id=_parent_event_id(),
+        depth=_parent_depth(store, parent_session_id),
     )
     store.create_session(meta)
 
@@ -686,6 +722,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_record.add_argument("--verbose", "-v", action="store_true", help="print events to stderr during recording")
     p_record.add_argument("--quiet", "-q", action="store_true", help="suppress all output except errors")
+    p_record.add_argument("--parent", metavar="SESSION",
+                          help="parent session ID for subagent correlation")
     p_record.add_argument("server_cmd", nargs=argparse.REMAINDER, help="MCP server command to run")
 
     # record-http
@@ -706,6 +744,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_record_http.add_argument("--verbose", "-v", action="store_true", help="print events to stderr during recording")
     p_record_http.add_argument("--quiet", "-q", action="store_true", help="suppress all output except errors")
+    p_record_http.add_argument("--parent", metavar="SESSION",
+                               help="parent session ID for subagent correlation")
 
     # replay
     p_replay = sub.add_parser("replay", help="replay a recorded session")
@@ -725,6 +765,12 @@ def build_parser() -> argparse.ArgumentParser:
                           help="inline subagent sessions under their parent tool_call")
     p_replay.add_argument("--tree", action="store_true",
                           help="show session hierarchy tree without full event replay")
+
+    # tree
+    p_tree = sub.add_parser("tree", help="show a parent/child session hierarchy")
+    p_tree.add_argument("session_id", nargs="?", help="root session ID or prefix (default: latest)")
+    p_tree.add_argument("--format", choices=["text", "json"], default="text",
+                        help="output format (default: text)")
 
     # list
     sub.add_parser("list", help="list all recorded sessions")
@@ -1580,6 +1626,7 @@ def main() -> None:
         "baseline": cmd_baseline,
         "drift": cmd_drift,
         "fingerprint": cmd_fingerprint,
+        "tree": cmd_tree,
         "identity": cmd_identity,
         "workspace": cmd_workspace,
         "compliance": cmd_compliance,

--- a/src/agent_trace/subagent.py
+++ b/src/agent_trace/subagent.py
@@ -11,6 +11,7 @@ parent_event_id. This module provides:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import dataclass, field
 from typing import TextIO
@@ -252,6 +253,89 @@ def format_tree_summary(
         format_tree_summary(child, out=out, last_child=(i == len(node.children) - 1))
 
 
+def _status(meta: SessionMeta) -> str:
+    if meta.errors:
+        return "error"
+    return "ok"
+
+
+def _duration_seconds(meta: SessionMeta) -> float:
+    if meta.total_duration_ms:
+        return meta.total_duration_ms / 1000
+    if meta.ended_at and meta.started_at:
+        return max(0.0, meta.ended_at - meta.started_at)
+    return 0.0
+
+
+def _node_cost(store: TraceStore, session_id: str) -> float:
+    try:
+        from .cost import estimate_cost
+        return estimate_cost(store, session_id).total_cost
+    except Exception:
+        return 0.0
+
+
+def _cost_map(store: TraceStore, node: SessionNode) -> dict[str, float]:
+    costs = {node.meta.session_id: _node_cost(store, node.meta.session_id)}
+    for child in node.children:
+        costs.update(_cost_map(store, child))
+    return costs
+
+
+def tree_to_dict(
+    node: SessionNode,
+    costs: dict[str, float] | None = None,
+) -> dict:
+    costs = costs or {}
+    return {
+        "session_id": node.meta.session_id,
+        "agent": node.meta.agent_name or node.meta.command or "",
+        "depth": node.depth,
+        "parent_session_id": node.meta.parent_session_id,
+        "parent_event_id": node.meta.parent_event_id,
+        "cost_usd": round(costs.get(node.meta.session_id, 0.0), 6),
+        "tool_calls": node.meta.tool_calls,
+        "llm_requests": node.meta.llm_requests,
+        "errors": node.meta.errors,
+        "status": _status(node.meta),
+        "duration_s": round(_duration_seconds(node.meta), 3),
+        "children": [tree_to_dict(child, costs) for child in node.children],
+    }
+
+
+def format_session_tree(
+    node: SessionNode,
+    costs: dict[str, float] | None = None,
+    out: TextIO = sys.stdout,
+    last_child: bool = False,
+) -> None:
+    """Print a compact tree with per-session cost, calls, status, and duration."""
+    costs = costs or {}
+    indent = _indent(node.depth, last_child=last_child)
+    duration = _duration_seconds(node.meta)
+    status = "✗" if node.meta.errors else "✓"
+    agent = node.meta.agent_name or node.meta.command or "session"
+    out.write(
+        f"{indent}{node.meta.session_id[:12]}  "
+        f"{agent[:28]:<28}  "
+        f"${costs.get(node.meta.session_id, 0.0):.4f}  "
+        f"{node.meta.tool_calls} tools  "
+        f"{duration:.1f}s  "
+        f"{status}"
+    )
+    if node.meta.errors:
+        out.write(f"  {node.meta.errors} errors")
+    out.write("\n")
+
+    for i, child in enumerate(node.children):
+        format_session_tree(
+            child,
+            costs=costs,
+            out=out,
+            last_child=(i == len(node.children) - 1),
+        )
+
+
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------
@@ -320,4 +404,49 @@ def cmd_stats_tree(args: argparse.Namespace) -> int:
         format_tree_summary(tree)
         sys.stdout.write("\n")
 
+    return 0
+
+
+def cmd_tree(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+
+    session_id = args.session_id or store.get_latest_session_id()
+    if not session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+    full_id = store.find_session(session_id)
+    if not full_id:
+        sys.stderr.write(f"Session not found: {session_id}\n")
+        return 1
+
+    try:
+        tree = build_tree(store, full_id)
+    except KeyError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
+    costs = _cost_map(store, tree)
+    stats = aggregate_stats(tree)
+    if getattr(args, "format", "text") == "json":
+        data = {
+            "root_session_id": full_id,
+            "total_sessions": stats.session_count,
+            "total_cost_usd": round(sum(costs.values()), 6),
+            "total_tool_calls": stats.tool_calls,
+            "total_llm_requests": stats.llm_requests,
+            "total_errors": stats.errors,
+            "tree": tree_to_dict(tree, costs),
+        }
+        sys.stdout.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        return 0
+
+    sys.stdout.write(f"\nSession tree for {full_id[:12]}\n\n")
+    format_session_tree(tree, costs=costs)
+    sys.stdout.write(
+        f"\nTotal: {stats.session_count} sessions, "
+        f"${sum(costs.values()):.4f}, "
+        f"{stats.tool_calls} tool calls, "
+        f"{stats.llm_requests} LLM requests"
+        f"{', ' + str(stats.errors) + ' errors' if stats.errors else ''}\n\n"
+    )
     return 0

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -2,9 +2,17 @@
 
 import io
 import json
+import argparse
 import tempfile
 import unittest
+from unittest.mock import patch
 
+from agent_trace.cli import (
+    build_parser,
+    _parent_depth,
+    _parent_session_id,
+    _resolve_parent_session_id,
+)
 from agent_trace.models import EventType, SessionMeta, TraceEvent
 from agent_trace.store import TraceStore
 from agent_trace.subagent import (
@@ -12,8 +20,11 @@ from agent_trace.subagent import (
     SessionNode,
     aggregate_stats,
     build_tree,
+    cmd_tree,
     format_tree,
+    format_session_tree,
     format_tree_summary,
+    tree_to_dict,
 )
 
 
@@ -254,6 +265,102 @@ class TestFormatTree(unittest.TestCase):
         buf = io.StringIO()
         format_tree(root_node, out=buf, expand=False)
         self.assertNotIn("child003", buf.getvalue())
+
+
+class TestSessionTreeCommand(unittest.TestCase):
+    def _make_tree(self):
+        root_meta = SessionMeta(
+            session_id="rootcmd1",
+            agent_name="orchestrator",
+            started_at=0.0,
+            tool_calls=3,
+            llm_requests=1,
+            total_duration_ms=4000,
+        )
+        child_meta = SessionMeta(
+            session_id="childcmd1",
+            agent_name="worker",
+            started_at=1.0,
+            parent_session_id="rootcmd1",
+            depth=1,
+            tool_calls=2,
+            total_duration_ms=1500,
+        )
+        return _make_store_with_sessions([
+            (root_meta, [_make_event(EventType.SESSION_END, 4.0, "rootcmd1")]),
+            (child_meta, [_make_event(EventType.SESSION_END, 2.0, "childcmd1")]),
+        ])
+
+    def test_tree_to_dict_contains_children(self):
+        store, tmp = self._make_tree()
+        tree = build_tree(store, "rootcmd1")
+        data = tree_to_dict(tree, {"rootcmd1": 0.01, "childcmd1": 0.02})
+        self.assertEqual(data["session_id"], "rootcmd1")
+        self.assertEqual(data["children"][0]["session_id"], "childcmd1")
+        self.assertEqual(data["children"][0]["cost_usd"], 0.02)
+        tmp.cleanup()
+
+    def test_format_session_tree_contains_cost_and_child(self):
+        store, tmp = self._make_tree()
+        tree = build_tree(store, "rootcmd1")
+        buf = io.StringIO()
+        format_session_tree(tree, costs={"rootcmd1": 0.01, "childcmd1": 0.02}, out=buf)
+        output = buf.getvalue()
+        self.assertIn("rootcmd1", output)
+        self.assertIn("childcmd1", output)
+        self.assertIn("$0.0100", output)
+        tmp.cleanup()
+
+    def test_cmd_tree_json(self):
+        store, tmp = self._make_tree()
+        captured = io.StringIO()
+        args = argparse.Namespace(
+            trace_dir=store.base_dir,
+            session_id="root",
+            format="json",
+        )
+        with patch("sys.stdout", captured):
+            result = cmd_tree(args)
+        self.assertEqual(result, 0)
+        data = json.loads(captured.getvalue())
+        self.assertEqual(data["total_sessions"], 2)
+        self.assertEqual(data["tree"]["children"][0]["session_id"], "childcmd1")
+        tmp.cleanup()
+
+    def test_parser_registers_tree_and_parent_flags(self):
+        parser = build_parser()
+        tree_args = parser.parse_args(["tree", "root", "--format", "json"])
+        self.assertEqual(tree_args.command, "tree")
+        self.assertEqual(tree_args.session_id, "root")
+
+        record_args = parser.parse_args(["record", "--parent", "root123", "--", "server"])
+        self.assertEqual(record_args.parent, "root123")
+
+    def test_parent_session_id_prefers_flag_over_env(self):
+        args = argparse.Namespace(parent="from-flag")
+        with patch.dict("os.environ", {"AGENT_STRACE_PARENT_SESSION": "from-env"}):
+            self.assertEqual(_parent_session_id(args), "from-flag")
+
+    def test_parent_session_id_reads_env(self):
+        args = argparse.Namespace(parent=None)
+        with patch.dict("os.environ", {"AGENT_STRACE_PARENT_SESSION": "from-env"}):
+            self.assertEqual(_parent_session_id(args), "from-env")
+
+    def test_parent_depth_uses_parent_meta(self):
+        tmp = tempfile.TemporaryDirectory()
+        store = TraceStore(tmp.name)
+        store.create_session(SessionMeta(session_id="parent1", depth=2))
+        self.assertEqual(_parent_depth(store, "parent1"), 3)
+        self.assertEqual(_parent_depth(store, "missing"), 1)
+        tmp.cleanup()
+
+    def test_resolve_parent_session_id_expands_prefix(self):
+        tmp = tempfile.TemporaryDirectory()
+        store = TraceStore(tmp.name)
+        store.create_session(SessionMeta(session_id="parent123456"))
+        args = argparse.Namespace(parent="parent")
+        self.assertEqual(_resolve_parent_session_id(store, args), "parent123456")
+        tmp.cleanup()
 
 
 class TestAggregateStatsDuration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `agent-strace tree` for parent/child session hierarchies with cost, tool calls, status, and duration
- add `record --parent` and `record-http --parent` for explicit sub-session linking
- honor `AGENT_STRACE_PARENT_SESSION` and canonicalize parent prefixes when possible
- document the command and bump version to `0.73.0`

Closes #173

## Verification
- `python3 -m pytest tests/test_subagent.py -v`
- `python3 -m compileall -q src/agent_trace`
- `git diff --check`
- `python3 -m agent_trace.cli --version`
- `python3 -m agent_trace.cli tree --help`
- `python3 -m agent_trace.cli record --help`
- `python3 -m pytest tests/ -v`