### PR TITLE
Add EU AI Act export package

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | Command | What it does |
 |---|---|
 | [`agent-strace export --format otlp-genai`](docs/production.md) | Export to Datadog, Honeycomb, Grafana, Jaeger |
+| [`agent-strace export --format eu-ai-act`](docs/commands.md#export) | Generate Article 12/13 audit packages |
 | [`agent-strace export --metrics`](docs/production.md#behavioral-metrics) | Export per-session behavioral metrics as OTLP gauges |
 | [`agent-strace identity show`](docs/commands.md#identity) | Machine identity — sign and verify sessions |
 | [`agent-strace server`](docs/server.md) | Server-side collector for multi-agent, multi-machine |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -245,6 +245,14 @@ Check tool calls against a policy file. Flags sensitive file access even without
 }
 ```
 
+### `verify`
+```
+agent-strace verify [session-id] [--format text|json]
+agent-strace verify --from-export FILE [--format text|json]
+```
+Verify a session hash chain, or verify the chain links embedded in an EU AI Act
+export package.
+
 ### `policy`
 ```
 agent-strace policy [--last N] [--output FILE]
@@ -328,9 +336,8 @@ Isolated workspaces — each workspace has its own session store. Use `use` to p
 
 ### `compliance`
 ```
-agent-strace compliance export --framework eu-ai-act|soc2|hipaa
-                                [--since DATE] [--until DATE]
-                                [--output FILE] [--format json|markdown]
+agent-strace compliance export [session-id] --framework eu-ai-act|soc2|hipaa|all
+                                [--since Nd] [--output FILE]
 ```
 Export a compliance report for the specified framework. Covers session retention, data handling, access logs, and policy enforcement evidence.
 
@@ -339,6 +346,24 @@ Export a compliance report for the specified framework. Covers session retention
 | `eu-ai-act` | Transparency, human oversight, data governance |
 | `soc2` | Access control, availability, confidentiality |
 | `hipaa` | PHI handling, audit trail, access logs |
+
+For an auditor-facing EU AI Act Article 12/13 package, use the session export path:
+
+```
+agent-strace export <session-id> --format eu-ai-act --output compliance-report.json
+agent-strace export --all --since 2026-01-01 --until 2026-03-31 \
+  --format eu-ai-act --output Q1-audit.json
+agent-strace verify --from-export compliance-report.json
+agent-strace audit-readiness [--format text|json]
+```
+
+### `audit-readiness`
+```
+agent-strace audit-readiness [--retention-days N] [--format text|json]
+```
+Check whether the local trace store has hash-chain integrity, retention
+coverage, timestamp continuity, and hash-chain presence before generating an
+EU AI Act audit package.
 
 ---
 
@@ -474,12 +499,16 @@ Track changes to AGENTS.md and other config files. `check` exits 1 when config h
 
 ### `export`
 ```
-agent-strace export <session-id> [--format json|csv|ndjson|otlp|otlp-genai]
+agent-strace export <session-id> [--format json|csv|ndjson|otlp|otlp-genai|eu-ai-act]
                     [--endpoint URL] [--header KEY:VALUE] [--service-name NAME]
                     [--anonymize] [--scores] [--metrics] [--backend otlp|langfuse]
-                    [--since DURATION] [--langfuse-host URL]
+                    [--all] [--since DURATION_OR_DATE] [--until DATE] [--output FILE]
 ```
 Export a session. See [production.md](production.md) for per-backend OTLP setup.
+
+`--format eu-ai-act` writes a structured JSON package with Article 12 logging
+evidence, Article 13 transparency documentation, hash-chain integrity metadata,
+and event-level line hashes for `agent-strace verify --from-export`.
 
 ### `share`
 ```

--- a/docs/production.md
+++ b/docs/production.md
@@ -166,6 +166,32 @@ Use `baseline check` as a CI gate — it exits 1 when the session is anomalous:
 agent-strace baseline check $SESSION_ID || echo "Session outside baseline"
 ```
 
+## EU AI Act Audit Packages
+
+`agent-strace export --format eu-ai-act` creates a local JSON package for
+Article 12 logging evidence and Article 13 transparency documentation:
+
+```bash
+agent-strace export <session-id> --format eu-ai-act --output compliance-report.json
+
+agent-strace export --all --since 2026-01-01 --until 2026-03-31 \
+  --format eu-ai-act --output Q1-2026-audit.json
+```
+
+The export includes event summaries, data categories processed, tools and
+models observed, human oversight points, and hash-chain integrity metadata.
+Verify the exported chain links with:
+
+```bash
+agent-strace verify --from-export compliance-report.json
+```
+
+Before exporting a store for review, run:
+
+```bash
+agent-strace audit-readiness
+```
+
 ---
 
 ## Behavioral metrics

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.75.0"
+__version__ = "0.76.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -32,7 +32,7 @@ from .rbac import cmd_rbac
 from .iac import cmd_apply, cmd_config_diff
 from .sso import cmd_auth
 from .baseline import cmd_baseline
-from .compliance import cmd_compliance
+from .compliance import cmd_audit_readiness, cmd_compliance, cmd_export_eu_ai_act, cmd_verify_export
 from .drift import cmd_drift, cmd_fingerprint
 from .identity import cmd_identity
 from .workspace import cmd_workspace
@@ -41,7 +41,7 @@ from .oncall import cmd_oncall
 from .optimize import cmd_optimize
 from .freshness import cmd_freshness
 from .standup import cmd_standup
-from .audit import cmd_audit
+from .audit import cmd_audit, verify_chain
 from .cost import cmd_cost
 from .curve import cmd_curve
 from .dashboard import cmd_dashboard
@@ -331,6 +331,9 @@ def cmd_export(args: argparse.Namespace) -> int:
     # Route to anonymized export when --anonymize is set
     if getattr(args, "anonymize", False):
         return cmd_anonymize_export(args)
+
+    if getattr(args, "format", "") == "eu-ai-act":
+        return cmd_export_eu_ai_act(args)
     store = TraceStore(args.trace_dir)
 
     session_id = args.session_id
@@ -435,6 +438,35 @@ def cmd_export(args: argparse.Namespace) -> int:
             return 0 if ok else 1
 
     return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    """Verify a session hash chain or an exported EU AI Act package."""
+    if getattr(args, "from_export", ""):
+        return cmd_verify_export(args)
+
+    store = TraceStore(args.trace_dir)
+    session_id = getattr(args, "session_id", None) or store.get_latest_session_id()
+    if not session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+    full_id = store.find_session(session_id) or session_id
+    if not store.session_exists(full_id):
+        sys.stderr.write(f"Session not found: {session_id}\n")
+        return 1
+
+    result = verify_chain(store, full_id)
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps({
+            "session_id": result.session_id,
+            "ok": result.ok,
+            "total_events": result.total_events,
+            "broken_at": result.broken_at,
+            "broken_event_id": result.broken_event_id,
+        }, indent=2) + "\n")
+    else:
+        result.format(sys.stdout)
+    return 0 if result.ok else 1
 
 
 def cmd_stats(args: argparse.Namespace) -> int:
@@ -793,7 +825,7 @@ def build_parser() -> argparse.ArgumentParser:
     # export
     p_export = sub.add_parser("export", help="export a session")
     p_export.add_argument("session_id", nargs="?", help="session ID or prefix")
-    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp", "otlp-genai"],
+    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp", "otlp-genai", "eu-ai-act"],
                           default="json",
                           help="output format (otlp-genai uses strict OTel GenAI semantic conventions)")
     p_export.add_argument("--endpoint", help="OTLP collector URL (e.g. http://localhost:4318)")
