### PR TITLE
Enable anonymous product telemetry by default

### DIFF
--- a/ADRs/0013-opt-in-product-telemetry.md
+++ b/ADRs/0013-opt-in-product-telemetry.md
@@ -1,6 +1,6 @@
 # ADR-0013: Opt-in Anonymous Product Telemetry
 
-**Status:** Accepted
+**Status:** Superseded by ADR-0014
 **Date:** 2026-08
 **Deciders:** Siddhant Khare
 

--- a/ADRs/0014-default-on-product-telemetry.md
+++ b/ADRs/0014-default-on-product-telemetry.md
@@ -1,0 +1,38 @@
+# ADR-0014: Default-on Anonymous Product Telemetry
+
+**Status:** Accepted
+**Date:** 2026-08
+**Deciders:** Siddhant Khare
+
+## Context
+
+ADR-0013 introduced privacy-preserving product telemetry as explicit opt-in.
+Opt-in collection cannot reliably show how the broader CLI population adopts
+commands and integrations. The strict event allowlist and separation from trace
+storage make default collection possible without uploading agent content.
+
+## Decision
+
+Supersede ADR-0013's consent default while retaining its data boundaries:
+
+- Telemetry is enabled when no preference has been stored. The first
+  interactive CLI invocation displays a non-blocking, one-time disclosure.
+- `agent-strace telemetry disable` stores an opt-out and deletes the anonymous
+  installation ID. `DO_NOT_TRACK=1` and `AGENT_STRACE_TELEMETRY=0` also disable
+  collection, while `agent-strace telemetry enable` re-enables it explicitly.
+- CI and test processes remain disabled by default. CI can opt in with
+  `AGENT_STRACE_TELEMETRY=1`.
+- The fixed event allowlist, excluded sensitive fields, disabled PostHog person
+  profiles and GeoIP enrichment, silent failures, and direct HTTPS/JSON delivery
+  from ADR-0013 remain unchanged.
+
+## Consequences
+
+- Maintainers receive more representative aggregate CLI adoption and
+  reliability signals.
+- Users can opt out before any event by running the disable command or setting a
+  supported environment variable.
+- Documentation and the first interactive disclosure must make the default and
+  controls prominent.
+- Direct PostHog requests remain observable to PostHog infrastructure even with
+  GeoIP enrichment disabled.

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -39,7 +39,8 @@ What are the trade-offs, limitations, and follow-on effects?
 | [0010](0010-session-explain-phase-detection.md) | Session Explanation via Prompt-Boundary Phase Detection | Accepted |
 | [0011](0011-otlp-genai-semantic-conventions.md) | OTLP GenAI Semantic Conventions Export Format | Accepted |
 | [0012](0012-server-side-event-collector.md) | Server-Side Event Collector | Accepted |
