### PR TITLE
Add cognitive debt report

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace dashboard`](docs/commands.md#dashboard) | Multi-session overview |
 | [`agent-strace budget-report`](docs/commands.md#budget-report) | Weekly spend digest |
 | [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
+| [`agent-strace cognitive-debt`](docs/commands.md#cognitive-debt) | Unreviewed agent-written code by session |
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |
 | [`agent-strace drift`](docs/commands.md#drift) | Detect behavioural drift over time |
 | [`agent-strace fingerprint`](docs/commands.md#fingerprint) | Baseline an agent's behavioural profile |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -169,7 +169,7 @@ Live session monitor with kill-switch rules.
 | `--on-violation terminal\|file\|kill` | Action when a rule fires |
 | `--on-death CMD` | Command to run after kill (receives `{post_mortem_path}`) |
 | `--policy FILE` | Scope policy file to enforce (default: `.agent-scope.json`) |
-| `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,loop:3/10,budget:$5,timeout:30m` |
+| `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,loop:3/10,budget:$5,timeout:30m,cognitive-debt:0.8` |
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
 | `--dry-run` | Evaluate rules without acting |
 
@@ -446,6 +446,26 @@ Team cost attribution across recorded sessions. By default it groups spend by gi
 | `--by author|branch|pr` | Group by git author, active branch, or PR inferred from branch names like `pr-123` |
 | `--export text|csv|json` | Output format. `csv` is intended for spreadsheets and finance workflows |
 | `--outlier-threshold N` | Flag sessions whose cost is above `N` times the report average; default is `2.0` |
+
+### `cognitive-debt`
+```
+agent-strace cognitive-debt [--session ID] [--since DATE] [--until DATE]
+                            [--by author|branch] [--threshold N]
+                            [--format text|json] [--github-token TOKEN]
+```
+Measure unreviewed agent-written code from trace file-write events and local git history. The report works without a GitHub token; when git history is unavailable it still reports agent-written lines and treats review evidence as unknown.
+
+| Flag | Description |
+|---|---|
+| `--session ID` | Score one session by ID or prefix |
+| `--since DATE` | Start of reporting window. Accepts ISO dates or durations like `30d`; default is `30d` |
+| `--until DATE` | End of reporting window. Accepts ISO dates or durations like `7d`; default is now |
+| `--by author|branch` | Group summary rows by git author or branch |
+| `--threshold N` | Flag sessions above this debt score; default is `0.7` |
+| `--format text|json` | Output format |
+| `--github-token TOKEN` | Optional GitHub token for merged PR review/comment enrichment; local git works without it |
+
+`agent-strace watch --rules cognitive-debt:0.8` enables a live rule that alerts when a session has modified files that have not yet had human review.
 
 ### `standup`
 ```

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.76.0"
+__version__ = "0.77.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -43,6 +43,7 @@ from .freshness import cmd_freshness
 from .standup import cmd_standup
 from .audit import cmd_audit, verify_chain
 from .cost import cmd_cost
+from .cognitive_debt import cmd_cognitive_debt
 from .curve import cmd_curve
 from .dashboard import cmd_dashboard
 from .shadow_ai import cmd_audit_tools
@@ -1056,6 +1057,23 @@ def build_parser() -> argparse.ArgumentParser:
                          default=2.0, metavar="SECONDS",
                          help="max seconds between flushes when streaming (default: 2.0)")
 