@@ -808,6 +840,10 @@ def build_parser() -> argparse.ArgumentParser:
                           help="export backend: langfuse or otlp")
     p_export.add_argument("--since", metavar="Nd",
                           help="export sessions from the last N days (e.g. 7d)")
+    p_export.add_argument("--until", metavar="DATE",
+                          help="upper time bound for batch exports (ISO date or timestamp)")
+    p_export.add_argument("--all", action="store_true",
+                          help="export all sessions in the selected time window")
     p_export.add_argument("--langfuse-public-key", dest="langfuse_public_key", metavar="KEY",
                           help="Langfuse public key (overrides LANGFUSE_PUBLIC_KEY)")
     p_export.add_argument("--langfuse-secret-key", dest="langfuse_secret_key", metavar="KEY",
@@ -823,7 +859,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_export.add_argument("--anonymize-config", dest="anonymize_config", metavar="FILE",
                           help="path to custom anonymization rules YAML file")
     p_export.add_argument("--output", "-o", default="",
-                          help="output file path for anonymized export")
+                          help="output file path")
     p_export.add_argument("--dry-run", action="store_true",
                           help="show what would be anonymized without writing output (use with --anonymize)")
 
@@ -905,6 +941,13 @@ def build_parser() -> argparse.ArgumentParser:
                          help="verify SHA-256 hash chain integrity before policy audit")
     p_audit.add_argument("--policy", default=".agent-scope.json",
                          help="path to policy file (default: .agent-scope.json)")