-| [0013](0013-opt-in-product-telemetry.md) | Opt-in Anonymous Product Telemetry | Accepted |
+| [0013](0013-opt-in-product-telemetry.md) | Opt-in Anonymous Product Telemetry | Superseded by ADR-0014 |
+| [0014](0014-default-on-product-telemetry.md) | Default-on Anonymous Product Telemetry | Accepted |
 
 ## Adding a new ADR
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace approval list`](docs/commands.md#approval) | Human-in-the-loop approval queue |
 | [`agent-strace rbac assign`](docs/commands.md#rbac) | Org and workspace-scoped role assignments |
 | [`agent-strace auth login`](docs/commands.md#auth) | SSO/OIDC login to a hosted collector |
-| [`agent-strace telemetry status`](docs/telemetry.md) | Inspect, enable, or disable anonymous CLI usage telemetry |
+| [`agent-strace telemetry status`](docs/telemetry.md) | Inspect, disable, or re-enable anonymous CLI telemetry, which is on by default |
 | [`agent-strace apply`](docs/commands.md#apply) | Apply `.agent-strace.yaml` config to local store or collector |
 | [`agent-strace workspace new`](docs/commands.md#workspace) | Create an isolated workspace |
 | [`agent-strace compliance export`](docs/commands.md#compliance) | Export compliance reports (EU AI Act, SOC 2, HIPAA) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,11 +38,12 @@ Print or install hooks config for supported agent CLIs. `--cli claude` prints Cl
 ```
 agent-strace telemetry [status|enable|disable]
 ```
-Show or change consent for anonymous product telemetry. Telemetry is disabled
-until the user opts in. `disable` also deletes the local anonymous installation
-ID. `DO_NOT_TRACK=1` or `AGENT_STRACE_TELEMETRY=0` always disables collection;
-`AGENT_STRACE_TELEMETRY=1` explicitly enables it, including in CI. See
-[telemetry.md](telemetry.md) for the exact event schema and maintainer setup.
+Show or change the anonymous product telemetry preference. Telemetry is enabled
+by default outside CI. `disable` persists an opt-out and deletes the local
+anonymous installation ID. `DO_NOT_TRACK=1` or `AGENT_STRACE_TELEMETRY=0`
+always disables collection; `AGENT_STRACE_TELEMETRY=1` explicitly enables it,
+including in CI. See [telemetry.md](telemetry.md) for the exact event schema and
+maintainer setup.
 
 ### `import`
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,10 +2,12 @@
 
 agent-strace provides two complementary mechanisms for keeping sensitive data out of traces: secret redaction (at capture time) and PII anonymization (at export time). A policy file lets you audit and restrict what the agent is allowed to do.
 
-Anonymous product telemetry is a separate, opt-in data path and never reads
-trace contents. Its fixed schema excludes prompts, responses, command arguments,
-paths, repository data, session IDs, endpoints, and exception messages. See
-[Product telemetry](telemetry.md) for the complete schema and controls.
+Anonymous product telemetry is a separate, default-on data path that can be
+disabled with `agent-strace telemetry disable`, `DO_NOT_TRACK=1`, or
+`AGENT_STRACE_TELEMETRY=0`. It never reads trace contents. Its fixed schema
+excludes prompts, responses, command arguments, paths, repository data, session
+IDs, endpoints, and exception messages. See [Product telemetry](telemetry.md)
+for the complete schema and controls.
 
 ---
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -4,9 +4,10 @@ agent-strace can send anonymous product usage events to a PostHog project owned
 by the project maintainer. This is separate from agent tracing: no `.agent-traces/`
 files or event data are read by the telemetry client.
 
-Telemetry is disabled until the user explicitly opts in. On a configured build,
-the first interactive CLI invocation asks once, with a default of **No**.
-Non-interactive use and CI do not prompt.
+Telemetry is enabled by default on a configured build. The first interactive
+CLI invocation shows a one-time disclosure with the disable command; it does
+not block for input. CI remains disabled by default to avoid ephemeral
+installation identifiers and test noise.
 
 ## User controls
 
@@ -21,9 +22,12 @@ AGENT_STRACE_TELEMETRY=0 agent-strace list
 AGENT_STRACE_TELEMETRY=1 agent-strace list
 ```
 
-Consent and a random installation ID are stored in
-`~/.agent-strace/telemetry.json`. Disabling telemetry deletes the identifier.
-CI is disabled by default; `AGENT_STRACE_TELEMETRY=1` is required to enable it.
+An unset preference means telemetry is enabled. A random installation ID is
+created on the first event and stored in `~/.agent-strace/telemetry.json`.
+`agent-strace telemetry disable` persists the opt-out and deletes the
+identifier. `DO_NOT_TRACK=1` and `AGENT_STRACE_TELEMETRY=0` disable telemetry
+without changing the stored preference. CI is disabled by default;
+`AGENT_STRACE_TELEMETRY=1` is required to enable it there.
 
 ## Collected fields
 
@@ -33,7 +37,7 @@ There are three events:
 |---|---|
 | `agent_strace_cli_command_completed` | command, subcommand, success, exit code, duration, error type, integration, export format/backend |
 | `agent_strace_session_completed` | provider, capture method, success, duration |
-| `agent_strace_telemetry_enabled` | consent source |
+| `agent_strace_telemetry_enabled` | explicit enablement source |
 
 Every event also includes the anonymous installation ID, telemetry schema
 version, agent-strace version, Python major/minor version, OS family, and CI
@@ -67,15 +71,15 @@ No database or deployed service is required. Use a managed PostHog project:
    export AGENT_STRACE_TELEMETRY_HOST="https://us.i.posthog.com"
    export AGENT_STRACE_TELEMETRY_CONFIG="$(mktemp)"
 
