### PR TITLE
Add opt-in anonymous CLI product telemetry

### DIFF
--- a/ADRs/0013-opt-in-product-telemetry.md
+++ b/ADRs/0013-opt-in-product-telemetry.md
@@ -1,0 +1,48 @@
+# ADR-0013: Opt-in Anonymous Product Telemetry
+
+**Status:** Accepted
+**Date:** 2026-08
+**Deciders:** Siddhant Khare
+
+## Context
+
+PyPI download counts show distribution but not whether people successfully set
+up agent-strace, capture sessions, return to the product, or encounter failing
+commands. The project needs basic product usage signals without weakening its
+local-first privacy model or adding runtime dependencies.
+
+Agent traces can contain prompts, tool arguments, file paths, repository data,
+and model responses. Product analytics must never reuse or upload that data.
+
+## Decision
+
+Add anonymous, explicit opt-in product telemetry with these boundaries:
+
+- Telemetry is disabled until the user consents through the interactive prompt,
+  `agent-strace telemetry enable`, or `AGENT_STRACE_TELEMETRY=1`.
+- `DO_NOT_TRACK=1` and `AGENT_STRACE_TELEMETRY=0` disable collection. CI is off
+  by default unless explicitly enabled.
+- A random installation ID is stored separately in
+  `~/.agent-strace/telemetry.json`. Disabling telemetry deletes the ID.
+- Events use a fixed property allowlist. Prompts, responses, arguments, paths,
+  repository metadata, endpoints, trace/session IDs, exception messages, and
+  trace contents cannot enter the payload.
+- The client sends HTTPS/JSON directly to a maintainer-controlled PostHog
+  project using `urllib.request`. Person profiles and GeoIP enrichment are
+  disabled on every event.
+- Network failures are silent and never affect command output, behavior, or exit
+  status. No on-disk event queue is maintained.
+- Internal hook invocations are not tracked individually. Hook integrations emit
+  one product event only when an agent session ends.
+
+## Consequences
+
+- Maintainers can measure activation, command adoption, integrations, versions,
+  retention, and aggregate failure rates without operating a telemetry database.
+- Opt-in data will be incomplete and may contain selection bias; it must not be
+  treated as billing, compliance, or security evidence.
+- The public PostHog project token must be configured before publishing a release.
+- Direct ingestion means PostHog receives the network request even though GeoIP
+  enrichment and person-profile processing are disabled. A first-party relay can
+  be added later without changing the event schema.
+- The implementation preserves the zero-runtime-dependency constraint.

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -37,6 +37,9 @@ What are the trade-offs, limitations, and follow-on effects?
 | [0008](0008-token-cost-estimation-heuristic.md) | Token and Cost Estimation via Character-Count Heuristic | Accepted |
 | [0009](0009-claude-code-jsonl-import.md) | Claude Code JSONL Session Import | Accepted |
 | [0010](0010-session-explain-phase-detection.md) | Session Explanation via Prompt-Boundary Phase Detection | Accepted |
+| [0011](0011-otlp-genai-semantic-conventions.md) | OTLP GenAI Semantic Conventions Export Format | Accepted |
+| [0012](0012-server-side-event-collector.md) | Server-Side Event Collector | Accepted |
+| [0013](0013-opt-in-product-telemetry.md) | Opt-in Anonymous Product Telemetry | Accepted |
 
 ## Adding a new ADR
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace approval list`](docs/commands.md#approval) | Human-in-the-loop approval queue |
 | [`agent-strace rbac assign`](docs/commands.md#rbac) | Org and workspace-scoped role assignments |
 | [`agent-strace auth login`](docs/commands.md#auth) | SSO/OIDC login to a hosted collector |
+| [`agent-strace telemetry status`](docs/telemetry.md) | Inspect, enable, or disable anonymous CLI usage telemetry |
 | [`agent-strace apply`](docs/commands.md#apply) | Apply `.agent-strace.yaml` config to local store or collector |
 | [`agent-strace workspace new`](docs/commands.md#workspace) | Create an isolated workspace |
 | [`agent-strace compliance export`](docs/commands.md#compliance) | Export compliance reports (EU AI Act, SOC 2, HIPAA) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,16 @@ agent-strace setup [--cli claude|codex|gemini|cursor|copilot|all] [--no-redact] 
 ```
 Print or install hooks config for supported agent CLIs. `--cli claude` prints Claude Code settings JSON for `~/.claude/settings.json`; `--cli codex` writes `$CODEX_CONFIG_DIR/hooks.json` or `~/.codex/hooks.json`; `--cli gemini` writes a Gemini CLI extension under `$GEMINI_CONFIG_DIR/extensions/agent-strace` or `~/.gemini/extensions/agent-strace`; `--cli cursor` writes `.cursor/hooks.json` or `$CURSOR_CONFIG_DIR/hooks.json`; `--cli copilot` writes `$COPILOT_HOME/hooks/agent-strace.json` or `~/.copilot/hooks/agent-strace.json`; `--cli all` configures all supported CLIs. Secret redaction is enabled by default; use `--no-redact` only for trusted local traces.
 