+
+    # verify
+    p_verify = sub.add_parser("verify", help="verify session or exported trace integrity")
+    p_verify.add_argument("session_id", nargs="?", help="session ID or prefix")
+    p_verify.add_argument("--from-export", dest="from_export", metavar="FILE",
+                          help="verify hash chain from an EU AI Act export")
+    p_verify.add_argument("--format", choices=["text", "json"], default="text")
 
     # share
     p_share = sub.add_parser("share", help="generate a self-contained HTML replay of a session")
@@ -1249,6 +1292,12 @@ def build_parser() -> argparse.ArgumentParser:
                             help="export sessions from last N days (e.g. 30d)")
     p_comp_exp.add_argument("--output", "-o", metavar="FILE",
                             help="write JSON report to FILE instead of stdout")
+
+    # audit-readiness
+    p_ready = sub.add_parser("audit-readiness", help="check EU AI Act audit export readiness")
+    p_ready.add_argument("--retention-days", type=float, default=90.0,
+                         help="required retention coverage in days (default: 90)")
+    p_ready.add_argument("--format", choices=["text", "json"], default="text")
 
     # workspace (workspace isolation)
     p_ws = sub.add_parser("workspace", help="manage isolated workspaces")
@@ -1624,6 +1673,7 @@ def main() -> None:
         "diff": cmd_diff,
         "why": cmd_why,
         "audit": cmd_audit,
+        "verify": cmd_verify,
         "share": cmd_share,
         "postmortem": cmd_postmortem,
         "eval": cmd_eval,
@@ -1644,6 +1694,7 @@ def main() -> None:
         "identity": cmd_identity,
         "workspace": cmd_workspace,
         "compliance": cmd_compliance,
+        "audit-readiness": cmd_audit_readiness,
         "approval": cmd_approval,
         "rbac": cmd_rbac,
         "apply": cmd_apply,

