### PR TITLE
Add per-project weekly budget guard

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -173,6 +173,20 @@ Live session monitor with kill-switch rules.
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
 | `--dry-run` | Evaluate rules without acting |
 
+**Project budget config** (`.agent-strace.yaml`):
+```yaml
+budget:
+  weekly: 20.00
+  warn_at: 0.80
+  stop_at: 1.00
+  per_session_max: 5.00
+```
+
+When this block is present, `watch` checks rolling seven-day spend at startup
+and during the session. `warn_at` writes a terminal warning and alert-log entry.
+`stop_at` blocks new `record` and `record-http` sessions. `per_session_max`
+uses the watchdog cost guard and kills only the over-budget session.
+
 **Rules file format** (`.watch-rules.json`):
 ```json
 {

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.73.0"
+__version__ = "0.74.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -53,6 +53,7 @@ from .explain import cmd_explain
 from .jsonl_import import cmd_import
 from .policy import cmd_policy
 from .postmortem import cmd_postmortem
+from .project_budget import enforce_new_session_budget, load_project_budget_config
 from .share import cmd_share
 from .token_budget import cmd_token_budget
 from .anonymize import cmd_anonymize_export
@@ -125,6 +126,11 @@ def _parent_depth(store: TraceStore, parent_session_id: str) -> int:
 def cmd_record(args: argparse.Namespace) -> int:
     """Record an MCP server session."""
     store = TraceStore(args.trace_dir, redact=_redact_setting(args))
+    budget_config = load_project_budget_config()
+    if budget_config.enabled and not enforce_new_session_budget(
+        store, budget_config, sys.stderr
+    ):
+        return 1
 
     server_cmd = args.server_cmd
     # Strip leading '--' separator added by argparse REMAINDER
@@ -174,6 +180,11 @@ def cmd_record(args: argparse.Namespace) -> int:
 def cmd_record_http(args: argparse.Namespace) -> int:
     """Record a remote MCP server session over HTTP/SSE."""
     store = TraceStore(args.trace_dir, redact=_redact_setting(args))
+    budget_config = load_project_budget_config()
+    if budget_config.enabled and not enforce_new_session_budget(
+        store, budget_config, sys.stderr
+    ):
+        return 1
 
     parent_session_id = _resolve_parent_session_id(store, args)
     meta = SessionMeta(

--- a/src/agent_trace/project_budget.py
+++ b/src/agent_trace/project_budget.py
@@ -1,0 +1,283 @@
+"""Per-project rolling budget guardrails.
+
+Reads the ``budget`` block from ``.agent-strace.yaml`` and evaluates local
+session spend over a rolling seven-day window. The module is intentionally
+stdlib-only so budget enforcement stays available in the core package.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+from .cost import estimate_cost
+from .store import TraceStore
+
+
+DEFAULT_CONFIG_PATHS = (
+    ".agent-strace.yaml",
+    ".agent-strace.yml",
+    ".agent-strace.json",
+)
+ROLLING_WINDOW_SECONDS = 7 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class ProjectBudgetConfig:
+    """Config for a per-project rolling cost budget."""
+
+    weekly: float = 0.0
+    warn_at: float = 0.80
+    stop_at: float = 1.00
+    per_session_max: float | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self.weekly > 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ProjectBudgetConfig":
+        budget = data.get("budget", data)
+        if not isinstance(budget, dict):
+            return cls()
+
+        weekly = _to_float(budget.get("weekly"), 0.0)
+        warn_at = _to_float(budget.get("warn_at"), 0.80)
+        stop_at = _to_float(budget.get("stop_at"), 1.00)
+        per_session_raw = budget.get("per_session_max")
+        per_session_max = (
+            None if per_session_raw in (None, "", "null", "~")
+            else _to_float(per_session_raw, 0.0)
+        )
+        if per_session_max is not None and per_session_max <= 0:
+            per_session_max = None
+
+        return cls(
+            weekly=max(0.0, weekly),
+            warn_at=max(0.0, warn_at),
+            stop_at=max(0.0, stop_at),
+            per_session_max=per_session_max,
+        )
+
+
+@dataclass(frozen=True)
+class ProjectBudgetStatus:
+    """Current spend against the configured rolling budget."""
+
+    config: ProjectBudgetConfig
+    spent: float
+    window_start: float
+    window_end: float
+
+    @property
+    def weekly(self) -> float:
+        return self.config.weekly
+
+    @property
+    def warn_amount(self) -> float:
+        return self.weekly * self.config.warn_at
+
+    @property
+    def stop_amount(self) -> float:
+        return self.weekly * self.config.stop_at
+
+    @property
+    def percent(self) -> float:
+        if self.weekly <= 0:
+            return 0.0
+        return self.spent / self.weekly
+
+    @property
+    def should_warn(self) -> bool:
+        return self.config.enabled and self.spent >= self.warn_amount
+
+    @property
+    def should_stop(self) -> bool:
+        return self.config.enabled and self.spent >= self.stop_amount
+
+
+def load_project_budget_config(
+    config_path: str | Path | None = None,
+) -> ProjectBudgetConfig:
+    """Load project budget config from JSON or minimal YAML.
+
+    If ``config_path`` is omitted, the standard project config filenames are
+    checked in order. Missing or invalid files fall back to a disabled config.
+    """
+
+    for path in _candidate_paths(config_path):
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text()
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                data = _parse_simple_yaml(text)
+            return ProjectBudgetConfig.from_dict(data)
+        except Exception:
+            return ProjectBudgetConfig()
+    return ProjectBudgetConfig()
+
+
+def rolling_project_spend(
+    store: TraceStore,
+    now: float | None = None,
+    window_seconds: float = ROLLING_WINDOW_SECONDS,
+    exclude_session_id: str = "",
+) -> float:
+    """Estimate spend for sessions started in the rolling project window."""
+
+    window_end = time.time() if now is None else now
+    window_start = window_end - window_seconds
+    total = 0.0
+
+    for meta in store.list_sessions():
+        if meta.session_id == exclude_session_id:
+            continue
+        if not (window_start <= meta.started_at < window_end):
+            continue
+        try:
+            total += estimate_cost(store, meta.session_id).total_cost
+        except Exception:
+            continue
+    return total
+
+
+def project_budget_status(
+    store: TraceStore,
+    config: ProjectBudgetConfig,
+    now: float | None = None,
+    current_session_spend: float = 0.0,
+    exclude_session_id: str = "",
+) -> ProjectBudgetStatus:
+    """Return current rolling budget status."""
+
+    window_end = time.time() if now is None else now
+    window_start = window_end - ROLLING_WINDOW_SECONDS
+    spent = rolling_project_spend(
+        store,
+        now=window_end,
+        exclude_session_id=exclude_session_id,
+    ) + max(0.0, current_session_spend)
+    return ProjectBudgetStatus(
+        config=config,
+        spent=spent,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+
+def format_project_budget_status(status: ProjectBudgetStatus) -> str:
+    """Format a concise status line for terminal/watch alerts."""
+
+    pct = status.percent * 100
+    return (
+        f"ProjectBudget: ${status.spent:.2f} spent in rolling 7 days "
+        f"({pct:.0f}% of ${status.weekly:.2f})"
+    )
+
+
+def warn_if_budget_near_limit(
+    store: TraceStore,
+    config: ProjectBudgetConfig,
+    out: TextIO,
+    now: float | None = None,
+) -> ProjectBudgetStatus:
+    """Print a warning when the rolling budget is at or above warn_at."""
+
+    status = project_budget_status(store, config, now=now)
+    if status.should_warn:
+        out.write(f"{format_project_budget_status(status)}\n")
+        out.flush()
+    return status
+
+
+def enforce_new_session_budget(
+    store: TraceStore,
+    config: ProjectBudgetConfig,
+    out: TextIO,
+    now: float | None = None,
+) -> bool:
+    """Return False and print an error when a new session should be refused."""
+
+    status = project_budget_status(store, config, now=now)
+    if not status.should_stop:
+        return True
+
+    out.write(
+        f"agent-strace: weekly project budget exceeded; refusing new session "
+        f"(${status.spent:.2f} spent, stop threshold ${status.stop_amount:.2f})\n"
+    )
+    out.flush()
+    return False
+
+
+def _candidate_paths(config_path: str | Path | None) -> Iterable[Path]:
+    if config_path:
+        yield Path(config_path)
+        return
+    for path in DEFAULT_CONFIG_PATHS:
+        yield Path(path)
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse top-level scalar keys and one level of nested scalar mappings."""
+
+    result: dict[str, Any] = {}
+    current_section: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+
+        indent = len(line) - len(stripped)
+        if indent == 0:
+            current_section = None
+            if stripped.endswith(":"):
+                current_section = stripped[:-1].strip()
+                result[current_section] = {}
+            elif ":" in stripped:
+                key, _, raw_value = stripped.partition(":")
+                result[key.strip()] = _coerce(raw_value.strip())
+        elif current_section and ":" in stripped:
+            section = result.get(current_section)
+            if isinstance(section, dict):
+                key, _, raw_value = stripped.partition(":")
+                section[key.strip()] = _coerce(raw_value.strip())
+
+    return result
+
+
+def _coerce(value: str) -> Any:
+    if value in ("", "null", "~"):
+        return None
+    if value.lower() in ("true", "yes"):
+        return True
+    if value.lower() in ("false", "no"):
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _to_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -38,6 +38,13 @@ from typing import Any, TextIO
 
 from .cost import _dollars, _event_tokens
 from .models import EventType, TraceEvent
+from .project_budget import (
+    ProjectBudgetConfig,
+    ProjectBudgetStatus,
+    format_project_budget_status,
+    load_project_budget_config,
+    project_budget_status,
+)
 from .store import TraceStore
 
 
@@ -714,7 +721,9 @@ def _dispatch_alert(
         # Write watchdog post-mortem JSON before killing
         pm_path: Path | None = None
         if store and session_id:
-            pm_path = _write_watchdog_postmortem(store, session_id, state, reason=message)
+            pm_path = _write_watchdog_postmortem(
+                store, session_id, state, reason=message, config=config
+            )
             if pm_path:
                 _alert_terminal(f"Post-mortem written to {pm_path}")
         if config.on_death_cmd:
@@ -727,6 +736,7 @@ def _write_watchdog_postmortem(
     session_id: str,
     state: WatchState,
     reason: str,
+    config: WatcherConfig | None = None,
 ) -> Path | None:
     """Write a structured JSON post-mortem to the session directory.
 
@@ -764,6 +774,9 @@ def _write_watchdog_postmortem(
             "Resume from the last tool call above."
         ),
     }
+    if config is not None:
+        pm["max_cost_dollars"] = config.max_cost_dollars
+        pm["budget_at_death"] = config.max_cost_dollars
 
     pm_path = store._session_dir(session_id) / "watchdog-postmortem.json"
     try:
@@ -800,7 +813,9 @@ def _dispatch_nanny_rule(
 
     # Auto-generate postmortem on kill
     if rule.action == "kill" and not dry_run:
-        pm_path = _write_watchdog_postmortem(store, session_id, state, reason=msg)
+        pm_path = _write_watchdog_postmortem(
+            store, session_id, state, reason=msg, config=config
+        )
         if pm_path:
             _alert_terminal(f"Post-mortem written to {pm_path}")
         on_death = getattr(config, "on_death_cmd", "")
@@ -1068,6 +1083,7 @@ def watch_session(
     nanny_rules: list[NannyRule] | None = None,
     dry_run: bool = False,
     stream_config: StreamConfig | None = None,
+    project_budget_config: ProjectBudgetConfig | None = None,
 ) -> None:
     """Watch a session's event stream and fire alerts on violations.
 
@@ -1088,6 +1104,21 @@ def watch_session(
     if stream_config and stream_config.url:
         out.write(f"[watch] Streaming events to {stream_config.url}\n")
     out.flush()
+
+    project_budget_base_spend = 0.0
+    if project_budget_config and project_budget_config.enabled:
+        budget_status = project_budget_status(
+            store,
+            project_budget_config,
+            exclude_session_id=session_id,
+        )
+        project_budget_base_spend = budget_status.spent
+        if budget_status.should_warn:
+            msg = format_project_budget_status(budget_status)
+            state.fired.add("project-budget")
+            out.write(f"[watch] {msg}\n")
+            out.flush()
+            _alert_file(msg, config.alert_log)
 
     streamer: EventStreamer | None = None
     if stream_config and stream_config.url:
@@ -1119,10 +1150,33 @@ def watch_session(
 
             violations = check_event(event, config, state)
             for msg in violations:
+                action = None
+                if (
+                    project_budget_config
+                    and project_budget_config.per_session_max
+                    and msg.startswith("CostWatcher")
+                ):
+                    action = "kill"
                 _dispatch_alert(
-                    msg, config, state, dry_run=dry_run,
+                    msg, config, state, action=action, dry_run=dry_run,
                     store=store, session_id=session_id,
                 )
+
+            if project_budget_config and project_budget_config.enabled:
+                budget_status = ProjectBudgetStatus(
+                    config=project_budget_config,
+                    spent=project_budget_base_spend + state.estimated_cost,
+                    window_start=time.time() - 7 * 24 * 60 * 60,
+                    window_end=time.time(),
+                )
+                if budget_status.should_warn and "project-budget" not in state.fired:
+                    state.fired.add("project-budget")
+                    msg = format_project_budget_status(budget_status)
+                    out.write(f"[watch] {msg}\n")
+                    out.flush()
+                    _alert_file(msg, config.alert_log)
+                    if config.webhook_url:
+                        _alert_webhook(msg, config.webhook_url)
 
             # --- Nanny rule evaluation ---
             if nanny_rules:
@@ -1199,6 +1253,12 @@ def cmd_watch(args: argparse.Namespace) -> int:
     if getattr(args, "loop_window", None) is not None:
         config.loop_window = int(getattr(args, "loop_window"))
 
+    project_budget_config = load_project_budget_config(config_path)
+    if config_path and not project_budget_config.enabled:
+        project_budget_config = load_project_budget_config()
+    if project_budget_config.per_session_max:
+        config.max_cost_dollars = project_budget_config.per_session_max
+
     # Load nanny rules if --rules provided
     nanny_rules: list[NannyRule] | None = None
     rules_path = getattr(args, "rules", None)
@@ -1237,8 +1297,15 @@ def cmd_watch(args: argparse.Namespace) -> int:
             otlp=getattr(args, "stream_otlp", False),
         )
 
-    watch_session(store, full_id, config, nanny_rules=nanny_rules, dry_run=dry_run,
-                  stream_config=stream_cfg)
+    watch_session(
+        store,
+        full_id,
+        config,
+        nanny_rules=nanny_rules,
+        dry_run=dry_run,
+        stream_config=stream_cfg,
+        project_budget_config=project_budget_config,
+    )
     return 0
 
 

--- a/tests/test_project_budget.py
+++ b/tests/test_project_budget.py
@@ -1,0 +1,209 @@
+"""Tests for per-project rolling budget guardrails."""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.project_budget import (
+    ProjectBudgetConfig,
+    enforce_new_session_budget,
+    load_project_budget_config,
+    project_budget_status,
+    rolling_project_spend,
+)
+from agent_trace.store import TraceStore
+from agent_trace.watch import WatcherConfig, watch_session
+
+
+def _add_session(store: TraceStore, started_at: float, payload_size: int = 4000) -> str:
+    meta = SessionMeta(agent_name="agent", command="test")
+    meta.started_at = started_at
+    session_path = store.create_session(meta)
+    session_id = session_path.name
+    store.append_event(
+        session_id,
+        TraceEvent(
+            event_type=EventType.SESSION_START,
+            timestamp=started_at,
+            session_id=session_id,
+            data={},
+        ),
+    )
+    store.append_event(
+        session_id,
+        TraceEvent(
+            event_type=EventType.ASSISTANT_RESPONSE,
+            timestamp=started_at + 1,
+            session_id=session_id,
+            data={"text": "x" * payload_size},
+        ),
+    )
+    store.append_event(
+        session_id,
+        TraceEvent(
+            event_type=EventType.SESSION_END,
+            timestamp=started_at + 2,
+            session_id=session_id,
+            data={},
+        ),
+    )
+    return session_id
+
+
+class TestProjectBudgetConfig(unittest.TestCase):
+    def test_loads_budget_block_from_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".agent-strace.yaml"
+            path.write_text(
+                "\n".join([
+                    "budget:",
+                    "  weekly: 20.00",
+                    "  warn_at: 0.75",
+                    "  stop_at: 1.00",
+                    "  per_session_max: 5.50",
+                ])
+            )
+
+            cfg = load_project_budget_config(path)
+
+        self.assertEqual(cfg.weekly, 20.0)
+        self.assertEqual(cfg.warn_at, 0.75)
+        self.assertEqual(cfg.stop_at, 1.0)
+        self.assertEqual(cfg.per_session_max, 5.5)
+
+    def test_missing_config_disables_budget(self) -> None:
+        cfg = load_project_budget_config("/no/such/.agent-strace.yaml")
+        self.assertFalse(cfg.enabled)
+
+
+class TestRollingProjectSpend(unittest.TestCase):
+    def test_rolling_spend_excludes_old_sessions(self) -> None:
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            recent_id = _add_session(store, now - 60)
+            _add_session(store, now - 8 * 24 * 60 * 60)
+
+            total = rolling_project_spend(store, now=now)
+            without_recent = rolling_project_spend(
+                store, now=now, exclude_session_id=recent_id
+            )
+
+        self.assertGreater(total, 0.0)
+        self.assertEqual(without_recent, 0.0)
+
+    def test_status_warns_and_stops_at_thresholds(self) -> None:
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            _add_session(store, now - 60, payload_size=20000)
+            spent = rolling_project_spend(store, now=now)
+            cfg = ProjectBudgetConfig(
+                weekly=spent,
+                warn_at=0.50,
+                stop_at=1.00,
+            )
+
+            status = project_budget_status(store, cfg, now=now)
+
+        self.assertTrue(status.should_warn)
+        self.assertTrue(status.should_stop)
+
+    def test_enforce_new_session_budget_refuses_over_stop(self) -> None:
+        now = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            _add_session(store, now - 60, payload_size=20000)
+            spent = rolling_project_spend(store, now=now)
+            cfg = ProjectBudgetConfig(weekly=spent / 2, stop_at=1.00)
+            out = io.StringIO()
+
+            allowed = enforce_new_session_budget(store, cfg, out, now=now)
+
+        self.assertFalse(allowed)
+        self.assertIn("refusing new session", out.getvalue())
+
+
+class TestWatchProjectBudget(unittest.TestCase):
+    def _fake_tail(self, events: list[TraceEvent]):
+        def _gen(_path, poll_interval=0.5):
+            yield from events
+        return _gen
+
+    def test_watch_session_writes_project_budget_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp) / "traces")
+            session_path = store.create_session(SessionMeta(agent_name="agent"))
+            session_id = session_path.name
+            out = io.StringIO()
+            alert_log = Path(tmp) / "alerts.log"
+            cfg = WatcherConfig(alert_log=str(alert_log))
+            budget = ProjectBudgetConfig(weekly=1.0, warn_at=0.0)
+            events = [
+                TraceEvent(
+                    event_type=EventType.SESSION_END,
+                    timestamp=time.time(),
+                    session_id=session_id,
+                    data={},
+                )
+            ]
+
+            with patch("agent_trace.watch._tail_events", self._fake_tail(events)):
+                watch_session(
+                    store,
+                    session_id,
+                    cfg,
+                    out=out,
+                    project_budget_config=budget,
+                )
+
+            self.assertIn("ProjectBudget", out.getvalue())
+            self.assertIn("ProjectBudget", alert_log.read_text())
+
+    def test_per_session_max_cost_violation_uses_kill_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(Path(tmp))
+            session_path = store.create_session(SessionMeta(agent_name="agent"))
+            session_id = session_path.name
+            cfg = WatcherConfig(max_cost_dollars=0.0)
+            budget = ProjectBudgetConfig(
+                weekly=10.0,
+                warn_at=2.0,
+                per_session_max=1.0,
+            )
+            events = [
+                TraceEvent(
+                    event_type=EventType.ASSISTANT_RESPONSE,
+                    timestamp=time.time(),
+                    session_id=session_id,
+                    data={"text": "x" * 10000},
+                ),
+                TraceEvent(
+                    event_type=EventType.SESSION_END,
+                    timestamp=time.time(),
+                    session_id=session_id,
+                    data={},
+                ),
+            ]
+
+            with patch("agent_trace.watch._tail_events", self._fake_tail(events)), \
+                 patch("agent_trace.watch._dispatch_alert") as dispatch:
+                watch_session(
+                    store,
+                    session_id,
+                    cfg,
+                    out=io.StringIO(),
+                    project_budget_config=budget,
+                )
+
+        self.assertEqual(dispatch.call_args.kwargs["action"], "kill")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `.agent-strace.yaml` `budget` config for rolling weekly project spend
- warn from `watch`, block new `record`/`record-http` sessions at `stop_at`, and kill cost overruns for `per_session_max`
- document the budget block and bump version to `0.74.0`

Closes #177

## Tests
- `python3 -m compileall -q src/agent_trace`
- `python3 -m pytest tests/ -q`
- `git diff --check`
- `python3 -m agent_trace.cli --version`