+### `telemetry`
+```
+agent-strace telemetry [status|enable|disable]
+```
+Show or change consent for anonymous product telemetry. Telemetry is disabled
+until the user opts in. `disable` also deletes the local anonymous installation
+ID. `DO_NOT_TRACK=1` or `AGENT_STRACE_TELEMETRY=0` always disables collection;
+`AGENT_STRACE_TELEMETRY=1` explicitly enables it, including in CI. See
+[telemetry.md](telemetry.md) for the exact event schema and maintainer setup.
+
 ### `import`
 ```
 agent-strace import <path.jsonl> [--discover]

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,6 +2,11 @@
 
 agent-strace provides two complementary mechanisms for keeping sensitive data out of traces: secret redaction (at capture time) and PII anonymization (at export time). A policy file lets you audit and restrict what the agent is allowed to do.
 
+Anonymous product telemetry is a separate, opt-in data path and never reads
+trace contents. Its fixed schema excludes prompts, responses, command arguments,
+paths, repository data, session IDs, endpoints, and exception messages. See
+[Product telemetry](telemetry.md) for the complete schema and controls.
+
 ---
 
 ## Secret redaction

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,106 @@
+# Product telemetry
+
+agent-strace can send anonymous product usage events to a PostHog project owned
+by the project maintainer. This is separate from agent tracing: no `.agent-traces/`
+files or event data are read by the telemetry client.
+
+Telemetry is disabled until the user explicitly opts in. On a configured build,
+the first interactive CLI invocation asks once, with a default of **No**.
+Non-interactive use and CI do not prompt.
+
+## User controls
+
+```bash
+agent-strace telemetry status
+agent-strace telemetry enable
+agent-strace telemetry disable
+
+# Environment-level overrides
+DO_NOT_TRACK=1 agent-strace list
+AGENT_STRACE_TELEMETRY=0 agent-strace list
+AGENT_STRACE_TELEMETRY=1 agent-strace list
+```
+
+Consent and a random installation ID are stored in
+`~/.agent-strace/telemetry.json`. Disabling telemetry deletes the identifier.
+CI is disabled by default; `AGENT_STRACE_TELEMETRY=1` is required to enable it.
+
+## Collected fields
+
+There are three events:
+
+| Event | Event-specific fields |
+|---|---|
+| `agent_strace_cli_command_completed` | command, subcommand, success, exit code, duration, error type, integration, export format/backend |
+| `agent_strace_session_completed` | provider, capture method, success, duration |
+| `agent_strace_telemetry_enabled` | consent source |
+
+Every event also includes the anonymous installation ID, telemetry schema
+version, agent-strace version, Python major/minor version, OS family, and CI
+boolean.
+
+The schema does **not** accept prompts, responses, command arguments, file paths,
+repository names or hashes, usernames, hostnames, endpoints, trace contents,
+session IDs, model input/output, exception messages, or stack traces. PostHog
+person-profile processing and GeoIP enrichment are disabled for every event.
+Like any direct HTTPS destination, PostHog still receives the network request
+under its own infrastructure and privacy terms.
+
+## Maintainer setup
+
+No database or deployed service is required. Use a managed PostHog project:
+
+1. Create a PostHog Cloud project and choose the US or EU region.
+2. Open **Project settings** and copy the **Project token**. This is the public
+   event-ingestion token, not a personal API key.
+3. In `src/agent_trace/telemetry.py`, set:
+
+   ```python
+   DEFAULT_POSTHOG_PROJECT_TOKEN = "phc_your_project_token"
+   DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"  # or https://eu.i.posthog.com
+   ```
+
+4. Verify locally without editing the constants first:
+
+   ```bash
+   export AGENT_STRACE_TELEMETRY_TOKEN="phc_your_project_token"
+   export AGENT_STRACE_TELEMETRY_HOST="https://us.i.posthog.com"
+   export AGENT_STRACE_TELEMETRY_CONFIG="$(mktemp)"
+
+   agent-strace telemetry enable
+   agent-strace list
+   agent-strace telemetry status
+   ```
+
+5. In PostHog's live events view, confirm that
+   `agent_strace_telemetry_enabled` and
+   `agent_strace_cli_command_completed` arrived and contain only the documented
+   properties.
+6. Commit the public project token and publish the release. End users do not set
+   a token; it is part of the distributed package.
+
+`AGENT_STRACE_TELEMETRY_TOKEN`, `AGENT_STRACE_TELEMETRY_HOST`, and
+`AGENT_STRACE_TELEMETRY_CONFIG` are intended for development, downstream
+distributions, and tests. Network delivery uses a 0.5-second timeout and is
+best-effort; failures never change CLI behavior or exit status.
+
+## Suggested PostHog dashboard
+
+Create these insights:
+
+1. **Weekly active installations:** unique users performing
+   `agent_strace_cli_command_completed`.
+2. **Command adoption:** event count grouped by `command`, filtered to successful
+   events.
+3. **Integration adoption:** successful `setup` events grouped by `integration`.
+4. **Reliability:** failed command events divided by all command events, grouped
+   by command and agent-strace version.
+5. **Activation funnel:** successful `setup` command →
+   `agent_strace_session_completed` → successful `replay`, `inspect`, `explain`,
+   or `export` command.
+6. **Retention:** users whose first `agent_strace_session_completed` event is
+   followed by another successful command in later weeks.
+
+Do not use this telemetry for billing, access control, compliance, or security
+evidence. Open-source clients and public ingestion endpoints can be modified or
+spoofed.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.80.1"
+__version__ = "0.81.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -58,6 +58,7 @@ from .postmortem import cmd_postmortem
 from .project_budget import enforce_new_session_budget, load_project_budget_config
 from .share import cmd_share
 from .token_budget import cmd_token_budget
+from . import telemetry as _product_telemetry
 from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
@@ -1050,6 +1051,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_setup.add_argument("--cli", choices=["claude", "codex", "gemini", "cursor", "copilot", "all"], default="claude",
                          help="agent CLI to configure (default: claude)")
 
+    # anonymous product telemetry controls
+    p_telemetry = sub.add_parser(
+        "telemetry",
+        help="show, enable, or disable anonymous product telemetry",
+    )
+    telemetry_sub = p_telemetry.add_subparsers(dest="telemetry_command")
+    telemetry_sub.add_parser("status", help="show telemetry status and collected fields")
+    telemetry_sub.add_parser("enable", help="opt in to anonymous product telemetry")
+    telemetry_sub.add_parser("disable", help="opt out and delete the anonymous installation ID")
+
     # import (Claude Code JSONL session logs)
     p_import = sub.add_parser("import", help="import a Claude Code JSONL session log")
     p_import.add_argument("path", nargs="?", help="path to .jsonl session file")
@@ -1826,6 +1837,105 @@ def cmd_auto(args: argparse.Namespace) -> int:
             pass
 
 
+_TELEMETRY_SUBCOMMAND_ATTRS = (
+    "eval_command",
+    "dataset_command",
+    "dash_command",
+    "baseline_cmd",
+    "approval_cmd",
+    "rbac_cmd",
+    "auth_cmd",
+    "compliance_cmd",
+    "workspace_cmd",
+    "identity_cmd",
+    "server_subcommand",
+    "config_watch_command",
+    "retention_command",
+)
+
+
+def _telemetry_command_properties(args: argparse.Namespace) -> dict:
+    """Return only low-cardinality, non-user-authored CLI properties."""
+    properties = {"command": args.command}
+    subcommands = [
+        getattr(args, name, "")
+        for name in _TELEMETRY_SUBCOMMAND_ATTRS
+        if getattr(args, name, "")
+    ]
+    if subcommands:
+        properties["subcommand"] = ".".join(subcommands)
+
+    if args.command == "setup":
+        properties["integration"] = getattr(args, "cli", "claude") or "claude"
+    elif args.command == "auto":
+        framework = getattr(args, "framework", "") or (
+            "detect" if getattr(args, "detect", False) else ""
+        )
+        if framework:
+            properties["integration"] = framework
+    elif args.command == "export":
+        properties["export_format"] = getattr(args, "format", "json")
+        backend = getattr(args, "backend", "") or ""
+        if backend:
+            properties["backend"] = backend
+    return properties
+
+
+def _normalise_exit_code(value) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return 1
+
+
+def _run_with_product_telemetry(args: argparse.Namespace, handler):
+    """Run a CLI handler and emit one best-effort completion event."""
+    started_at = time.monotonic()
+    base = _telemetry_command_properties(args)
+    try:
+        result = handler(args)
+    except SystemExit as exc:
+        exit_code = _normalise_exit_code(exc.code)
+        _product_telemetry.capture(
+            _product_telemetry.CLI_COMMAND_COMPLETED,
+            {
+                **base,
+                "success": exit_code == 0,
+                "exit_code": exit_code,
+                "duration_ms": _product_telemetry.monotonic_ms_since(started_at),
+                "error_type": "SystemExit",
+            },
+        )
+        raise
+    except BaseException as exc:
+        _product_telemetry.capture(
+            _product_telemetry.CLI_COMMAND_COMPLETED,
+            {
+                **base,
+                "success": False,
+                "exit_code": 1,
+                "duration_ms": _product_telemetry.monotonic_ms_since(started_at),
+                "error_type": type(exc).__name__,
+            },
+        )
+        raise
+
+    exit_code = _normalise_exit_code(result)
+    _product_telemetry.capture(
+        _product_telemetry.CLI_COMMAND_COMPLETED,
+        {
+            **base,
+            "success": exit_code == 0,
+            "exit_code": exit_code,
+            "duration_ms": _product_telemetry.monotonic_ms_since(started_at),
+        },
+    )
+    return result
+
+
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
@@ -1842,11 +1952,13 @@ def main() -> None:
         hook_main(hook_args)
         sys.exit(0)
 
-    if args.command == "setup":
-        cmd_setup(args)
-        sys.exit(0)
+    if args.command == "telemetry":
+        sys.exit(_product_telemetry.cmd_telemetry(args))
+
+    _product_telemetry.maybe_prompt_for_consent()
 
     handlers = {
+        "setup": cmd_setup,
         "record": cmd_record,
         "record-http": cmd_record_http,
         "replay": cmd_replay,
@@ -1910,7 +2022,7 @@ def main() -> None:
 
     handler = handlers.get(args.command)
     if handler:
-        sys.exit(handler(args))
+        sys.exit(_run_with_product_telemetry(args, handler))
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -49,6 +49,7 @@ from .models import EventType, SessionMeta, TraceEvent
 from .attribution import collect_attribution
 from .redact import redact_data, redact_data_with_status, redaction_enabled
 from .store import TraceStore
+from . import telemetry as _product_telemetry
 
 # Pending tool calls are tracked in a file so separate hook processes
 # can link PostToolUse back to PreToolUse for latency measurement.
@@ -337,6 +338,15 @@ def handle_session_end(input_data: dict, provider: str = "claude") -> None:
             ),
         )
         store.update_meta(meta)
+        _product_telemetry.capture(
+            _product_telemetry.SESSION_COMPLETED,
+            {
+                "provider": provider,
+                "capture_method": "hooks",
+                "success": meta.errors == 0,
+                "duration_ms": int(meta.total_duration_ms),
+            },
+        )
 
     _clear_active_session(provider=provider)
 

--- a/src/agent_trace/telemetry.py
+++ b/src/agent_trace/telemetry.py
@@ -31,7 +31,9 @@ from . import __version__
 # PostHog project tokens are public ingestion tokens, not personal API keys.
 # Replace this value with the project token from Project settings before a
 # release.  The environment override is useful for local verification.
-DEFAULT_POSTHOG_PROJECT_TOKEN = ""
+DEFAULT_POSTHOG_PROJECT_TOKEN = (
+    "phc_yWjxK7ibJuFfskDuTr4HbXGdyGvFC6V3Y3fRwNDiRK6x"
+)
 DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 
 TELEMETRY_SCHEMA_VERSION = 1

--- a/src/agent_trace/telemetry.py
+++ b/src/agent_trace/telemetry.py
@@ -1,0 +1,401 @@
+"""Privacy-preserving product telemetry for the agent-strace CLI.
+
+Telemetry is disabled until the user explicitly opts in.  When enabled, the
+client sends a small allow-listed event directly to PostHog's public capture
+API.  It never reads or sends trace events, prompts, command arguments, file
+paths, repository metadata, or session identifiers.
+
+The PostHog project token is intentionally a public, write-only ingestion
+token.  Set ``DEFAULT_POSTHOG_PROJECT_TOKEN`` before publishing a release, or
+use ``AGENT_STRACE_TELEMETRY_TOKEN`` while developing and testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TextIO
+from urllib import request
+
+from . import __version__
+
+
+# PostHog project tokens are public ingestion tokens, not personal API keys.
+# Replace this value with the project token from Project settings before a
+# release.  The environment override is useful for local verification.
+DEFAULT_POSTHOG_PROJECT_TOKEN = ""
+DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
+
+TELEMETRY_SCHEMA_VERSION = 1
+
+CLI_COMMAND_COMPLETED = "agent_strace_cli_command_completed"
+SESSION_COMPLETED = "agent_strace_session_completed"
+TELEMETRY_ENABLED = "agent_strace_telemetry_enabled"
+
+_CONFIG_ENV = "AGENT_STRACE_TELEMETRY_CONFIG"
+_ENABLED_ENV = "AGENT_STRACE_TELEMETRY"
+_TOKEN_ENV = "AGENT_STRACE_TELEMETRY_TOKEN"
+_HOST_ENV = "AGENT_STRACE_TELEMETRY_HOST"
+_TIMEOUT_ENV = "AGENT_STRACE_TELEMETRY_TIMEOUT"
+
+_TRUE = {"1", "true", "yes", "on", "enabled"}
+_FALSE = {"0", "false", "no", "off", "disabled"}
+_SAFE_TEXT = re.compile(r"^[A-Za-z0-9_.:/-]{1,80}$")
+
+# Only these properties can leave the process.  Free-form command arguments,
+# exception messages, paths, trace data, and session IDs are not accepted.
+_EVENT_FIELDS: dict[str, dict[str, type]] = {
+    CLI_COMMAND_COMPLETED: {
+        "command": str,
+        "subcommand": str,
+        "success": bool,
+        "exit_code": int,
+        "duration_ms": int,
+        "error_type": str,
+        "integration": str,
+        "export_format": str,
+        "backend": str,
+    },
+    SESSION_COMPLETED: {
+        "provider": str,
+        "capture_method": str,
+        "success": bool,
+        "duration_ms": int,
+    },
+    TELEMETRY_ENABLED: {
+        "source": str,
+    },
+}
+
+
+def _config_path() -> Path:
+    override = os.environ.get(_CONFIG_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".agent-strace" / "telemetry.json"
+
+
+def _read_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def _write_config(data: dict[str, Any]) -> bool:
+    path = _config_path()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        tmp.replace(path)
+        return True
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+
+
+def _parse_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalised = value.strip().lower()
+    if normalised in _TRUE:
+        return True
+    if normalised in _FALSE:
+        return False
+    return None
+
+
+def _in_ci() -> bool:
+    return any(
+        os.environ.get(name)
+        for name in (
+            "CI",
+            "GITHUB_ACTIONS",
+            "GITLAB_CI",
+            "BUILDKITE",
+            "JENKINS_URL",
+            "TF_BUILD",
+        )
+    )
+
+
+def consent_state() -> str:
+    """Return the persisted consent state: enabled, disabled, or unset."""
+    enabled = _read_config().get("enabled")
+    if enabled is True:
+        return "enabled"
+    if enabled is False:
+        return "disabled"
+    return "unset"
+
+
+def telemetry_enabled() -> bool:
+    """Return whether product telemetry is enabled for this process."""
+    if _parse_bool(os.environ.get("DO_NOT_TRACK")) is True:
+        return False
+
+    override = _parse_bool(os.environ.get(_ENABLED_ENV))
+    if override is not None:
+        return override
+
+    # Avoid ephemeral CI/test identifiers and accidental events from the test
+    # suite.  CI can opt in explicitly with AGENT_STRACE_TELEMETRY=1.
+    if _in_ci() or os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+
+    return consent_state() == "enabled"
+
+
+def set_telemetry_enabled(enabled: bool) -> bool:
+    """Persist the user's telemetry preference.
+
+    Disabling telemetry deletes the anonymous installation identifier.  A
+    later opt-in therefore starts with a new identity.
+    """
+    current = _read_config()
+    data: dict[str, Any] = {
+        "enabled": bool(enabled),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if enabled:
+        existing_id = current.get("anonymous_id", "")
+        data["anonymous_id"] = (
+            existing_id if _valid_anonymous_id(existing_id) else uuid.uuid4().hex
+        )
+    return _write_config(data)
+
+
+def _valid_anonymous_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{32}", value))
+
+
+def _anonymous_id() -> str:
+    data = _read_config()
+    value = data.get("anonymous_id", "")
+    if _valid_anonymous_id(value):
+        return value
+    if not telemetry_enabled():
+        return ""
+    value = uuid.uuid4().hex
+    data["anonymous_id"] = value
+    data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return value if _write_config(data) else ""
+
+
+def _project_token() -> str:
+    return os.environ.get(_TOKEN_ENV, DEFAULT_POSTHOG_PROJECT_TOKEN).strip()
+
+
+def _posthog_host() -> str:
+    return os.environ.get(_HOST_ENV, DEFAULT_POSTHOG_HOST).strip().rstrip("/")
+
+
+def telemetry_configured() -> bool:
+    """Return whether a PostHog project token is available."""
+    token = _project_token()
+    return bool(token and "REPLACE" not in token.upper())
+
+
+def _timeout() -> float:
+    try:
+        value = float(os.environ.get(_TIMEOUT_ENV, "0.5"))
+        return max(0.05, min(value, 2.0))
+    except ValueError:
+        return 0.5
+
+
+def _safe_value(value: Any, expected: type) -> Any | None:
+    if expected is bool:
+        return value if isinstance(value, bool) else None
+    if expected is int:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return max(-1, min(int(value), 2_678_400_000))  # up to 31 days in ms
+    if expected is str:
+        if not isinstance(value, str):
+            return None
+        value = value.strip()
+        return value if _SAFE_TEXT.fullmatch(value) else None
+    return None
+
+
+def _sanitise_properties(event: str, properties: dict[str, Any]) -> dict[str, Any]:
+    allowed = _EVENT_FIELDS.get(event, {})
+    clean: dict[str, Any] = {}
+    for name, expected in allowed.items():
+        if name not in properties:
+            continue
+        value = _safe_value(properties[name], expected)
+        if value is not None:
+            clean[name] = value
+    return clean
+
+
+def build_payload(
+    event: str,
+    properties: dict[str, Any],
+    anonymous_id: str,
+) -> dict[str, Any] | None:
+    """Build a PostHog capture payload from an allow-listed event."""
+    if event not in _EVENT_FIELDS or not _valid_anonymous_id(anonymous_id):
+        return None
+
+    clean = _sanitise_properties(event, properties)
+    clean.update({
+        "$process_person_profile": False,
+        "$geoip_disable": True,
+        "$lib": "agent-strace",
+        "$lib_version": __version__,
+        "telemetry_schema_version": TELEMETRY_SCHEMA_VERSION,
+        "agent_strace_version": __version__,
+        "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "os": platform.system().lower() or "unknown",
+        "ci": _in_ci(),
+    })
+    return {
+        "api_key": _project_token(),
+        "event": event,
+        "distinct_id": anonymous_id,
+        "properties": clean,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "uuid": str(uuid.uuid4()),
+    }
+
+
+def capture(event: str, properties: dict[str, Any] | None = None) -> bool:
+    """Send one product event, returning False silently on any failure.
+
+    Telemetry must never change command output, exit status, or control flow.
+    """
+    try:
+        if not telemetry_enabled() or not telemetry_configured():
+            return False
+        anonymous_id = _anonymous_id()
+        payload = build_payload(event, properties or {}, anonymous_id)
+        if payload is None:
+            return False
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        req = request.Request(
+            _posthog_host() + "/i/v0/e/",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": f"agent-strace/{__version__}",
+            },
+            method="POST",
+        )
+        with request.urlopen(req, timeout=_timeout()) as response:
+            return 200 <= getattr(response, "status", 200) < 300
+    except Exception:
+        return False
+
+
+def maybe_prompt_for_consent(
+    input_stream: TextIO | None = None,
+    output_stream: TextIO | None = None,
+) -> bool:
+    """Prompt once on an interactive CLI, returning True if a choice was made."""
+    input_stream = input_stream or sys.stdin
+    output_stream = output_stream or sys.stderr
+    if (
+        consent_state() != "unset"
+        or os.environ.get(_ENABLED_ENV) is not None
+        or _parse_bool(os.environ.get("DO_NOT_TRACK")) is True
+        or _in_ci()
+        or os.environ.get("PYTEST_CURRENT_TEST")
+        or not telemetry_configured()
+    ):
+        return False
+    try:
+        if not input_stream.isatty() or not output_stream.isatty():
+            return False
+        output_stream.write(
+            "Help improve agent-strace by sending anonymous CLI usage?\n"
+            "No prompts, arguments, paths, repository data, or trace contents are sent. "
+            "[y/N] "
+        )
+        output_stream.flush()
+        answer = input_stream.readline().strip().lower()
+        enabled = answer in {"y", "yes"}
+        set_telemetry_enabled(enabled)
+        if enabled:
+            capture(TELEMETRY_ENABLED, {"source": "first_run_prompt"})
+            output_stream.write("Anonymous telemetry enabled. Disable with: agent-strace telemetry disable\n")
+        else:
+            output_stream.write("Anonymous telemetry disabled. Enable with: agent-strace telemetry enable\n")
+        return True
+    except (OSError, EOFError):
+        return False
+
+
+def cmd_telemetry(args: argparse.Namespace) -> int:
+    """Manage anonymous product telemetry consent."""
+    action = getattr(args, "telemetry_command", None) or "status"
+    if action == "enable":
+        if not set_telemetry_enabled(True):
+            sys.stderr.write(f"Could not write telemetry preference to {_config_path()}\n")
+            return 1
+        sys.stdout.write("Anonymous product telemetry enabled.\n")
+        if telemetry_configured():
+            capture(TELEMETRY_ENABLED, {"source": "cli"})
+        else:
+            sys.stdout.write(
+                "PostHog is not configured in this build; no events will be sent.\n"
+            )
+        return 0
+
+    if action == "disable":
+        if not set_telemetry_enabled(False):
+            sys.stderr.write(f"Could not write telemetry preference to {_config_path()}\n")
+            return 1
+        sys.stdout.write("Anonymous product telemetry disabled; the local anonymous ID was deleted.\n")
+        return 0
+
+    state = consent_state()
+    effective = "enabled" if telemetry_enabled() else "disabled"
+    source = "stored preference"
+    if _parse_bool(os.environ.get("DO_NOT_TRACK")) is True:
+        source = "DO_NOT_TRACK"
+    elif _parse_bool(os.environ.get(_ENABLED_ENV)) is not None:
+        source = _ENABLED_ENV
+    elif state == "unset":
+        source = "no consent recorded"
+    elif _in_ci():
+        source = "CI default"
+
+    sys.stdout.write(
+        f"Anonymous product telemetry: {effective} ({source})\n"
+        f"Stored consent: {state}\n"
+        f"PostHog destination: "
+        f"{_posthog_host() if telemetry_configured() else 'not configured'}\n"
+        "Collected: command/subcommand, success, duration, integration/export format, "
+        "agent-strace/Python version, OS, and CI flag.\n"
+        "Never collected: prompts, responses, arguments, paths, repository data, "
+        "trace contents, session IDs, or exception messages.\n"
+    )
+    return 0
+
+
+def monotonic_ms_since(started_at: float) -> int:
+    """Return a non-negative elapsed duration in milliseconds."""
+    return max(0, int((time.monotonic() - started_at) * 1000))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,273 @@
+"""Tests for privacy-preserving product telemetry."""
+
+import argparse
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace import telemetry
+from agent_trace.cli import (
+    _run_with_product_telemetry,
+    _telemetry_command_properties,
+    build_parser,
+)
+from agent_trace.hooks import handle_session_end, handle_session_start
+
+
+class _Response:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _TTY(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class TelemetryTestCase(unittest.TestCase):
+    _ENV_NAMES = (
+        "AGENT_STRACE_TELEMETRY_CONFIG",
+        "AGENT_STRACE_TELEMETRY",
+        "AGENT_STRACE_TELEMETRY_TOKEN",
+        "AGENT_STRACE_TELEMETRY_HOST",
+        "AGENT_STRACE_TELEMETRY_TIMEOUT",
+        "DO_NOT_TRACK",
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "BUILDKITE",
+        "JENKINS_URL",
+        "TF_BUILD",
+        "PYTEST_CURRENT_TEST",
+        "AGENT_TRACE_DIR",
+        "AGENT_TRACE_CLAUDE_SESSION_ID",
+    )
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._old_env = {name: os.environ.get(name) for name in self._ENV_NAMES}
+        for name in self._ENV_NAMES:
+            os.environ.pop(name, None)
+        self.config_path = Path(self.tmp.name) / "telemetry.json"
+        os.environ["AGENT_STRACE_TELEMETRY_CONFIG"] = str(self.config_path)
+
+    def tearDown(self):
+        for name in self._ENV_NAMES:
+            os.environ.pop(name, None)
+        for name, value in self._old_env.items():
+            if value is not None:
+                os.environ[name] = value
+        self.tmp.cleanup()
+
+
+class TestTelemetryConsent(TelemetryTestCase):
+    def test_default_is_disabled_without_creating_an_identifier(self):
+        self.assertEqual(telemetry.consent_state(), "unset")
+        self.assertFalse(telemetry.telemetry_enabled())
+        self.assertFalse(self.config_path.exists())
+
+    def test_enable_and_disable_manage_anonymous_identifier(self):
+        self.assertTrue(telemetry.set_telemetry_enabled(True))
+        enabled = json.loads(self.config_path.read_text())
+        self.assertTrue(enabled["enabled"])
+        self.assertRegex(enabled["anonymous_id"], r"^[0-9a-f]{32}$")
+        self.assertTrue(telemetry.telemetry_enabled())
+
+        self.assertTrue(telemetry.set_telemetry_enabled(False))
+        disabled = json.loads(self.config_path.read_text())
+        self.assertFalse(disabled["enabled"])
+        self.assertNotIn("anonymous_id", disabled)
+        self.assertFalse(telemetry.telemetry_enabled())
+
+    def test_do_not_track_overrides_stored_consent(self):
+        telemetry.set_telemetry_enabled(True)
+        os.environ["DO_NOT_TRACK"] = "1"
+        self.assertFalse(telemetry.telemetry_enabled())
+
+    def test_environment_can_explicitly_enable_ci(self):
+        os.environ["CI"] = "true"
+        self.assertFalse(telemetry.telemetry_enabled())
+        os.environ["AGENT_STRACE_TELEMETRY"] = "1"
+        self.assertTrue(telemetry.telemetry_enabled())
+
+    def test_environment_override_does_not_persist_consent(self):
+        os.environ["AGENT_STRACE_TELEMETRY"] = "1"
+        os.environ["AGENT_STRACE_TELEMETRY_TOKEN"] = "phc_public_project_token"
+        with patch.object(telemetry.request, "urlopen", return_value=_Response()):
+            telemetry.capture(
+                telemetry.CLI_COMMAND_COMPLETED,
+                {"command": "list", "success": True},
+            )
+        self.assertEqual(telemetry.consent_state(), "unset")
+
+    def test_interactive_prompt_records_explicit_opt_in(self):
+        os.environ["AGENT_STRACE_TELEMETRY_TOKEN"] = "phc_public_project_token"
+        input_stream = _TTY("yes\n")
+        output_stream = _TTY()
+        with patch.object(telemetry, "capture", return_value=True) as capture:
+            prompted = telemetry.maybe_prompt_for_consent(input_stream, output_stream)
+
+        self.assertTrue(prompted)
+        self.assertEqual(telemetry.consent_state(), "enabled")
+        self.assertIn("No prompts, arguments, paths", output_stream.getvalue())
+        capture.assert_called_once_with(
+            telemetry.TELEMETRY_ENABLED,
+            {"source": "first_run_prompt"},
+        )
+
+
+class TestTelemetryPayload(TelemetryTestCase):
+    def setUp(self):
+        super().setUp()
+        os.environ["AGENT_STRACE_TELEMETRY_TOKEN"] = "phc_public_project_token"
+
+    def test_payload_drops_unknown_and_free_form_properties(self):
+        payload = telemetry.build_payload(
+            telemetry.CLI_COMMAND_COMPLETED,
+            {
+                "command": "replay",
+                "success": True,
+                "duration_ms": 25,
+                "error_type": "ValueError",
+                "prompt": "secret prompt",
+                "path": "/private/repository",
+                "arguments": "--token secret",
+            },
+            "a" * 32,
+        )
+
+        self.assertIsNotNone(payload)
+        properties = payload["properties"]
+        self.assertEqual(properties["command"], "replay")
+        self.assertTrue(properties["success"])
+        self.assertNotIn("prompt", properties)
+        self.assertNotIn("path", properties)
+        self.assertNotIn("arguments", properties)
+        self.assertFalse(properties["$process_person_profile"])
+        self.assertTrue(properties["$geoip_disable"])
+
+    def test_payload_rejects_unknown_events_and_unsafe_text(self):
+        self.assertIsNone(telemetry.build_payload("unknown", {}, "a" * 32))
+        payload = telemetry.build_payload(
+            telemetry.CLI_COMMAND_COMPLETED,
+            {"command": "replay /private/path", "success": True},
+            "a" * 32,
+        )
+        self.assertNotIn("command", payload["properties"])
+
+    def test_capture_posts_to_posthog_without_raising(self):
+        os.environ["AGENT_STRACE_TELEMETRY"] = "1"
+        os.environ["AGENT_STRACE_TELEMETRY_HOST"] = "https://eu.i.posthog.com"
+        with patch.object(telemetry.request, "urlopen", return_value=_Response()) as urlopen:
+            sent = telemetry.capture(
+                telemetry.CLI_COMMAND_COMPLETED,
+                {"command": "list", "success": True, "duration_ms": 3},
+            )
+
+        self.assertTrue(sent)
+        request_arg = urlopen.call_args.args[0]
+        self.assertEqual(request_arg.full_url, "https://eu.i.posthog.com/i/v0/e/")
+        body = json.loads(request_arg.data)
+        self.assertEqual(body["event"], telemetry.CLI_COMMAND_COMPLETED)
+        self.assertEqual(body["properties"]["command"], "list")
+
+    def test_network_failure_is_silent(self):
+        os.environ["AGENT_STRACE_TELEMETRY"] = "1"
+        with patch.object(telemetry.request, "urlopen", side_effect=OSError("offline")):
+            self.assertFalse(
+                telemetry.capture(
+                    telemetry.CLI_COMMAND_COMPLETED,
+                    {"command": "list", "success": True},
+                )
+            )
+
+
+class TestCliTelemetry(TelemetryTestCase):
+    def test_parser_registers_telemetry_commands(self):
+        parser = build_parser()
+        for action in ("status", "enable", "disable"):
+            args = parser.parse_args(["telemetry", action])
+            self.assertEqual(args.command, "telemetry")
+            self.assertEqual(args.telemetry_command, action)
+
+    def test_command_properties_never_include_user_arguments(self):
+        args = argparse.Namespace(
+            command="export",
+            format="otlp-genai",
+            backend="otlp",
+            session_id="private-session-id",
+            endpoint="https://secret.example",
+        )
+        properties = _telemetry_command_properties(args)
+        self.assertEqual(properties["export_format"], "otlp-genai")
+        self.assertEqual(properties["backend"], "otlp")
+        self.assertNotIn("session_id", properties)
+        self.assertNotIn("endpoint", properties)
+
+    def test_wrapper_captures_success_and_preserves_return_code(self):
+        args = argparse.Namespace(command="list")
+        with patch("agent_trace.cli._product_telemetry.capture") as capture:
+            result = _run_with_product_telemetry(args, lambda _args: 2)
+
+        self.assertEqual(result, 2)
+        properties = capture.call_args.args[1]
+        self.assertEqual(properties["command"], "list")
+        self.assertFalse(properties["success"])
+        self.assertEqual(properties["exit_code"], 2)
+
+    def test_wrapper_reports_exception_type_not_message(self):
+        args = argparse.Namespace(command="list")
+
+        def fail(_args):
+            raise RuntimeError("secret path and token")
+
+        with patch("agent_trace.cli._product_telemetry.capture") as capture:
+            with self.assertRaises(RuntimeError):
+                _run_with_product_telemetry(args, fail)
+
+        properties = capture.call_args.args[1]
+        self.assertEqual(properties["error_type"], "RuntimeError")
+        self.assertNotIn("secret", json.dumps(properties))
+
+    def test_status_explains_collection_boundaries(self):
+        args = argparse.Namespace(telemetry_command="status")
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            self.assertEqual(telemetry.cmd_telemetry(args), 0)
+        self.assertIn("Never collected: prompts", output.getvalue())
+
+
+class TestSessionTelemetry(TelemetryTestCase):
+    def test_session_end_emits_one_sanitised_lifecycle_event(self):
+        trace_dir = Path(self.tmp.name) / "traces"
+        os.environ["AGENT_TRACE_DIR"] = str(trace_dir)
+        with patch("agent_trace.hooks._product_telemetry.capture") as capture:
+            handle_session_start(
+                {"session_id": "telemetry-session-123", "source": "startup"},
+                provider="claude",
+            )
+            handle_session_end(
+                {"session_id": "telemetry-session-123", "cwd": "/private/repo"},
+                provider="claude",
+            )
+
+        capture.assert_called_once()
+        event, properties = capture.call_args.args
+        self.assertEqual(event, telemetry.SESSION_COMPLETED)
+        self.assertEqual(properties["provider"], "claude")
+        self.assertEqual(properties["capture_method"], "hooks")
+        self.assertNotIn("session_id", properties)
+        self.assertNotIn("cwd", properties)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add stdlib-only, opt-in PostHog telemetry for anonymous CLI command outcomes and completed hook sessions
- add explicit consent controls, `DO_NOT_TRACK`/CI handling, a strict property allowlist, and silent best-effort delivery
- document the exact event schema, dashboard suggestions, and architectural decision
- bump the package version to `0.81.0`

No prompts, responses, command arguments, paths, repository data, trace contents, session IDs, endpoints, exception messages, or stack traces are collected.

## PostHog configuration

The managed PostHog US project and its public, write-only project token are configured in `src/agent_trace/telemetry.py`. No database or deployed telemetry service is required. Events remain opt-in for users.

## Testing

- `PYTHONPATH=src python3 -m pytest tests/ -v` — 1,620 passed
- `PYTHONPATH=src python3 -m pytest tests/test_telemetry.py -v` — 16 passed after project configuration
- `python3 -m compileall -q src tests/test_telemetry.py`
- `git diff --check`