--- a/src/agent_trace/compliance.py
+++ b/src/agent_trace/compliance.py
@@ -591,7 +591,7 @@ def build_audit_readiness(
 def format_audit_readiness(report: dict, out: TextIO = sys.stdout) -> None:
     checks = report["checks"]
     out.write("EU AI Act readiness check\n")
-    out.write("─────────────────────────\n")
+    out.write("-------------------------\n")
     out.write(f"Sessions analysed: {report['session_count']}\n")
     out.write(
         f"{'OK' if checks['hash_chain_integrity']['ok'] else 'FAIL'} "
@@ -659,11 +659,11 @@ def cmd_verify_export(args: argparse.Namespace) -> int:
         sys.stdout.write(json.dumps(result, indent=2) + "\n")
     elif result["ok"]:
         sys.stdout.write(
-            f"Export hash chain intact — {result['checked_events']} events checked\n"
+            f"Export hash chain intact - {result['checked_events']} events checked\n"
         )
     else:
         sys.stdout.write(
-            f"Export hash chain failed — {len(result['failures'])} broken links\n"
+            f"Export hash chain failed - {len(result['failures'])} broken links\n"
         )
     return 0 if result["ok"] else 1
 

--- a/src/agent_trace/compliance.py
+++ b/src/agent_trace/compliance.py
@@ -21,19 +21,142 @@ Frameworks:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 import time
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal, TextIO
 
+from . import __version__
+from .audit import verify_chain
+from .cost import _dollars, _event_tokens
 from .models import EventType, TraceEvent
 from .store import TraceStore
 
 Framework = Literal["eu-ai-act", "soc2", "hipaa", "all"]
 
 _FRAMEWORKS: list[str] = ["eu-ai-act", "soc2", "hipaa"]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _iso(ts: float | None) -> str | None:
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time_bound(value: str | None, default: float | None = None) -> float | None:
+    if not value:
+        return default
+    raw = value.strip()
+    if not raw:
+        return default
+    if raw.endswith("d") and raw[:-1].replace(".", "", 1).isdigit():
+        return time.time() - float(raw[:-1]) * 86400
+    if raw.endswith("h") and raw[:-1].replace(".", "", 1).isdigit():
+        return time.time() - float(raw[:-1]) * 3600
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _load_event_lines(store: TraceStore, session_id: str) -> list[str]:
+    path = store._session_dir(session_id) / "events.ndjson"
+    if not path.exists():
+        return []
+    return [line for line in path.read_text().splitlines() if line.strip()]
+
+
+def _root_hash(lines: list[str]) -> str:
+    if not lines:
+        return ""
+    return hashlib.sha256(lines[-1].encode()).hexdigest()
+
+
+def _line_hashes(lines: list[str]) -> list[str]:
+    return [hashlib.sha256(line.encode()).hexdigest() for line in lines]
+
+
+def _summarise(value: Any, limit: int = 240) -> str:
+    text = json.dumps(value, sort_keys=True, default=str)
+    return text[:limit] + ("..." if len(text) > limit else "")
+
+
+def _event_tool_name(event: TraceEvent) -> str:
+    return str(event.data.get("tool_name") or event.data.get("tool") or "")
+
+
+def _event_cost(event: TraceEvent) -> float:
+    input_tokens, output_tokens = _event_tokens(event)
+    return _dollars(input_tokens, output_tokens, "sonnet")
+
+
+def _data_categories(events: list[TraceEvent]) -> list[str]:
+    categories = set()
+    for event in events:
+        if event.event_type in (EventType.LLM_REQUEST, EventType.USER_PROMPT):
+            categories.add("prompt_content")
+        elif event.event_type in (EventType.LLM_RESPONSE, EventType.ASSISTANT_RESPONSE):
+            categories.add("model_output")
+        elif event.event_type in (EventType.TOOL_CALL, EventType.TOOL_RESULT):
+            categories.add("tool_io")
+        elif event.event_type in (EventType.FILE_READ, EventType.FILE_WRITE):
+            categories.add("file_content")
+        elif event.event_type == EventType.ERROR:
+            categories.add("error_log")
+    return sorted(categories)
+
+
+def _human_oversight_points(store: TraceStore, session_id: str, events: list[TraceEvent]) -> list[dict]:
+    points = []
+    for event in events:
+        if event.event_type == EventType.ERROR:
+            points.append({
+                "timestamp": _iso(event.timestamp),
+                "type": "ERROR_RECORDED",
+                "detail": _summarise(event.data, 180),
+            })
+        elif event.data.get("blocked") or event.data.get("policy_violation"):
+            points.append({
+                "timestamp": _iso(event.timestamp),
+                "type": "POLICY_INTERVENTION",
+                "detail": _summarise(event.data, 180),
+            })
+
+    session_dir = store._session_dir(session_id)
+    if (session_dir / "watchdog-postmortem.json").exists():
+        points.append({
+            "timestamp": None,
+            "type": "WATCHDOG_POSTMORTEM",
+            "detail": "watchdog-postmortem.json present",
+        })
+    if (session_dir / "postmortem.md").exists():
+        points.append({
+            "timestamp": None,
+            "type": "CRASH_POSTMORTEM",
+            "detail": "postmortem.md present",
+        })
+    return points
+
+
+def _models_used(events: list[TraceEvent]) -> list[str]:
+    models = set()
+    for event in events:
+        model = event.data.get("model") or event.data.get("model_name")
+        if model:
+            models.add(str(model))
+    return sorted(models)
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +331,341 @@ def export_compliance_bulk(
             continue
         reports.append(export_compliance(store, meta.session_id, framework))
     return reports
+
+
+# ---------------------------------------------------------------------------
+# EU AI Act Article 12/13 export
+# ---------------------------------------------------------------------------
+
+def _eu_ai_act_session_record(store: TraceStore, session_id: str) -> dict:
+    meta = store.load_meta(session_id)
+    events = store.load_events(session_id)
+    lines = _load_event_lines(store, session_id)
+    hashes = _line_hashes(lines)
+    chain = verify_chain(store, session_id)
+
+    event_records = []
+    for idx, event in enumerate(events):
+        input_summary = ""
+        output_summary = ""
+        if event.event_type in (EventType.USER_PROMPT, EventType.LLM_REQUEST, EventType.TOOL_CALL):
+            input_summary = _summarise(event.data)
+        elif event.event_type in (EventType.ASSISTANT_RESPONSE, EventType.LLM_RESPONSE, EventType.TOOL_RESULT):
+            output_summary = _summarise(event.data)
+        else:
+            input_summary = _summarise(event.data)
+
+        event_records.append({
+            "seq": idx + 1,
+            "timestamp": _iso(event.timestamp),
+            "event_type": event.event_type.value,
+            "event_id": event.event_id,
+            "tool_name": _event_tool_name(event),
+            "input_summary": input_summary,
+            "output_summary": output_summary,
+            "duration_ms": event.duration_ms,
+            "cost_usd": round(_event_cost(event), 8),
+            "prev_hash": event.prev_hash,
+            "line_hash": hashes[idx] if idx < len(hashes) else "",
+        })
+
+    tools = sorted({
+        _event_tool_name(event)
+        for event in events
+        if event.event_type == EventType.TOOL_CALL and _event_tool_name(event)
+    })
+    errors = [event for event in events if event.event_type == EventType.ERROR]
+    context_resets = [
+        event for event in events
+        if "context" in json.dumps(event.data, default=str).lower()
+        and "reset" in json.dumps(event.data, default=str).lower()
+    ]
+
+    article_12 = {
+        "system_id": session_id,
+        "generation_timestamp": _iso(time.time()),
+        "trace_integrity": {
+            "hash_chain_valid": chain.ok,
+            "root_hash": _root_hash(lines),
+            "event_count": len(events),
+            "broken_at": chain.broken_at,
+            "broken_event_id": chain.broken_event_id,
+            "verification_command": f"agent-strace verify {session_id}",
+        },
+        "events": event_records,
+        "data_categories_processed": _data_categories(events),
+        "retention_period_days": None,
+    }
+
+    article_13 = {
+        "system_description": "AI agent session trace",
+        "intended_purpose": meta.command or meta.agent_name or "not specified",
+        "capabilities_summary": {
+            "tools_available": tools,
+            "tools_used": tools,
+            "models_used": _models_used(events),
+            "frameworks_detected": [],
+        },
+        "human_oversight_points": _human_oversight_points(store, session_id, events),
+        "limitations": {
+            "context_resets": len(context_resets),
+            "errors_encountered": len(errors),
+            "unresolved_failures": 0 if meta.ended_at else 1,
+        },
+    }
+
+    return {
+        "session_id": session_id,
+        "session_start": _iso(meta.started_at),
+        "session_end": _iso(meta.ended_at),
+        "agent_name": meta.agent_name,
+        "article_12": article_12,
+        "article_13": article_13,
+    }
+
+
+def select_sessions(
+    store: TraceStore,
+    since: str | None = None,
+    until: str | None = None,
+) -> list[str]:
+    """Select session IDs in a time window, newest first."""
+    since_ts = _parse_time_bound(since, None)
+    until_ts = _parse_time_bound(until, None)
+    selected = []
+    for meta in store.list_sessions():
+        if since_ts is not None and meta.started_at < since_ts:
+            continue
+        if until_ts is not None and meta.started_at > until_ts:
+            continue
+        selected.append(meta.session_id)
+    return selected
+
+
+def export_eu_ai_act(
+    store: TraceStore,
+    session_ids: list[str],
+) -> dict:
+    """Build an EU AI Act Article 12/13 JSON export for one or more sessions."""
+    sessions = [_eu_ai_act_session_record(store, session_id) for session_id in session_ids]
+    article_12_sessions = [
+        {
+            "session_id": session["session_id"],
+            **session["article_12"],
+        }
+        for session in sessions
+    ]
+    article_13_sessions = [
+        {
+            "session_id": session["session_id"],
+            **session["article_13"],
+        }
+        for session in sessions
+    ]
+
+    return {
+        "compliance_metadata": {
+            "regulation": "EU AI Act (Regulation (EU) 2024/1689)",
+            "articles_covered": ["Article 12", "Article 13"],
+            "export_tool": "agent-strace",
+            "export_version": __version__,
+            "exported_at": _iso(time.time()),
+            "tamper_evident": True,
+            "session_count": len(sessions),
+        },
+        "article_12": {
+            "logging_obligations": article_12_sessions,
+        },
+        "article_13": {
+            "transparency_documentation": article_13_sessions,
+        },
+        "sessions": sessions,
+    }
+
+
+def cmd_export_eu_ai_act(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    if getattr(args, "all", False):
+        session_ids = select_sessions(
+            store,
+            since=getattr(args, "since", None),
+            until=getattr(args, "until", None),
+        )
+    else:
+        session_id = getattr(args, "session_id", None) or store.get_latest_session_id()
+        if not session_id:
+            sys.stderr.write("No sessions found.\n")
+            return 1
+        full_id = store.find_session(session_id) or session_id
+        if not store.session_exists(full_id):
+            sys.stderr.write(f"Session not found: {session_id}\n")
+            return 1
+        session_ids = [full_id]
+
+    report = export_eu_ai_act(store, session_ids)
+    result = json.dumps(report, indent=2)
+    output = getattr(args, "output", "") or ""
+    if output:
+        Path(output).write_text(result + "\n")
+        sys.stderr.write(f"EU AI Act export written to {output}\n")
+    else:
+        sys.stdout.write(result + "\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Readiness and export verification
+# ---------------------------------------------------------------------------
+
+def build_audit_readiness(
+    store: TraceStore,
+    retention_days: float = 90.0,
+) -> dict:
+    sessions = store.list_sessions()
+    chain_results = [verify_chain(store, meta.session_id) for meta in sessions]
+    broken = [result for result in chain_results if not result.ok]
+    now = time.time()
+    oldest = min((meta.started_at for meta in sessions), default=None)
+
+    sorted_sessions = sorted(sessions, key=lambda meta: meta.started_at)
+    gaps = []
+    for prev, cur in zip(sorted_sessions, sorted_sessions[1:]):
+        gap = cur.started_at - prev.started_at
+        if gap > 86400:
+            gaps.append({
+                "from_session": prev.session_id,
+                "to_session": cur.session_id,
+                "gap_hours": round(gap / 3600, 2),
+            })
+
+    missing_hash = []
+    for meta in sessions:
+        events = store.load_events(meta.session_id)
+        if len(events) > 1 and not any(event.prev_hash for event in events[1:]):
+            missing_hash.append(meta.session_id)
+
+    retention_days_present = ((now - oldest) / 86400) if oldest else 0.0
+    checks = {
+        "hash_chain_integrity": {
+            "ok": not broken,
+            "checked_sessions": len(chain_results),
+            "broken_sessions": [result.session_id for result in broken],
+        },
+        "retention_coverage": {
+            "ok": retention_days_present >= retention_days if sessions else False,
+            "required_days": retention_days,
+            "available_days": round(retention_days_present, 2),
+        },
+        "timestamp_continuity": {
+            "ok": not gaps,
+            "gaps_over_24h": gaps,
+        },
+        "hash_chain_presence": {
+            "ok": not missing_hash,
+            "sessions_missing_prev_hashes": missing_hash,
+        },
+    }
+    score = 100
+    if broken:
+        score -= 35
+    if missing_hash:
+        score -= 20
+    if gaps:
+        score -= 10
+    if sessions and retention_days_present < retention_days:
+        score -= 10
+    if not sessions:
+        score = 0
+
+    return {
+        "framework": "eu-ai-act",
+        "articles_checked": ["Article 12", "Article 13"],
+        "generated_at": _iso(now),
+        "session_count": len(sessions),
+        "checks": checks,
+        "compliance_score": max(0, score),
+        "ready": score >= 80 and not broken,
+    }
+
+
+def format_audit_readiness(report: dict, out: TextIO = sys.stdout) -> None:
+    checks = report["checks"]
+    out.write("EU AI Act readiness check\n")
+    out.write("─────────────────────────\n")
+    out.write(f"Sessions analysed: {report['session_count']}\n")
+    out.write(
+        f"{'OK' if checks['hash_chain_integrity']['ok'] else 'FAIL'} "
+        f"Hash chain integrity: {checks['hash_chain_integrity']['checked_sessions']} sessions checked\n"
+    )
+    out.write(
+        f"{'OK' if checks['retention_coverage']['ok'] else 'WARN'} "
+        f"Retention coverage: {checks['retention_coverage']['available_days']} / "
+        f"{checks['retention_coverage']['required_days']} days\n"
+    )
+    out.write(
+        f"{'OK' if checks['timestamp_continuity']['ok'] else 'WARN'} "
+        f"Timestamp continuity: {len(checks['timestamp_continuity']['gaps_over_24h'])} gaps over 24h\n"
+    )
+    out.write(
+        f"{'OK' if checks['hash_chain_presence']['ok'] else 'WARN'} "
+        f"Hash chain presence: {len(checks['hash_chain_presence']['sessions_missing_prev_hashes'])} legacy sessions\n"
+    )
+    out.write(f"\nCompliance score: {report['compliance_score']}/100\n")
+
+
+def cmd_audit_readiness(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    report = build_audit_readiness(
+        store,
+        retention_days=float(getattr(args, "retention_days", 90.0)),
+    )
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps(report, indent=2) + "\n")
+    else:
+        format_audit_readiness(report)
+    return 0 if report["ready"] else 1
+
+
+def verify_eu_ai_act_export(path: str | Path) -> dict:
+    data = json.loads(Path(path).read_text())
+    sessions = data.get("sessions", [])
+    failures = []
+    checked_events = 0
+    for session in sessions:
+        events = session.get("article_12", {}).get("events", [])
+        checked_events += len(events)
+        for idx, event in enumerate(events):
+            if idx == 0:
+                continue
+            prev_hash = event.get("prev_hash", "")
+            previous_line_hash = events[idx - 1].get("line_hash", "")
+            if prev_hash and previous_line_hash and prev_hash != previous_line_hash:
+                failures.append({
+                    "session_id": session.get("session_id", ""),
+                    "seq": event.get("seq"),
+                    "event_id": event.get("event_id", ""),
+                })
+    return {
+        "ok": not failures,
+        "checked_sessions": len(sessions),
+        "checked_events": checked_events,
+        "failures": failures,
+    }
+
+
+def cmd_verify_export(args: argparse.Namespace) -> int:
+    result = verify_eu_ai_act_export(getattr(args, "from_export"))
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps(result, indent=2) + "\n")
+    elif result["ok"]:
+        sys.stdout.write(
+            f"Export hash chain intact — {result['checked_events']} events checked\n"
+        )
+    else:
+        sys.stdout.write(
+            f"Export hash chain failed — {len(result['failures'])} broken links\n"
+        )
+    return 0 if result["ok"] else 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -9,7 +9,15 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from agent_trace.compliance import export_compliance, export_compliance_bulk
+from agent_trace.cli import build_parser
+from agent_trace.compliance import (
+    build_audit_readiness,
+    export_compliance,
+    export_compliance_bulk,
+    export_eu_ai_act,
+    select_sessions,
+    verify_eu_ai_act_export,
+)
 from agent_trace.models import EventType, SessionMeta, TraceEvent
 from agent_trace.store import TraceStore
 
@@ -164,6 +172,112 @@ class TestBulkExport(unittest.TestCase):
 
         reports = export_compliance_bulk(self.store, "soc2", since_days=30)
         self.assertEqual(len(reports), 0)
+
+
+class TestEuAiActArticleExport(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_article_12_and_13_blocks_present(self):
+        sid = _make_session(self.store, ["Bash", "Read"], errors=1)
+        report = export_eu_ai_act(self.store, [sid])
+
+        self.assertIn("compliance_metadata", report)
+        self.assertIn("article_12", report)
+        self.assertIn("article_13", report)
+        self.assertEqual(report["compliance_metadata"]["articles_covered"], ["Article 12", "Article 13"])
+        self.assertEqual(report["compliance_metadata"]["session_count"], 1)
+
+    def test_article_12_events_include_hashes(self):
+        sid = _make_session(self.store, ["Bash", "Read"])
+        report = export_eu_ai_act(self.store, [sid])
+        events = report["sessions"][0]["article_12"]["events"]
+
+        self.assertGreaterEqual(len(events), 2)
+        self.assertIn("prev_hash", events[1])
+        self.assertIn("line_hash", events[1])
+        self.assertTrue(events[1]["line_hash"])
+
+    def test_article_13_lists_tools_and_oversight(self):
+        sid = _make_session(self.store, ["Bash"], errors=1)
+        report = export_eu_ai_act(self.store, [sid])
+        article_13 = report["sessions"][0]["article_13"]
+
+        self.assertIn("Bash", article_13["capabilities_summary"]["tools_used"])
+        self.assertEqual(len(article_13["human_oversight_points"]), 1)
+
+    def test_select_sessions_honours_since_until(self):
+        recent = _make_session(self.store, ["Bash"])
+        old_meta = SessionMeta(agent_name="old")
+        old_meta.started_at = time.time() - 86400 * 60
+        old_meta.ended_at = old_meta.started_at + 10
+        self.store.create_session(old_meta)
+        self.store.update_meta(old_meta)
+
+        selected = select_sessions(self.store, since="30d")
+
+        self.assertIn(recent, selected)
+        self.assertNotIn(old_meta.session_id, selected)
+
+    def test_verify_export_detects_tampered_hash_link(self):
+        sid = _make_session(self.store, ["Bash", "Read"])
+        report = export_eu_ai_act(self.store, [sid])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(report, f)
+            ok_path = f.name
+
+        self.assertTrue(verify_eu_ai_act_export(ok_path)["ok"])
+
+        report["sessions"][0]["article_12"]["events"][1]["prev_hash"] = "bad"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(report, f)
+            bad_path = f.name
+
+        result = verify_eu_ai_act_export(bad_path)
+        self.assertFalse(result["ok"])
+        self.assertEqual(len(result["failures"]), 1)
+
+
+class TestAuditReadiness(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = TraceStore(self.tmpdir)
+
+    def test_readiness_report_has_checks(self):
+        _make_session(self.store, ["Bash"])
+
+        report = build_audit_readiness(self.store, retention_days=0)
+
+        self.assertIn("hash_chain_integrity", report["checks"])
+        self.assertIn("retention_coverage", report["checks"])
+        self.assertIn("timestamp_continuity", report["checks"])
+        self.assertIn("compliance_score", report)
+
+    def test_empty_store_is_not_ready(self):
+        report = build_audit_readiness(self.store)
+        self.assertFalse(report["ready"])
+        self.assertEqual(report["compliance_score"], 0)
+
+
+class TestComplianceCliParser(unittest.TestCase):
+    def test_export_accepts_eu_ai_act_format_and_all(self):
+        parser = build_parser()
+        args = parser.parse_args(["export", "--format", "eu-ai-act", "--all", "--since", "30d"])
+        self.assertEqual(args.format, "eu-ai-act")
+        self.assertTrue(args.all)
+
+    def test_audit_readiness_command_registered(self):
+        parser = build_parser()
+        args = parser.parse_args(["audit-readiness", "--format", "json"])
+        self.assertEqual(args.command, "audit-readiness")
+        self.assertEqual(args.format, "json")
+
+    def test_verify_from_export_registered(self):
+        parser = build_parser()
+        args = parser.parse_args(["verify", "--from-export", "audit.json"])
+        self.assertEqual(args.command, "verify")
+        self.assertEqual(args.from_export, "audit.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `agent-strace export --format eu-ai-act` with single-session and `--all --since/--until` batch output
- include Article 12 logging evidence, Article 13 transparency sections, hash-chain metadata, and export verification line hashes
- add `agent-strace verify --from-export` and `agent-strace audit-readiness`
- document the workflow and bump version to `0.76.0`

Closes #164

## Tests
- `python3 -m compileall -q src/agent_trace`
- `python3 -m pytest tests/ -q`
- `git diff --check`
- `python3 -m agent_trace.cli --version`