-   agent-strace telemetry enable
    agent-strace list
    agent-strace telemetry status
+   agent-strace telemetry disable
    ```
 
 5. In PostHog's live events view, confirm that
-   `agent_strace_telemetry_enabled` and
-   `agent_strace_cli_command_completed` arrived and contain only the documented
-   properties.
+   `agent_strace_cli_command_completed` arrived and contains only the documented
+   properties. Running `agent-strace telemetry enable` explicitly also sends
+   `agent_strace_telemetry_enabled`.
 6. Commit the public project token and publish the release. End users do not set
    a token; it is part of the distributed package.
 

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.81.0"
+__version__ = "0.82.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -1058,7 +1058,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     telemetry_sub = p_telemetry.add_subparsers(dest="telemetry_command")
     telemetry_sub.add_parser("status", help="show telemetry status and collected fields")
-    telemetry_sub.add_parser("enable", help="opt in to anonymous product telemetry")
+    telemetry_sub.add_parser("enable", help="explicitly enable anonymous product telemetry")
     telemetry_sub.add_parser("disable", help="opt out and delete the anonymous installation ID")
 
     # import (Claude Code JSONL session logs)
@@ -1955,7 +1955,7 @@ def main() -> None:
     if args.command == "telemetry":
         sys.exit(_product_telemetry.cmd_telemetry(args))
 
-    _product_telemetry.maybe_prompt_for_consent()
+    _product_telemetry.maybe_show_telemetry_notice()
 
     handlers = {
         "setup": cmd_setup,

--- a/src/agent_trace/telemetry.py
+++ b/src/agent_trace/telemetry.py
@@ -1,9 +1,9 @@
 """Privacy-preserving product telemetry for the agent-strace CLI.
 
-Telemetry is disabled until the user explicitly opts in.  When enabled, the
-client sends a small allow-listed event directly to PostHog's public capture
-API.  It never reads or sends trace events, prompts, command arguments, file
-paths, repository metadata, or session identifiers.
+Telemetry is enabled by default and can be disabled at any time.  The client
+sends a small allow-listed event directly to PostHog's public capture API.  It
+never reads or sends trace events, prompts, command arguments, file paths,
+repository metadata, or session identifiers.
 
 The PostHog project token is intentionally a public, write-only ingestion
 token.  Set ``DEFAULT_POSTHOG_PROJECT_TOKEN`` before publishing a release, or
@@ -142,7 +142,7 @@ def _in_ci() -> bool:
 
 
 def consent_state() -> str:
-    """Return the persisted consent state: enabled, disabled, or unset."""
+    """Return the persisted preference state: enabled, disabled, or unset."""
     enabled = _read_config().get("enabled")
     if enabled is True:
         return "enabled"
@@ -165,14 +165,16 @@ def telemetry_enabled() -> bool:
     if _in_ci() or os.environ.get("PYTEST_CURRENT_TEST"):
         return False
 
-    return consent_state() == "enabled"
+    # An unset preference uses the product default.  Only an explicit opt-out
+    # disables telemetry outside CI and test processes.
+    return consent_state() != "disabled"
 
 
 def set_telemetry_enabled(enabled: bool) -> bool:
     """Persist the user's telemetry preference.
 
     Disabling telemetry deletes the anonymous installation identifier.  A
-    later opt-in therefore starts with a new identity.
+    later re-enable therefore starts with a new identity.
     """
     current = _read_config()
     data: dict[str, Any] = {
@@ -312,15 +314,15 @@ def capture(event: str, properties: dict[str, Any] | None = None) -> bool:
         return False
 
 
-def maybe_prompt_for_consent(
-    input_stream: TextIO | None = None,
+def maybe_show_telemetry_notice(
     output_stream: TextIO | None = None,
 ) -> bool:
-    """Prompt once on an interactive CLI, returning True if a choice was made."""
-    input_stream = input_stream or sys.stdin
+    """Show the default-on disclosure once on an interactive CLI."""
     output_stream = output_stream or sys.stderr
+    data = _read_config()
     if (
         consent_state() != "unset"
+        or data.get("notice_shown") is True
         or os.environ.get(_ENABLED_ENV) is not None
         or _parse_bool(os.environ.get("DO_NOT_TRACK")) is True
         or _in_ci()
@@ -329,29 +331,24 @@ def maybe_prompt_for_consent(
     ):
         return False
     try:
-        if not input_stream.isatty() or not output_stream.isatty():
+        if not output_stream.isatty():
             return False
         output_stream.write(
-            "Help improve agent-strace by sending anonymous CLI usage?\n"
-            "No prompts, arguments, paths, repository data, or trace contents are sent. "
-            "[y/N] "
+            "Anonymous product telemetry is enabled by default. "
+            "No prompts, arguments, paths, repository data, or trace contents are sent.\n"
+            "Disable at any time with: agent-strace telemetry disable\n"
         )
         output_stream.flush()
-        answer = input_stream.readline().strip().lower()
-        enabled = answer in {"y", "yes"}
-        set_telemetry_enabled(enabled)
-        if enabled:
-            capture(TELEMETRY_ENABLED, {"source": "first_run_prompt"})
-            output_stream.write("Anonymous telemetry enabled. Disable with: agent-strace telemetry disable\n")
-        else:
-            output_stream.write("Anonymous telemetry disabled. Enable with: agent-strace telemetry enable\n")
+        data["notice_shown"] = True
+        data["updated_at"] = datetime.now(timezone.utc).isoformat()
+        _write_config(data)
         return True
-    except (OSError, EOFError):
+    except OSError:
         return False
 
 
 def cmd_telemetry(args: argparse.Namespace) -> int:
-    """Manage anonymous product telemetry consent."""
+    """Manage the anonymous product telemetry preference."""
     action = getattr(args, "telemetry_command", None) or "status"
     if action == "enable":
         if not set_telemetry_enabled(True):
@@ -380,14 +377,14 @@ def cmd_telemetry(args: argparse.Namespace) -> int:
         source = "DO_NOT_TRACK"
     elif _parse_bool(os.environ.get(_ENABLED_ENV)) is not None:
         source = _ENABLED_ENV
-    elif state == "unset":
-        source = "no consent recorded"
     elif _in_ci():
         source = "CI default"
+    elif state == "unset":
+        source = "enabled by default"
 
     sys.stdout.write(
         f"Anonymous product telemetry: {effective} ({source})\n"
-        f"Stored consent: {state}\n"
+        f"Stored preference: {state}\n"
         f"PostHog destination: "
         f"{_posthog_host() if telemetry_configured() else 'not configured'}\n"
         "Collected: command/subcommand, success, duration, integration/export format, "

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -69,10 +69,10 @@ class TelemetryTestCase(unittest.TestCase):
         self.tmp.cleanup()
 
 
-class TestTelemetryConsent(TelemetryTestCase):
-    def test_default_is_disabled_without_creating_an_identifier(self):
+class TestTelemetryPreference(TelemetryTestCase):
+    def test_default_is_enabled_without_eagerly_creating_an_identifier(self):
         self.assertEqual(telemetry.consent_state(), "unset")
-        self.assertFalse(telemetry.telemetry_enabled())
+        self.assertTrue(telemetry.telemetry_enabled())
         self.assertFalse(self.config_path.exists())
 
     def test_enable_and_disable_manage_anonymous_identifier(self):
@@ -93,6 +93,22 @@ class TestTelemetryConsent(TelemetryTestCase):
         os.environ["DO_NOT_TRACK"] = "1"
         self.assertFalse(telemetry.telemetry_enabled())
 
+    def test_environment_can_disable_the_default(self):
+        os.environ["AGENT_STRACE_TELEMETRY"] = "0"
+        self.assertFalse(telemetry.telemetry_enabled())
+        self.assertEqual(telemetry.consent_state(), "unset")
+
+    def test_stored_opt_out_prevents_capture(self):
+        telemetry.set_telemetry_enabled(False)
+        with patch.object(telemetry.request, "urlopen") as urlopen:
+            self.assertFalse(
+                telemetry.capture(
+                    telemetry.CLI_COMMAND_COMPLETED,
+                    {"command": "list", "success": True},
+                )
+            )
+        urlopen.assert_not_called()
+
     def test_environment_can_explicitly_enable_ci(self):
         os.environ["CI"] = "true"
         self.assertFalse(telemetry.telemetry_enabled())
@@ -109,20 +125,21 @@ class TestTelemetryConsent(TelemetryTestCase):
             )
         self.assertEqual(telemetry.consent_state(), "unset")
 
-    def test_interactive_prompt_records_explicit_opt_in(self):
+    def test_interactive_notice_discloses_default_once_without_prompting(self):
         os.environ["AGENT_STRACE_TELEMETRY_TOKEN"] = "phc_public_project_token"
-        input_stream = _TTY("yes\n")
         output_stream = _TTY()
-        with patch.object(telemetry, "capture", return_value=True) as capture:
-            prompted = telemetry.maybe_prompt_for_consent(input_stream, output_stream)
+        shown = telemetry.maybe_show_telemetry_notice(output_stream)
 
-        self.assertTrue(prompted)
-        self.assertEqual(telemetry.consent_state(), "enabled")
+        self.assertTrue(shown)
+        self.assertEqual(telemetry.consent_state(), "unset")
+        self.assertTrue(telemetry.telemetry_enabled())
+        self.assertTrue(json.loads(self.config_path.read_text())["notice_shown"])
+        self.assertIn("enabled by default", output_stream.getvalue())
         self.assertIn("No prompts, arguments, paths", output_stream.getvalue())
-        capture.assert_called_once_with(
-            telemetry.TELEMETRY_ENABLED,
-            {"source": "first_run_prompt"},
-        )
+
+        second_output = _TTY()
+        self.assertFalse(telemetry.maybe_show_telemetry_notice(second_output))
+        self.assertEqual(second_output.getvalue(), "")
 
 
 class TestTelemetryPayload(TelemetryTestCase):
@@ -165,7 +182,6 @@ class TestTelemetryPayload(TelemetryTestCase):
         self.assertNotIn("command", payload["properties"])
 
     def test_capture_posts_to_posthog_without_raising(self):
-        os.environ["AGENT_STRACE_TELEMETRY"] = "1"
         os.environ["AGENT_STRACE_TELEMETRY_HOST"] = "https://eu.i.posthog.com"
         with patch.object(telemetry.request, "urlopen", return_value=_Response()) as urlopen:
             sent = telemetry.capture(
@@ -179,6 +195,11 @@ class TestTelemetryPayload(TelemetryTestCase):
         body = json.loads(request_arg.data)
         self.assertEqual(body["event"], telemetry.CLI_COMMAND_COMPLETED)
         self.assertEqual(body["properties"]["command"], "list")
+        self.assertRegex(body["distinct_id"], r"^[0-9a-f]{32}$")
+        self.assertRegex(
+            json.loads(self.config_path.read_text())["anonymous_id"],
+            r"^[0-9a-f]{32}$",
+        )
 
     def test_network_failure_is_silent(self):
         os.environ["AGENT_STRACE_TELEMETRY"] = "1"
@@ -243,6 +264,7 @@ class TestCliTelemetry(TelemetryTestCase):
         output = io.StringIO()
         with patch("sys.stdout", output):
             self.assertEqual(telemetry.cmd_telemetry(args), 0)
+        self.assertIn("enabled (enabled by default)", output.getvalue())
         self.assertIn("Never collected: prompts", output.getvalue())
 
 


### PR DESCRIPTION
## Summary

- enable anonymous product telemetry by default when no preference is stored
- replace the first-run consent prompt with a non-blocking, one-time disclosure
- retain persistent opt-out via `agent-strace telemetry disable`, plus `DO_NOT_TRACK=1` and `AGENT_STRACE_TELEMETRY=0`
- keep CI and test processes disabled by default to avoid ephemeral identifiers and noise
- update README, command/security/telemetry docs, and supersede ADR-0013 with ADR-0014
- bump the package version to `0.82.0`

The strict event allowlist is unchanged. Prompts, responses, arguments, paths, repository data, trace contents, session IDs, endpoints, exception messages, and stack traces are never collected. PostHog person profiles and GeoIP enrichment remain disabled.

## Testing

- `PYTHONPATH=src python3 -m pytest tests/test_telemetry.py -v` — 18 passed
- `PYTHONPATH=src python3 -m pytest tests/ -v` — 1,622 passed
- `python3 -m compileall -q src tests/test_telemetry.py`
- `git diff --check`