+    # cognitive-debt
+    p_debt = sub.add_parser("cognitive-debt", help="measure unreviewed agent-written code")
+    p_debt.add_argument("--session", metavar="ID", default="",
+                        help="session ID or prefix to score (default: recent sessions)")
+    p_debt.add_argument("--since", default="30d", metavar="DATE",
+                        help="start of reporting window, ISO date or duration (default: 30d)")
+    p_debt.add_argument("--until", default="", metavar="DATE",
+                        help="end of reporting window, ISO date or duration (default: now)")
+    p_debt.add_argument("--by", choices=["author", "branch"], default="author",
+                        help="group summary rows by author or branch (default: author)")
+    p_debt.add_argument("--threshold", type=float, default=0.7,
+                        help="flag sessions above this debt score (default: 0.7)")
+    p_debt.add_argument("--format", choices=["text", "json"], default="text",
+                        help="output format (default: text)")
+    p_debt.add_argument("--github-token", default="",
+                        help="GitHub token for optional PR review/comment enrichment")
+
     # mcp-scan
     p_mcp_scan = sub.add_parser("mcp-scan", help="scan runtime MCP tool poisoning indicators")
     p_mcp_scan.add_argument("--session", metavar="ID",
@@ -1670,6 +1688,7 @@ def main() -> None:
         "explain": cmd_explain,
         "timeline": cmd_timeline,
         "cost": cmd_cost,
+        "cognitive-debt": cmd_cognitive_debt,
         "diff": cmd_diff,
         "why": cmd_why,
         "audit": cmd_audit,

--- a/src/agent_trace/cognitive_debt.py
+++ b/src/agent_trace/cognitive_debt.py
@@ -1,0 +1,555 @@
+"""Cognitive debt reporting for agent-written code.
+
+The report is intentionally local and best-effort: it derives agent-written
+lines from trace events, then uses git history when available to estimate how
+much of that code has review evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time as _time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from .budget_report import _parse_date
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+@dataclass
+class FileDebt:
+    path: str
+    agent_written_lines: int
+    human_reviewed_lines: int = 0
+    review_signals: list[str] = field(default_factory=list)
+
+    @property
+    def zero_review(self) -> bool:
+        return self.agent_written_lines > 0 and self.human_reviewed_lines <= 0
+
+
+@dataclass
+class SessionDebt:
+    session_id: str
+    started_at: float
+    branch: str
+    author: str
+    agent_written_lines: int
+    human_reviewed_lines: int
+    files: list[FileDebt]
+    git_available: bool = True
+
+    @property
+    def debt_score(self) -> float:
+        if self.agent_written_lines <= 0:
+            return 0.0
+        unreviewed = max(0, self.agent_written_lines - self.human_reviewed_lines)
+        return unreviewed / self.agent_written_lines
+
+    @property
+    def zero_review_files(self) -> list[FileDebt]:
+        return [f for f in self.files if f.zero_review]
+
+
+@dataclass
+class CognitiveDebtReport:
+    window_start: float
+    window_end: float
+    group_by: str
+    threshold: float
+    sessions: list[SessionDebt]
+    rows: dict[str, dict]
+    git_available: bool
+
+    @property
+    def total_agent_written_lines(self) -> int:
+        return sum(s.agent_written_lines for s in self.sessions)
+
+    @property
+    def total_reviewed_lines(self) -> int:
+        return sum(s.human_reviewed_lines for s in self.sessions)
+
+    @property
+    def average_score(self) -> float:
+        if not self.sessions:
+            return 0.0
+        return sum(s.debt_score for s in self.sessions) / len(self.sessions)
+
+    @property
+    def high_debt_sessions(self) -> list[SessionDebt]:
+        return [s for s in self.sessions if s.debt_score > self.threshold]
+
+    @property
+    def zero_review_files(self) -> list[tuple[SessionDebt, FileDebt]]:
+        rows: list[tuple[SessionDebt, FileDebt]] = []
+        for session in self.sessions:
+            for file_debt in session.zero_review_files:
+                rows.append((session, file_debt))
+        return rows
+
+
+def _git(cwd: str, *args: str, timeout: float = 2.0) -> str:
+    if not shutil.which("git"):
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _meta_attr(meta: SessionMeta) -> dict:
+    attr = getattr(meta, "attribution", {}) or {}
+    return attr if isinstance(attr, dict) else {}
+
+
+def _working_dir(meta: SessionMeta) -> str:
+    attr = _meta_attr(meta)
+    return str(attr.get("working_dir") or os.getcwd())
+
+
+def _branch(meta: SessionMeta, cwd: str) -> str:
+    attr = _meta_attr(meta)
+    branch = attr.get("git_branch") or _git(cwd, "branch", "--show-current")
+    if branch:
+        return str(branch)
+    match = re.search(r"branch:\s*([^,)]+)", getattr(meta, "command", "") or "")
+    if match:
+        return match.group(1).strip()
+    return "(unknown)"
+
+
+def _author(meta: SessionMeta, cwd: str) -> str:
+    attr = _meta_attr(meta)
+    return (
+        str(attr.get("git_author") or "")
+        or _git(cwd, "config", "user.email")
+        or str(attr.get("os_user") or "")
+        or os.environ.get("USER", "")
+        or os.environ.get("USERNAME", "")
+        or "(unknown)"
+    )
+
+
+def _path_from_event(event: TraceEvent) -> str:
+    if event.event_type == EventType.FILE_WRITE:
+        return str(
+            event.data.get("path")
+            or event.data.get("file_path")
+            or event.data.get("uri")
+            or ""
+        )
+    if event.event_type != EventType.TOOL_CALL:
+        return ""
+    tool = str(event.data.get("tool_name", "")).lower()
+    args = event.data.get("arguments", {}) or {}
+    if not isinstance(args, dict):
+        return ""
+    write_tools = {"write", "edit", "multiedit", "write_file", "edit_file", "replace", "str_replace"}
+    if tool in write_tools or "write" in tool or "edit" in tool or "replace" in tool:
+        return str(args.get("file_path") or args.get("path") or "")
+    return ""
+
+
+def _line_count(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        if not value:
+            return 0
+        return max(1, len(value.splitlines()))
+    if isinstance(value, list):
+        return sum(_line_count(item) for item in value)
+    if isinstance(value, dict):
+        keys = (
+            "content",
+            "text",
+            "new_text",
+            "new_string",
+            "replacement",
+        )
+        return sum(_line_count(value.get(key)) for key in keys)
+    return 0
+
+
+def _patch_added_lines(text: str) -> int:
+    added = 0
+    for line in text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added += 1
+    return added
+
+
+def _event_line_count(event: TraceEvent) -> int:
+    data = event.data
+    args = data.get("arguments", {}) if isinstance(data.get("arguments", {}), dict) else {}
+    total = _line_count(data) + _line_count(args)
+    for source in (data, args):
+        for key in ("patch", "diff"):
+            value = source.get(key) if isinstance(source, dict) else None
+            if isinstance(value, str):
+                total += _patch_added_lines(value)
+    return max(1, total)
+
+
+def modified_file_lines(events: list[TraceEvent]) -> dict[str, int]:
+    files: dict[str, int] = {}
+    for event in events:
+        path = _path_from_event(event)
+        if not path:
+            continue
+        files[path] = files.get(path, 0) + _event_line_count(event)
+    return files
+
+
+def _git_available(cwd: str) -> bool:
+    return bool(_git(cwd, "rev-parse", "--is-inside-work-tree"))
+
+
+def _review_for_file(cwd: str, path: str, since_ts: float, agent_lines: int) -> tuple[int, list[str]]:
+    if not _git_available(cwd):
+        return 0, ["git_unavailable"]
+
+    since = f"@{int(since_ts)}"
+    raw = _git(
+        cwd,
+        "log",
+        f"--since={since}",
+        "--format=%H%x00%ae%x00%s%x00%b%x1e",
+        "--",
+        path,
+        timeout=3.0,
+    )
+    if not raw:
+        return 0, ["not_committed"]
+
+    signals: set[str] = {"committed_after_session"}
+    authors: set[str] = set()
+    factor = 0.15
+    for record in raw.split("\x1e"):
+        if not record.strip():
+            continue
+        parts = record.strip().split("\x00", 3)
+        if len(parts) < 4:
+            continue
+        _, author, subject, body = parts
+        authors.add(author)
+        text = f"{subject}\n{body}".lower()
+        if "merge pull request" in text or "pull request" in text or re.search(r"\(#\d+\)", subject):
+            signals.add("pull_request_merge")
+            factor = max(factor, 0.35)
+        if "co-authored-by:" in text:
+            signals.add("multiple_authors")
+            factor = max(factor, 0.45)
+        if "reviewed-by:" in text:
+            signals.add("reviewed_by_trailer")
+            factor = max(factor, 0.75)
+        if "review" in text or "comment" in text or "line" in text:
+            signals.add("review_reference")
+            factor = max(factor, 0.55)
+    if len(authors) > 1:
+        signals.add("multiple_commit_authors")
+        factor = max(factor, 0.50)
+
+    return min(agent_lines, int(round(agent_lines * factor))), sorted(signals)
+
+
+def _github_repo(cwd: str) -> tuple[str, str] | None:
+    remote = _git(cwd, "remote", "get-url", "origin")
+    if not remote:
+        return None
+    match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)(?:\.git)?$", remote)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _github_json(path: str, token: str) -> dict | list:
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "agent-strace-cognitive-debt",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _github_review_for_file(
+    cwd: str,
+    branch: str,
+    path: str,
+    token: str,
+    agent_lines: int,
+) -> tuple[int, list[str]]:
+    repo = _github_repo(cwd)
+    if not repo or not token or not branch or branch == "(unknown)":
+        return 0, []
+    owner, name = repo
+    query = urllib.parse.urlencode({
+        "q": f"repo:{owner}/{name} is:pr is:merged head:{branch}",
+        "per_page": "5",
+    })
+    try:
+        search = _github_json(f"/search/issues?{query}", token)
+        items = search.get("items", []) if isinstance(search, dict) else []
+        if not items:
+            return 0, []
+        number = items[0].get("number")
+        if not number:
+            return 0, []
+
+        factor = 0.45
+        signals = {"github_merged_pr"}
+        reviews = _github_json(f"/repos/{owner}/{name}/pulls/{number}/reviews?per_page=100", token)
+        if isinstance(reviews, list) and reviews:
+            factor = max(factor, 0.75)
+            signals.add("github_reviews")
+        comments = _github_json(f"/repos/{owner}/{name}/pulls/{number}/comments?per_page=100", token)
+        if isinstance(comments, list) and comments:
+            factor = max(factor, 0.85)
+            signals.add("github_review_comments")
+            if any(comment.get("path") == path for comment in comments if isinstance(comment, dict)):
+                factor = 1.0
+                signals.add("github_line_comments")
+        return min(agent_lines, int(round(agent_lines * factor))), sorted(signals)
+    except (OSError, urllib.error.HTTPError, urllib.error.URLError, ValueError, KeyError, TypeError):
+        return 0, []
+
+
+def analyze_session_debt(store: TraceStore, meta: SessionMeta, github_token: str = "") -> SessionDebt:
+    cwd = _working_dir(meta)
+    branch = _branch(meta, cwd)
+    author = _author(meta, cwd)
+    git_ok = _git_available(cwd)
+    try:
+        events = store.load_events(meta.session_id)
+    except Exception:
+        events = []
+
+    files = []
+    total_written = 0
+    total_reviewed = 0
+    for path, lines in sorted(modified_file_lines(events).items()):
+        reviewed, signals = _review_for_file(cwd, path, meta.started_at, lines)
+        gh_reviewed, gh_signals = _github_review_for_file(cwd, branch, path, github_token, lines)
+        if gh_reviewed > reviewed:
+            reviewed = gh_reviewed
+        signals = sorted(set(signals) | set(gh_signals))
+        files.append(FileDebt(
+            path=path,
+            agent_written_lines=lines,
+            human_reviewed_lines=reviewed,
+            review_signals=signals,
+        ))
+        total_written += lines
+        total_reviewed += reviewed
+
+    return SessionDebt(
+        session_id=meta.session_id,
+        started_at=meta.started_at,
+        branch=branch,
+        author=author,
+        agent_written_lines=total_written,
+        human_reviewed_lines=total_reviewed,
+        files=files,
+        git_available=git_ok,
+    )
+
+
+def _row_key(group_by: str, session: SessionDebt) -> str:
+    if group_by == "branch":
+        return session.branch
+    return session.author
+
+
+def build_cognitive_debt_report(
+    store: TraceStore,
+    window_start: float,
+    window_end: float,
+    session_id: str = "",
+    group_by: str = "author",
+    threshold: float = 0.7,
+    github_token: str = "",
+) -> CognitiveDebtReport:
+    metas = []
+    if session_id:
+        full_id = store.find_session(session_id) or session_id
+        if store.session_exists(full_id):
+            metas = [store.load_meta(full_id)]
+    else:
+        metas = [
+            meta for meta in store.list_sessions()
+            if window_start <= meta.started_at < window_end
+        ]
+
+    sessions = [analyze_session_debt(store, meta, github_token=github_token) for meta in metas]
+    rows: dict[str, dict] = {}
+    for session in sessions:
+        key = _row_key(group_by, session)
+        if key not in rows:
+            rows[key] = {
+                "group": key,
+                "sessions": 0,
+                "agent_written_lines": 0,
+                "human_reviewed_lines": 0,
+                "score": 0.0,
+                "high_debt_sessions": 0,
+            }
+        row = rows[key]
+        row["sessions"] += 1
+        row["agent_written_lines"] += session.agent_written_lines
+        row["human_reviewed_lines"] += session.human_reviewed_lines
+        if session.debt_score > threshold:
+            row["high_debt_sessions"] += 1
+
+    for row in rows.values():
+        written = row["agent_written_lines"]
+        reviewed = row["human_reviewed_lines"]
+        row["score"] = 0.0 if written <= 0 else max(0, written - reviewed) / written
+
+    rows = dict(sorted(rows.items(), key=lambda item: item[1]["score"], reverse=True))
+    return CognitiveDebtReport(
+        window_start=window_start,
+        window_end=window_end,
+        group_by=group_by,
+        threshold=threshold,
+        sessions=sessions,
+        rows=rows,
+        git_available=all(s.git_available for s in sessions) if sessions else _git_available(os.getcwd()),
+    )
+
+
+def _fmt_date(ts: float) -> str:
+    import datetime
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+
+def _fmt_score(score: float) -> str:
+    return f"{score:.2f}"
+
+
+def format_cognitive_debt_text(report: CognitiveDebtReport, out: TextIO = sys.stdout) -> None:
+    w = out.write
+    w(f"Cognitive debt report - {_fmt_date(report.window_start)} to {_fmt_date(report.window_end)}\n")
+    if not report.git_available:
+        w("Review scoring: git unavailable for one or more sessions; review lines default to zero.\n")
+    w("\n")
+    if not report.sessions:
+        w("No sessions with agent-written files in this period.\n")
+        return
+
+    w(f"{'Session':<14}  {'Branch':<24}  {'Lines':>7}  {'Reviewed':>8}  {'Score':>5}\n")
+    w("-" * 70 + "\n")
+    for session in sorted(report.sessions, key=lambda s: s.debt_score, reverse=True):
+        if session.agent_written_lines <= 0:
+            continue
+        marker = "!" if session.debt_score > report.threshold else " "
+        w(
+            f"{session.session_id[:12]:<14}  {session.branch[:24]:<24}  "
+            f"{session.agent_written_lines:>7}  {session.human_reviewed_lines:>8}  "
+            f"{_fmt_score(session.debt_score):>5} {marker}\n"
+        )
+    w("-" * 70 + "\n")
+    w(f"Average score: {_fmt_score(report.average_score)}\n")
+
+    if report.rows:
+        w(f"\nBy {report.group_by}:\n")
+        for row in report.rows.values():
+            w(
+                f"  {row['group']}: score {_fmt_score(row['score'])}, "
+                f"{row['agent_written_lines']} lines, {row['human_reviewed_lines']} reviewed\n"
+            )
+
+    high = report.high_debt_sessions
+    if high:
+        w(f"\nHigh-debt sessions (score > {report.threshold:g}):\n")
+        for session in high[:5]:
+            w(
+                f"  {session.session_id[:12]} - {session.agent_written_lines} agent-written lines, "
+                f"{session.human_reviewed_lines} reviewed\n"
+            )
+
+    zero_review = report.zero_review_files
+    if zero_review:
+        w("\nFiles with zero human review:\n")
+        for session, file_debt in zero_review[:10]:
+            w(f"  {file_debt.path} ({file_debt.agent_written_lines} lines, session {session.session_id[:12]})\n")
+
+
+def format_cognitive_debt_json(report: CognitiveDebtReport) -> str:
+    return json.dumps({
+        "window_start": report.window_start,
+        "window_end": report.window_end,
+        "group_by": report.group_by,
+        "threshold": report.threshold,
+        "git_available": report.git_available,
+        "average_score": report.average_score,
+        "total_agent_written_lines": report.total_agent_written_lines,
+        "total_reviewed_lines": report.total_reviewed_lines,
+        "rows": list(report.rows.values()),
+        "sessions": [
+            {
+                "session_id": session.session_id,
+                "started_at": session.started_at,
+                "branch": session.branch,
+                "author": session.author,
+                "agent_written_lines": session.agent_written_lines,
+                "human_reviewed_lines": session.human_reviewed_lines,
+                "score": session.debt_score,
+                "git_available": session.git_available,
+                "files": [
+                    {
+                        "path": file_debt.path,
+                        "agent_written_lines": file_debt.agent_written_lines,
+                        "human_reviewed_lines": file_debt.human_reviewed_lines,
+                        "review_signals": file_debt.review_signals,
+                    }
+                    for file_debt in session.files
+                ],
+            }
+            for session in report.sessions
+        ],
+    }, indent=2)
+
+
+def cmd_cognitive_debt(args: argparse.Namespace) -> int:
+    store = TraceStore(args.trace_dir)
+    now = _time.time()
+    until = _parse_date(getattr(args, "until", "")) if getattr(args, "until", "") else now
+    since_arg = getattr(args, "since", "") or "30d"
+    since = _parse_date(since_arg)
+    threshold = float(getattr(args, "threshold", 0.7))
+    group_by = getattr(args, "by", "author")
+    report = build_cognitive_debt_report(
+        store,
+        window_start=since,
+        window_end=until,
+        session_id=getattr(args, "session", "") or "",
+        group_by=group_by,
+        threshold=threshold,
+        github_token=getattr(args, "github_token", "") or "",
+    )
+
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(format_cognitive_debt_json(report) + "\n")
+    else:
+        format_cognitive_debt_text(report)
+    return 0

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -346,6 +346,7 @@ class WatcherConfig:
     on_death_cmd: str = ""
     # Built-in rule names enabled via --rules mcp-poisoning,budget:$5,...
     built_in_rules: set[str] = field(default_factory=set)
+    cognitive_debt_threshold: float | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> "WatcherConfig":
@@ -384,6 +385,10 @@ class WatcherConfig:
             operation_rules=rules,
             max_context_pct=int(d.get("max_context_pct", 90)),
             built_in_rules=set(d.get("built_in_rules", [])),
+            cognitive_debt_threshold=(
+                float(d["cognitive_debt_threshold"])
+                if d.get("cognitive_debt_threshold") is not None else None
+            ),
         )
 
     @classmethod
@@ -849,6 +854,11 @@ def check_event(
             if _path and _path not in state.files_modified_set:
                 state.files_modified_set.add(_path)
                 state.files_modified = len(state.files_modified_set)
+    elif event.event_type == EventType.FILE_WRITE:
+        _path = str(event.data.get("path") or event.data.get("file_path") or event.data.get("uri") or "")
+        if _path and _path not in state.files_modified_set:
+            state.files_modified_set.add(_path)
+            state.files_modified = len(state.files_modified_set)
 
     # --- Track consecutive test failures (for nanny rules) ---
     if event.event_type == EventType.TOOL_RESULT:
@@ -892,6 +902,21 @@ def check_event(
             violations.append(
                 f"CostWatcher: ${state.estimated_cost:.2f} (threshold: ${config.max_cost_dollars})"
             )
+
+    # --- Live cognitive debt threshold ---
+    if "cognitive-debt" in config.built_in_rules and state.files_modified > 0:
+        threshold = config.cognitive_debt_threshold
+        if threshold is None:
+            threshold = 0.8
+        live_score = 1.0
+        if live_score > threshold:
+            key_id = "cognitive-debt"
+            if key_id not in state.fired:
+                state.fired.add(key_id)
+                violations.append(
+                    f"CognitiveDebtWatcher: live debt score {live_score:.2f} "
+                    f"({state.files_modified} modified files, no review yet; threshold: {threshold:g})"
+                )
 
     # --- Duration threshold ---
     elapsed = time.time() - state.start_time
@@ -1364,6 +1389,14 @@ def _apply_builtin_rules_spec(spec: str, config: WatcherConfig) -> list[str]:
                 config.max_duration_seconds = _parse_duration(value)
             except ValueError:
                 warnings.append(f"invalid timeout rule {item!r}")
+            continue
+        if item.startswith("cognitive-debt:"):
+            value = item.split(":", 1)[1].strip()
+            try:
+                config.cognitive_debt_threshold = float(value)
+                config.built_in_rules.add("cognitive-debt")
+            except ValueError:
+                warnings.append(f"invalid cognitive-debt rule {item!r}")
             continue
         warnings.append(f"unknown built-in rule {item!r}")
     return warnings

--- a/tests/test_cognitive_debt.py
+++ b/tests/test_cognitive_debt.py
@@ -1,0 +1,184 @@
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agent_trace.cli import build_parser
+from agent_trace.cognitive_debt import (
+    SessionDebt,
+    build_cognitive_debt_report,
+    modified_file_lines,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", "-C", cwd, *args], check=True, capture_output=True, text=True)
+
+
+def _make_store_session(store, cwd, branch="main", author="dev@example.com"):
+    meta = SessionMeta(
+        agent_name="codex",
+        attribution={
+            "working_dir": cwd,
+            "git_branch": branch,
+            "git_author": author,
+        },
+    )
+    meta.started_at = time.time() - 10
+    store.create_session(meta)
+    return meta
+
+
+class TestCognitiveDebtScoring(unittest.TestCase):
+    def test_debt_score_uses_unreviewed_agent_lines(self):
+        session = SessionDebt(
+            session_id="s1",
+            started_at=0,
+            branch="main",
+            author="dev@example.com",
+            agent_written_lines=100,
+            human_reviewed_lines=40,
+            files=[],
+        )
+
+        self.assertAlmostEqual(session.debt_score, 0.60)
+
+    def test_modified_file_lines_counts_tool_payloads(self):
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            data={
+                "tool_name": "Write",
+                "arguments": {
+                    "file_path": "src/app.py",
+                    "content": "a\nb\nc\n",
+                },
+            },
+        )
+
+        self.assertEqual(modified_file_lines([event]), {"src/app.py": 3})
+
+    def test_git_unavailable_fallback_reports_zero_review(self):
+        tmp = tempfile.mkdtemp()
+        store = TraceStore(Path(tmp) / "traces")
+        meta = _make_store_session(store, tmp)
+        store.append_event(
+            meta.session_id,
+            TraceEvent(
+                event_type=EventType.FILE_WRITE,
+                data={"path": "src/app.py", "content": "a\nb\nc"},
+            ),
+        )
+
+        report = build_cognitive_debt_report(
+            store,
+            window_start=time.time() - 60,
+            window_end=time.time() + 60,
+            threshold=0.7,
+        )
+
+        self.assertFalse(report.git_available)
+        self.assertEqual(report.sessions[0].agent_written_lines, 3)
+        self.assertEqual(report.sessions[0].human_reviewed_lines, 0)
+        self.assertEqual(len(report.zero_review_files), 1)
+
+    def test_local_git_review_signal_adds_reviewed_lines(self):
+        tmp = tempfile.mkdtemp()
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        _git(str(repo), "init")
+        _git(str(repo), "config", "user.email", "reviewer@example.com")
+        _git(str(repo), "config", "user.name", "Reviewer")
+
+        store = TraceStore(Path(tmp) / "traces")
+        meta = _make_store_session(store, str(repo), branch="feat/reviewed")
+        (repo / "app.py").write_text("print('hello')\n")
+        store.append_event(
+            meta.session_id,
+            TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                data={
+                    "tool_name": "Write",
+                    "arguments": {
+                        "file_path": "app.py",
+                        "content": "\n".join(str(i) for i in range(10)),
+                    },
+                },
+            ),
+        )
+
+        _git(str(repo), "add", "app.py")
+        _git(str(repo), "commit", "-m", "Merge pull request #12 from feat/reviewed")
+
+        report = build_cognitive_debt_report(
+            store,
+            window_start=time.time() - 60,
+            window_end=time.time() + 60,
+            group_by="branch",
+            threshold=0.7,
+        )
+        session = report.sessions[0]
+
+        self.assertTrue(report.git_available)
+        self.assertGreater(session.human_reviewed_lines, 0)
+        self.assertLess(session.debt_score, 1.0)
+        self.assertIn("pull_request_merge", session.files[0].review_signals)
+        self.assertIn("feat/reviewed", report.rows)
+
+    def test_github_token_can_enrich_review_signals(self):
+        tmp = tempfile.mkdtemp()
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        _git(str(repo), "init")
+        _git(str(repo), "config", "user.email", "reviewer@example.com")
+        _git(str(repo), "config", "user.name", "Reviewer")
+
+        store = TraceStore(Path(tmp) / "traces")
+        meta = _make_store_session(store, str(repo), branch="feat/github-reviewed")
+        store.append_event(
+            meta.session_id,
+            TraceEvent(
+                event_type=EventType.TOOL_CALL,
+                data={
+                    "tool_name": "Write",
+                    "arguments": {
+                        "file_path": "app.py",
+                        "content": "\n".join(str(i) for i in range(8)),
+                    },
+                },
+            ),
+        )
+
+        with patch(
+            "agent_trace.cognitive_debt._github_review_for_file",
+            return_value=(8, ["github_line_comments"]),
+        ):
+            report = build_cognitive_debt_report(
+                store,
+                window_start=time.time() - 60,
+                window_end=time.time() + 60,
+                github_token="token",
+            )
+
+        session = report.sessions[0]
+        self.assertEqual(session.human_reviewed_lines, 8)
+        self.assertEqual(session.debt_score, 0.0)
+        self.assertIn("github_line_comments", session.files[0].review_signals)
+
+    def test_parser_registers_command(self):
+        parser = build_parser()
+        args = parser.parse_args(["cognitive-debt", "--by", "branch", "--threshold", "0.8"])
+        self.assertEqual(args.command, "cognitive-debt")
+        self.assertEqual(args.by, "branch")
+        self.assertAlmostEqual(args.threshold, 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -279,7 +279,10 @@ class TestBuiltInRules(unittest.TestCase):
     def test_builtin_rules_spec_enables_mcp_poisoning_and_limits(self):
         config = WatcherConfig()
 
-        warnings = _apply_builtin_rules_spec("mcp-poisoning,loop:4/12,budget:$5,timeout:30m", config)
+        warnings = _apply_builtin_rules_spec(
+            "mcp-poisoning,loop:4/12,budget:$5,timeout:30m,cognitive-debt:0.8",
+            config,
+        )
 
         self.assertEqual(warnings, [])
         self.assertIn("mcp-poisoning", config.built_in_rules)
@@ -288,6 +291,8 @@ class TestBuiltInRules(unittest.TestCase):
         self.assertEqual(config.loop_window, 12)
         self.assertEqual(config.max_cost_dollars, 5.0)
         self.assertEqual(config.max_duration_seconds, 1800.0)
+        self.assertIn("cognitive-debt", config.built_in_rules)
+        self.assertAlmostEqual(config.cognitive_debt_threshold, 0.8)
 
     def test_watch_parser_registers_loop_flags(self):
         parser = build_parser()
@@ -316,6 +321,19 @@ class TestBuiltInRules(unittest.TestCase):
         violations = check_event(http_event, config, state)
 
         self.assertTrue(any("McpPoisoningWatcher" in v for v in violations))
+
+    def test_cognitive_debt_rule_alerts_on_live_write(self):
+        config = WatcherConfig(built_in_rules={"cognitive-debt"}, cognitive_debt_threshold=0.8)
+        state = WatchState()
+        event = _make_event(
+            EventType.FILE_WRITE,
+            0.0,
+            path="src/app.py",
+        )
+
+        violations = check_event(event, config, state)
+
+        self.assertTrue(any("CognitiveDebtWatcher" in v for v in violations))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `agent-strace cognitive-debt` for local-git cognitive debt reporting by session, author, or branch
- estimate agent-written lines from file-write/write-tool trace events and review evidence from local git history
- support optional `--github-token` PR review/comment enrichment using stdlib HTTP only
- add live `watch --rules cognitive-debt:<threshold>` shorthand
- document the command and bump the package version to `0.77.0`

Closes #170

## Verification
- `python3 -m pytest tests/test_cognitive_debt.py tests/test_watch.py -q`
- `python3 -m compileall -q src/agent_trace && git diff --check`
- `python3 -m pytest tests/ -q` -> `1591 passed`
- `python3 -m agent_trace.cli --version` -> `agent-strace 0.77.0`