### PR TITLE
Document Copilot Desktop MCP tracing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ agent-strace replay            # replay the latest
 
 Full config and JSON: [docs/setup.md](docs/setup.md)
 
-**Option 2: MCP proxy** — wraps any MCP server, works with Cursor and Windsurf
+**Option 2: MCP proxy** — wraps any MCP server, works with Cursor, Windsurf, and Copilot Desktop MCP servers
 
 ```bash
 agent-strace record -- npx -y @modelcontextprotocol/server-filesystem /tmp

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -59,8 +59,11 @@ Use setup-generated hooks when the agent CLI has its own lifecycle hook system.
 | Gemini CLI | `agent-strace setup --cli gemini` | Session start/end, prompts, assistant responses, `BeforeTool`/`AfterTool` tools |
 | Cursor | `agent-strace setup --cli cursor` | Session start/end, prompts, shell execution, file edits, assistant responses when emitted by Cursor hooks |
 | GitHub Copilot CLI | `agent-strace setup --cli copilot` | Session starts, prompts, hook-visible tool calls/results, and stop payloads when emitted by Copilot hooks |
+| GitHub Copilot Desktop | Wrap each local MCP server with `agent-strace record -- ...` | MCP initialize/tool call/tool result traffic for wrapped servers only; full chat transcripts and non-MCP activity are not exposed |
 
 All paths write the same event stream under `.agent-traces/`, so replay, timeline, explain, why, watch, export, and audit commands work the same way after capture.
+
+For Copilot Desktop, use a shared absolute trace directory such as `/Users/alice/.agent-strace/traces`, configure `agent-strace --trace-dir <dir> mcp` as an optional trace-reader MCP server, and wrap each tool-providing MCP server with `agent-strace --trace-dir <dir> record --name <label> -- <original-command> <args>`. See [setup.md](setup.md#github-copilot-desktop) for the full Local server field values and validation commands.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -194,6 +194,60 @@ agent-strace record -- npx -y @modelcontextprotocol/server-filesystem /tmp
 agent-strace replay
 ```
 
+### GitHub Copilot Desktop
+
+GitHub Copilot Desktop can connect to local MCP servers, but it does not expose the same hook system as Copilot CLI. For Copilot Desktop, agent-strace traces the MCP traffic that passes through a wrapped MCP server. It does not capture the full Copilot chat transcript, internal planning, token usage, or non-MCP file edits.
+
+Use one shared trace directory so all wrapped MCP servers write to the same store:
+
+```bash
+mkdir -p ~/.agent-strace/traces
+which agent-strace
+```
+
+Desktop apps often do not inherit the same shell `PATH` as your terminal. If `which agent-strace` prints `/Users/alice/.local/bin/agent-strace`, use that full path in Copilot Desktop.
+
+Add an unwrapped reader server if you want Copilot to query existing traces:
+
+| Field | Value |
+|---|---|
+| Server name | `agent-trace` |
+| Type | `Local` |
+| Command | `/Users/alice/.local/bin/agent-strace` |
+| Arguments | `--trace-dir /Users/alice/.agent-strace/traces mcp` |
+
+This server only exposes tools such as `list_sessions`, `get_session`, `search_events`, `get_session_summary`, and `diff_sessions`. It does not record Copilot Desktop activity by itself.
+
+Wrap each MCP server whose tool traffic you want to record. For example, to trace the filesystem MCP server:
+
+| Field | Value |
+|---|---|
+| Server name | `filesystem-traced` |
+| Type | `Local` |
+| Command | `/Users/alice/.local/bin/agent-strace` |
+| Arguments | `--trace-dir /Users/alice/.agent-strace/traces record --name copilot-filesystem -- npx -y @modelcontextprotocol/server-filesystem /Users/alice` |
+
+Disable any unwrapped duplicate filesystem MCP server, otherwise Copilot may call the unwrapped server and bypass the recorder.
+
+Ask Copilot Desktop to use the traced server:
+
+```text
+Use the filesystem-traced MCP server to list files in /Users/alice/Desktop.
+```
+
+Then inspect the captured session:
+
+```bash
+TRACE=/Users/alice/.agent-strace/traces
+
+agent-strace --trace-dir "$TRACE" list
+grep -Rl '"event_type":"tool_call"' "$TRACE"/*/events.ndjson
+agent-strace --trace-dir "$TRACE" replay <session-id>
+agent-strace --trace-dir "$TRACE" inspect <session-id>
+```
+
+Long-lived MCP servers may keep `meta.json` counters stale while Copilot Desktop is still running. If `agent-strace list` shows `Tool calls: 0` but `replay` or `inspect` shows `tool_call` and `tool_result` events, the capture is working and the summary metadata has not been finalized yet.
+
 ### Cursor
 
 Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project):


### PR DESCRIPTION
## Summary

- Add GitHub Copilot Desktop MCP tracing setup to `docs/setup.md`
- Explain reader vs recorder MCP servers and exact Local server field values
- Document validation commands and the stale live metadata counter caveat
- Add Copilot Desktop to the integrations overview and README MCP proxy mention

## Testing

- `git diff --check`

## Notes

This documents that Copilot Desktop can be traced at the MCP-server level by wrapping local MCP servers with `agent-strace record -- ...`, while full chat transcripts and non-MCP activity require hooks or native runtime support.