### PR TITLE
Add privacy-preserving VS Code extension telemetry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,25 @@ jobs:
         run: python -m unittest discover -s tests -v
         env:
           PYTHONPATH: src
+
+  vscode-extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vscode-extension
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile and test extension
+        run: npm test

--- a/ADRs/0015-extension-native-product-telemetry.md
+++ b/ADRs/0015-extension-native-product-telemetry.md
@@ -1,0 +1,42 @@
+# ADR-0015: Extension-native Product Telemetry
+
+**Status:** Accepted
+**Date:** 2026-08
+**Deciders:** Siddhant Khare
+
+## Context
+
+The Python CLI telemetry introduced in ADR-0013 and made default-on in ADR-0014
+cannot observe VS Code/Open VSX extension activation or feature usage. The
+extension reads trace storage directly and does not invoke the CLI, so relying
+on CLI events leaves the editor experience invisible.
+
+## Decision
+
+Add an extension-native telemetry client with the same privacy boundaries:
+
+- Send HTTPS/JSON directly to the maintainer-controlled PostHog project using
+  Node.js built-ins only; add no runtime package dependency.
+- Enable telemetry by default after a one-time, non-blocking disclosure. Provide
+  application-scoped enable/disable commands and the
+  `agentTrace.telemetry.enabled` setting.
+- Honor VS Code's editor-wide telemetry switch, `DO_NOT_TRACK=1`, and
+  `AGENT_STRACE_TELEMETRY=0` as opt-outs.
+- Store a separate random extension installation ID in VS Code global state and
+  delete it when extension telemetry is disabled.
+- Allow only extension activation, fixed command names, session lifecycle,
+  success, duration, and aggregate tool/error counts. Never accept workspace
+  identifiers, paths, repositories, command arguments, trace/session IDs,
+  prompts, responses, event contents, or exception messages.
+- Disable PostHog person profiles and GeoIP enrichment on every event. Keep
+  network delivery best-effort with a short timeout.
+
+## Consequences
+
+- Maintainers can measure extension adoption and feature usage across VS Code,
+  Cursor, Windsurf, VSCodium, and other Open VSX-compatible editors.
+- CLI and extension installation IDs and persisted preferences remain separate;
+  shared environment opt-outs disable both when inherited by the editor host.
+- Session completion telemetry reads only aggregate counters already maintained
+  by the extension; no trace payload fields enter the analytics schema.
+- Extension schema tests and compilation run in pull-request CI under Node 20.

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -41,6 +41,7 @@ What are the trade-offs, limitations, and follow-on effects?
 | [0012](0012-server-side-event-collector.md) | Server-Side Event Collector | Accepted |
 | [0013](0013-opt-in-product-telemetry.md) | Opt-in Anonymous Product Telemetry | Superseded by ADR-0014 |
 | [0014](0014-default-on-product-telemetry.md) | Default-on Anonymous Product Telemetry | Accepted |
+| [0015](0015-extension-native-product-telemetry.md) | Extension-native Product Telemetry | Accepted |
 
 ## Adding a new ADR
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![CI](https://github.com/Siddhant-K-code/agent-trace/actions/workflows/test.yml/badge.svg)](https://github.com/Siddhant-K-code/agent-trace/actions/workflows/test.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-agent--trace%20eval-blue?logo=github)](https://github.com/marketplace/actions/agent-trace-eval)
 [![Open VSX](https://img.shields.io/open-vsx/v/Siddhant-K-code/agent-strace)](https://open-vsx.org/extension/Siddhant-K-code/agent-strace)
-[![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-v0.2.1-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=Siddhant-K-code.agent-strace)
+[![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-v0.3.0-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=Siddhant-K-code.agent-strace)
 [![License](https://img.shields.io/github/license/Siddhant-K-code/agent-trace)](LICENSE)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/agent-strace?period=total&units=INTERNATIONAL_SYSTEM&left_color=ORANGE&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/agent-strace)
 
@@ -152,6 +152,10 @@ Full flag reference: [docs/commands.md](docs/commands.md)
 ## VS Code extension
 
 Install **agent-strace** from the [Extensions panel](https://open-vsx.org/extension/Siddhant-K-code/agent-strace) to see live session activity without leaving the editor.
+
+Anonymous extension usage telemetry is enabled by default and can be disabled
+from the Command Palette or `agentTrace.telemetry.enabled` setting. No prompts,
+trace contents, paths, session IDs, command arguments, or repository data are sent.
 
 | Feature | Description |
 |---|---|

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,12 +2,15 @@
 
 agent-strace provides two complementary mechanisms for keeping sensitive data out of traces: secret redaction (at capture time) and PII anonymization (at export time). A policy file lets you audit and restrict what the agent is allowed to do.
 
-Anonymous product telemetry is a separate, default-on data path that can be
-disabled with `agent-strace telemetry disable`, `DO_NOT_TRACK=1`, or
-`AGENT_STRACE_TELEMETRY=0`. It never reads trace contents. Its fixed schema
-excludes prompts, responses, command arguments, paths, repository data, session
-IDs, endpoints, and exception messages. See [Product telemetry](telemetry.md)
-for the complete schema and controls.
+Anonymous product telemetry is a separate, default-on data path. CLI telemetry
+can be disabled with `agent-strace telemetry disable`; extension telemetry can
+be disabled with the `agentTrace.telemetry.enabled` setting or the Command
+Palette. `DO_NOT_TRACK=1`, `AGENT_STRACE_TELEMETRY=0`, and the editor-wide
+telemetry switch also disable extension telemetry. Both clients use fixed
+schemas that exclude prompts, responses, command arguments, paths, repository
+data, session IDs, endpoints, and exception messages. The extension sends only
+session success, duration, and aggregate tool/error counts—not trace contents.
+See [Product telemetry](telemetry.md) for the complete schemas and controls.
 
 ---
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,13 +1,14 @@
 # Product telemetry
 
 agent-strace can send anonymous product usage events to a PostHog project owned
-by the project maintainer. This is separate from agent tracing: no `.agent-traces/`
-files or event data are read by the telemetry client.
+by the project maintainer. This is separate from agent tracing. The CLI client
+never reads `.agent-traces/`; the editor extension sends only session success,
+duration, and aggregate tool/error counts from the state it already maintains.
+Neither client sends trace contents.
 
-Telemetry is enabled by default on a configured build. The first interactive
-CLI invocation shows a one-time disclosure with the disable command; it does
-not block for input. CI remains disabled by default to avoid ephemeral
-installation identifiers and test noise.
+Telemetry is enabled by default on configured CLI and editor-extension builds.
+Each surface shows a one-time, non-blocking disclosure. CI remains disabled by
+default to avoid ephemeral installation identifiers and test noise.
 
 ## User controls
 
@@ -29,9 +30,21 @@ identifier. `DO_NOT_TRACK=1` and `AGENT_STRACE_TELEMETRY=0` disable telemetry
 without changing the stored preference. CI is disabled by default;
 `AGENT_STRACE_TELEMETRY=1` is required to enable it there.
 
+The VS Code/Open VSX extension has its own application-scoped preference:
+
+- Set `agentTrace.telemetry.enabled` to `false`, or run
+  **agent-trace: Disable Product Telemetry** from the Command Palette.
+- Run **agent-trace: Enable Product Telemetry** to re-enable it.
+- VS Code's editor-wide telemetry switch, `DO_NOT_TRACK=1`, and
+  `AGENT_STRACE_TELEMETRY=0` also disable extension events.
+
+The extension stores a separate random ID in VS Code global state and deletes
+it when disabled. CLI and extension preferences are separate; environment-level
+opt-outs apply to both when inherited by the editor extension host.
+
 ## Collected fields
 
-There are three events:
+The CLI emits three events:
 
 | Event | Event-specific fields |
 |---|---|
@@ -42,6 +55,20 @@ There are three events:
 Every event also includes the anonymous installation ID, telemetry schema
 version, agent-strace version, Python major/minor version, OS family, and CI
 boolean.
+
+The editor extension emits five events:
+
+| Event | Event-specific fields |
+|---|---|
+| `agent_strace_vscode_extension_activated` | none |
+| `agent_strace_vscode_command_completed` | fixed command name, success, duration, error type |
+| `agent_strace_vscode_session_started` | none |
+| `agent_strace_vscode_session_completed` | success, duration, aggregate tool-call count, aggregate error count |
+| `agent_strace_vscode_telemetry_enabled` | enablement source |
+
+Extension events also include the random extension installation ID, schema and
+extension versions, editor family/version, desktop/web UI kind, remote boolean,
+and OS family.
 
 The schema does **not** accept prompts, responses, command arguments, file paths,
 repository names or hashes, usernames, hostnames, endpoints, trace contents,
@@ -57,11 +84,18 @@ No database or deployed service is required. Use a managed PostHog project:
 1. Create a PostHog Cloud project and choose the US or EU region.
 2. Open **Project settings** and copy the **Project token**. This is the public
    event-ingestion token, not a personal API key.
-3. In `src/agent_trace/telemetry.py`, set:
+3. Set the public project token and regional host in
+   `src/agent_trace/telemetry.py`. Set the same values in
+   `vscode-extension/src/telemetry.ts` for extension releases.
 
    ```python
    DEFAULT_POSTHOG_PROJECT_TOKEN = "phc_your_project_token"
    DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"  # or https://eu.i.posthog.com
+   ```
+
+   ```typescript
+   const POSTHOG_PROJECT_TOKEN = "phc_your_project_token";
+   const POSTHOG_HOST = "https://us.i.posthog.com";
    ```
 
 4. Verify locally without editing the constants first:
@@ -80,13 +114,18 @@ No database or deployed service is required. Use a managed PostHog project:
    `agent_strace_cli_command_completed` arrived and contains only the documented
    properties. Running `agent-strace telemetry enable` explicitly also sends
    `agent_strace_telemetry_enabled`.
-6. Commit the public project token and publish the release. End users do not set
+6. Install a development VSIX, activate a workspace containing `.agent-traces/`,
+   and confirm `agent_strace_vscode_extension_activated` arrives. Exercise one
+   extension command and verify only allow-listed properties are present.
+7. Commit the public project token and publish the release. End users do not set
    a token; it is part of the distributed package.
 
 `AGENT_STRACE_TELEMETRY_TOKEN`, `AGENT_STRACE_TELEMETRY_HOST`, and
 `AGENT_STRACE_TELEMETRY_CONFIG` are intended for development, downstream
 distributions, and tests. Network delivery uses a 0.5-second timeout and is
-best-effort; failures never change CLI behavior or exit status.
+best-effort; failures never change CLI behavior or exit status. The extension
+also uses a 0.5-second timeout, keeps no on-disk queue, and never changes editor
+behavior when delivery fails.
 
 ## Suggested PostHog dashboard
 
@@ -104,6 +143,11 @@ Create these insights:
    or `export` command.
 6. **Retention:** users whose first `agent_strace_session_completed` event is
    followed by another successful command in later weeks.
+7. **Extension adoption:** unique installations performing
+   `agent_strace_vscode_extension_activated`, grouped by editor and extension
+   version.
+8. **Extension feature usage:** `agent_strace_vscode_command_completed` grouped
+   by command and success.
 
 Do not use this telemetry for billing, access control, compliance, or security
 evidence. Open-source clients and public ingestion endpoints can be modified or

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -54,6 +54,8 @@ All commands are available from the Command Palette (`Cmd/Ctrl+Shift+P`):
 | `agent-trace: Resume Agent` | Send SIGCONT to resume a paused agent |
 | `agent-trace: Open Panel` | Open the main agent-strace panel |
 | `agent-trace: Clear Decorations` | Remove all gutter annotations from the editor |
+| `agent-trace: Enable Product Telemetry` | Enable anonymous extension usage telemetry |
+| `agent-trace: Disable Product Telemetry` | Opt out and delete the extension's anonymous ID |
 
 ---
 
@@ -85,6 +87,24 @@ All settings are under `agentTrace.*` in VS Code settings:
 | `agentTrace.sessionBrowserRefreshInterval` | `5` | How often (in seconds) the session browser refreshes |
 | `agentTrace.showGutterAnnotations` | `true` | Show gutter icons on files the agent read or modified |
 | `agentTrace.showInlineText` | `true` | Show inline read/write counts at the top of agent-touched files |
+| `agentTrace.telemetry.enabled` | `true` | Send privacy-preserving anonymous extension usage events |
+
+---
+
+## Product telemetry
+
+Anonymous extension telemetry is enabled by default. On first activation, the
+extension displays a non-blocking disclosure and an immediate disable action.
+Disable it at any time with the `agentTrace.telemetry.enabled` application
+setting or **agent-trace: Disable Product Telemetry**. The editor-wide telemetry
+switch, `DO_NOT_TRACK=1`, and `AGENT_STRACE_TELEMETRY=0` are also respected.
+
+The extension measures activation, fixed command names and outcomes, and
+session success/duration with aggregate tool and error counts. It never sends
+prompts, responses, event or trace contents, paths, repository data, session
+IDs, command arguments, endpoints, usernames, hostnames, or exception messages.
+PostHog person profiles and GeoIP enrichment are disabled. See
+[Product telemetry](telemetry.md) for the exact schema.
 
 ---
 

--- a/tests/test_vscode_telemetry.py
+++ b/tests/test_vscode_telemetry.py
@@ -1,0 +1,63 @@
+"""Manifest and privacy-boundary tests for VS Code extension telemetry."""
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXTENSION = ROOT / "vscode-extension"
+
+
+class TestVSCodeTelemetryManifest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.package = json.loads((EXTENSION / "package.json").read_text())
+
+    def test_extension_minor_version_is_bumped(self):
+        self.assertEqual(self.package["version"], "0.3.0")
+
+    def test_default_on_application_setting_is_registered(self):
+        setting = self.package["contributes"]["configuration"]["properties"][
+            "agentTrace.telemetry.enabled"
+        ]
+        self.assertIs(setting["default"], True)
+        self.assertEqual(setting["scope"], "application")
+
+    def test_enable_and_disable_commands_are_registered(self):
+        commands = {
+            item["command"] for item in self.package["contributes"]["commands"]
+        }
+        self.assertIn("agentTrace.enableTelemetry", commands)
+        self.assertIn("agentTrace.disableTelemetry", commands)
+
+
+class TestVSCodeTelemetryPrivacyBoundary(unittest.TestCase):
+    def test_event_schema_has_no_sensitive_fields(self):
+        source = (EXTENSION / "src" / "telemetryCore.ts").read_text()
+        schema = source.split("const EVENT_FIELDS", 1)[1].split(
+            "export function isExtensionTelemetryEvent", 1
+        )[0]
+        for forbidden in (
+            "arguments",
+            "endpoint",
+            "hostname",
+            "path",
+            "prompt",
+            "repository",
+            "response",
+            "session_id",
+            "trace",
+            "username",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, schema)
+
+    def test_posthog_profiles_and_geoip_are_disabled(self):
+        source = (EXTENSION / "src" / "telemetry.ts").read_text()
+        self.assertIn("$process_person_profile: false", source)
+        self.assertIn("$geoip_disable: true", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -4,4 +4,6 @@ src/**
 .gitignore
 tsconfig.json
 **/*.map
+out/**/*.test.js
+out/**/*.test.js.map
 node_modules/**

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -63,6 +63,8 @@ All commands are available from the Command Palette (`Cmd/Ctrl+Shift+P`):
 | `agent-trace: Pause Agent` | Send SIGSTOP to the agent (requires `watch` running) |
 | `agent-trace: Resume Agent` | Send SIGCONT to resume a paused agent |
 | `agent-trace: Clear File Decorations` | Remove all gutter annotations from the editor |
+| `agent-trace: Enable Product Telemetry` | Enable anonymous extension usage telemetry |
+| `agent-trace: Disable Product Telemetry` | Opt out and delete the extension's anonymous ID |
 
 ## Watchdog integration
 
@@ -85,10 +87,24 @@ When the watchdog kills a session, the post-mortem viewer opens automatically. T
 | `agentTrace.sessionBrowserRefreshInterval` | `5` | How often (seconds) the session browser refreshes |
 | `agentTrace.showGutterAnnotations` | `true` | Gutter icons on agent-touched files |
 | `agentTrace.showInlineText` | `true` | Inline read/write counts at top of file |
+| `agentTrace.telemetry.enabled` | `true` | Send privacy-preserving anonymous extension usage events |
+
+## Product telemetry
+
+Anonymous extension telemetry is enabled by default with a one-time,
+non-blocking disclosure. Disable it using `agentTrace.telemetry.enabled`, the
+Command Palette, VS Code's editor-wide telemetry switch, `DO_NOT_TRACK=1`, or
+`AGENT_STRACE_TELEMETRY=0`.
+
+The extension sends activation, fixed command names/outcomes, and session
+success/duration with aggregate tool/error counts. It never sends prompts,
+responses, trace contents, paths, repository data, session IDs, command
+arguments, endpoints, usernames, hostnames, or exception messages. See the
+[full telemetry schema](../docs/telemetry.md).
 
 ## How it works
 
-The extension watches `.agent-traces/.active-session` for the current session ID, then tails `events.ndjson` for new events using `fs.watch`. No polling when idle. No network calls. No new processes.
+The extension watches `.agent-traces/.active-session` for the current session ID, then tails `events.ndjson` for new events using `fs.watch`. No polling when idle and no new processes. Its only outbound network path, other than an explicitly configured live-stream collector, is the documented best-effort anonymous product telemetry above.
 
 Pause works by writing `.agent-traces/.pause-request` — `agent-strace watch` checks for this file on every poll cycle and sends SIGSTOP / SIGCONT to the agent PID.
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "agent-strace",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-strace",
+      "version": "0.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "agent-strace",
   "displayName": "agent-strace",
   "description": "Live session overlay for agent-strace: status bar, gutter annotations, and event stream panel.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "publisher": "Siddhant-K-code",
   "license": "MIT",
   "repository": {
@@ -66,6 +66,14 @@
       {
         "command": "agentTrace.clearDecorations",
         "title": "agent-trace: Clear File Decorations"
+      },
+      {
+        "command": "agentTrace.enableTelemetry",
+        "title": "agent-trace: Enable Product Telemetry"
+      },
+      {
+        "command": "agentTrace.disableTelemetry",
+        "title": "agent-trace: Disable Product Telemetry"
       }
     ],
     "views": {
@@ -136,6 +144,12 @@
           "type": "number",
           "default": 5,
           "description": "How often (in seconds) the session browser tree view refreshes."
+        },
+        "agentTrace.telemetry.enabled": {
+          "type": "boolean",
+          "default": true,
+          "scope": "application",
+          "markdownDescription": "Send anonymous extension usage telemetry to help improve agent-strace. No prompts, trace contents, paths, session IDs, command arguments, or repository data are sent. Disable this setting to opt out."
         }
       }
     }
@@ -143,6 +157,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
+    "test": "npm run compile && node --test out/telemetryCore.test.js",
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts"
   },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,11 +15,14 @@ import { LiveStreamPanel } from "./liveStream";
 import { PostMortemManager } from "./postMortem";
 import { SessionTreeProvider } from "./sessionTree";
 import { StatusBarManager, WatchdogStatusBar } from "./statusBar";
+import { ExtensionTelemetry } from "./telemetry";
 import { TraceWatcher } from "./traceStore";
 
 export function activate(context: vscode.ExtensionContext): void {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (!workspaceRoot) { return; }
+  if (!workspaceRoot) {
+    return;
+  }
 
   const config = vscode.workspace.getConfiguration("agentTrace");
   const traceDirSetting = config.get<string>("traceDir", ".agent-traces")!;
@@ -40,6 +43,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const postMortem = new PostMortemManager(traceDir);
   const liveStream = new LiveStreamPanel(context.extensionUri);
   const sessionTree = new SessionTreeProvider(traceDir);
+  const telemetry = new ExtensionTelemetry(context);
 
   // -------------------------------------------------------------------------
   // Webview panel registration
@@ -48,7 +52,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(EventStreamPanel.viewId, panel, {
       webviewOptions: { retainContextWhenHidden: true },
-    })
+    }),
   );
 
   // -------------------------------------------------------------------------
@@ -56,10 +60,11 @@ export function activate(context: vscode.ExtensionContext): void {
   // -------------------------------------------------------------------------
 
   watcher.onSessionStart((state) => {
+    telemetry.captureSessionStarted();
     vscode.commands.executeCommand(
       "setContext",
       "agentTrace.sessionActive",
-      true
+      true,
     );
     statusBar.update(state);
     watchdogBar.onSessionStart(traceDir, state);
@@ -68,10 +73,11 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   watcher.onSessionEnd((state) => {
+    telemetry.captureSessionCompleted(state);
     vscode.commands.executeCommand(
       "setContext",
       "agentTrace.sessionActive",
-      false
+      false,
     );
     statusBar.update(null);
     watchdogBar.onSessionEnd();
@@ -97,38 +103,54 @@ export function activate(context: vscode.ExtensionContext): void {
   // -------------------------------------------------------------------------
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("agentTrace.pauseAgent", () => {
-      const state = watcher.state;
-      if (!state) {
-        vscode.window.showWarningMessage("agent-trace: no active session to pause.");
-        return;
-      }
-      pauseManager.pause(state);
-      statusBar.update(state);
-      vscode.window.setStatusBarMessage("agent-trace: agent paused.", 3000);
-    })
+    vscode.commands.registerCommand(
+      "agentTrace.pauseAgent",
+      telemetry.trackCommand("pause_agent", () => {
+        const state = watcher.state;
+        if (!state) {
+          vscode.window.showWarningMessage(
+            "agent-trace: no active session to pause.",
+          );
+          return;
+        }
+        pauseManager.pause(state);
+        statusBar.update(state);
+        vscode.window.setStatusBarMessage("agent-trace: agent paused.", 3000);
+      }),
+    ),
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("agentTrace.resumeAgent", () => {
-      const state = watcher.state;
-      if (!state) { return; }
-      pauseManager.resume(state);
-      statusBar.update(state);
-      vscode.window.setStatusBarMessage("agent-trace: agent resumed.", 3000);
-    })
+    vscode.commands.registerCommand(
+      "agentTrace.resumeAgent",
+      telemetry.trackCommand("resume_agent", () => {
+        const state = watcher.state;
+        if (!state) {
+          return;
+        }
+        pauseManager.resume(state);
+        statusBar.update(state);
+        vscode.window.setStatusBarMessage("agent-trace: agent resumed.", 3000);
+      }),
+    ),
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("agentTrace.openPanel", () => {
-      vscode.commands.executeCommand("agentTrace.eventStream.focus");
-    })
+    vscode.commands.registerCommand(
+      "agentTrace.openPanel",
+      telemetry.trackCommand("open_panel", () => {
+        vscode.commands.executeCommand("agentTrace.eventStream.focus");
+      }),
+    ),
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("agentTrace.clearDecorations", () => {
-      decorations.clear();
-    })
+    vscode.commands.registerCommand(
+      "agentTrace.clearDecorations",
+      telemetry.trackCommand("clear_decorations", () => {
+        decorations.clear();
+      }),
+    ),
   );
 
   // -------------------------------------------------------------------------
@@ -137,56 +159,112 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("agentTrace")) {
+      const telemetryChanged = e.affectsConfiguration(
+        "agentTrace.telemetry.enabled",
+      );
+      if (telemetryChanged) {
+        telemetry.handleConfigurationChange();
+      }
+      if (e.affectsConfiguration("agentTrace") && !telemetryChanged) {
         vscode.window.showInformationMessage(
-          "agent-trace: configuration changed — reload window to apply."
+          "agent-trace: configuration changed — reload window to apply.",
         );
       }
-    })
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.env.onDidChangeTelemetryEnabled((enabled) => {
+      telemetry.handleEditorTelemetryChange(enabled);
+    }),
   );
 
   // -------------------------------------------------------------------------
   // Start watching
   // -------------------------------------------------------------------------
 
+  telemetry.initialize();
   watcher.start();
 
   // Register session browser tree view
   const treeView = vscode.window.registerTreeDataProvider(
     "agentTrace.sessionBrowser",
-    sessionTree
+    sessionTree,
   );
 
   // Register commands for new features
   context.subscriptions.push(
-    vscode.commands.registerCommand("agentTrace.openLiveStream", () => {
-      liveStream.open();
-    }),
-    vscode.commands.registerCommand("agentTrace.openPostMortem", (sessionId?: string) => {
-      if (sessionId) {
-        postMortem.openForSession(sessionId);
-      } else {
-        // Prompt user to pick a session
-        vscode.window.showInputBox({ prompt: "Enter session ID" }).then((id) => {
-          if (id) { postMortem.openForSession(id); }
-        });
-      }
-    }),
-    vscode.commands.registerCommand("agentTrace.refreshSessionBrowser", () => {
-      sessionTree.refresh();
-    }),
-    vscode.commands.registerCommand("agentTrace.revealSession", (sessionId: string) => {
-      // Refresh tree and let the user find the session
-      sessionTree.refresh();
-    })
+    vscode.commands.registerCommand(
+      "agentTrace.openLiveStream",
+      telemetry.trackCommand("open_live_stream", () => {
+        liveStream.open();
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "agentTrace.openPostMortem",
+      telemetry.trackCommand("open_post_mortem", (sessionId?: unknown) => {
+        if (typeof sessionId === "string" && sessionId) {
+          postMortem.openForSession(sessionId);
+        } else {
+          // Prompt user to pick a session
+          return vscode.window
+            .showInputBox({ prompt: "Enter session ID" })
+            .then((id) => {
+              if (id) {
+                postMortem.openForSession(id);
+              }
+            });
+        }
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "agentTrace.refreshSessionBrowser",
+      telemetry.trackCommand("refresh_session_browser", () => {
+        sessionTree.refresh();
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "agentTrace.revealSession",
+      telemetry.trackCommand("reveal_session", (_sessionId?: unknown) => {
+        // Refresh tree and let the user find the session
+        sessionTree.refresh();
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "agentTrace.enableTelemetry",
+      telemetry.trackCommand("enable_telemetry", async () => {
+        await telemetry.setEnabled(true, "command");
+        vscode.window.showInformationMessage(
+          "agent-strace: anonymous product telemetry enabled.",
+        );
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "agentTrace.disableTelemetry",
+      telemetry.trackCommand("disable_telemetry", async () => {
+        await telemetry.setEnabled(false, "command");
+        vscode.window.showInformationMessage(
+          "agent-strace: anonymous product telemetry disabled and anonymous ID deleted.",
+        );
+      }),
+    ),
   );
 
   // Start post-mortem watcher
   postMortem.start();
 
   // Register disposables
-  context.subscriptions.push(watcher, statusBar, watchdogBar, decorations,
-    postMortem, liveStream, treeView, { dispose: () => sessionTree.dispose() });
+  context.subscriptions.push(
+    watcher,
+    statusBar,
+    watchdogBar,
+    decorations,
+    postMortem,
+    liveStream,
+    treeView,
+    telemetry,
+    { dispose: () => sessionTree.dispose() },
+  );
 }
 
 export function deactivate(): void {

--- a/vscode-extension/src/telemetry.ts
+++ b/vscode-extension/src/telemetry.ts
@@ -1,0 +1,333 @@
+/** Default-on, privacy-preserving product telemetry for the editor extension. */
+
+import * as crypto from "crypto";
+import * as https from "https";
+import * as vscode from "vscode";
+import {
+  COMMAND_COMPLETED,
+  EXTENSION_ACTIVATED,
+  ExtensionCommand,
+  ExtensionTelemetryEvent,
+  SESSION_COMPLETED,
+  SESSION_STARTED,
+  TELEMETRY_ENABLED,
+  sanitiseEventProperties,
+} from "./telemetryCore";
+import { SessionState } from "./traceStore";
+
+// PostHog project tokens are public, write-only event-ingestion tokens.
+const POSTHOG_PROJECT_TOKEN =
+  "phc_yWjxK7ibJuFfskDuTr4HbXGdyGvFC6V3Y3fRwNDiRK6x";
+const POSTHOG_HOST = "https://us.i.posthog.com";
+const REQUEST_TIMEOUT_MS = 500;
+const TELEMETRY_SCHEMA_VERSION = 1;
+
+const ANONYMOUS_ID_KEY = "agentTrace.telemetry.anonymousId";
+const NOTICE_SHOWN_KEY = "agentTrace.telemetry.noticeShown";
+const CONFIG_SECTION = "agentTrace";
+const CONFIG_KEY = "telemetry.enabled";
+const TRUE_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off", "disabled"]);
+
+type EnablementSource = "command" | "settings" | "editor_setting";
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalised = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalised)) {
+    return true;
+  }
+  if (FALSE_VALUES.has(normalised)) {
+    return false;
+  }
+  return undefined;
+}
+
+function editorName(): string {
+  const name = vscode.env.appName.toLowerCase();
+  if (name.includes("cursor")) {
+    return "cursor";
+  }
+  if (name.includes("windsurf")) {
+    return "windsurf";
+  }
+  if (name.includes("vscodium")) {
+    return "vscodium";
+  }
+  if (name.includes("visual studio code")) {
+    return "vscode";
+  }
+  return "other";
+}
+
+function errorType(error: unknown): string {
+  if (error instanceof Error && /^[A-Za-z0-9_.:/-]{1,80}$/.test(error.name)) {
+    return error.name;
+  }
+  return "UnknownError";
+}
+
+export class ExtensionTelemetry implements vscode.Disposable {
+  private anonymousId: string | undefined;
+  private disclosurePending = false;
+  private settingFromCommand = false;
+  private readonly requests = new Set<ReturnType<typeof https.request>>();
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    const storedId = context.globalState.get<string>(ANONYMOUS_ID_KEY);
+    if (storedId && /^[0-9a-f]{32}$/.test(storedId)) {
+      this.anonymousId = storedId;
+    }
+  }
+
+  /** Display the one-time disclosure before sending this installation's first event. */
+  initialize(): void {
+    const noticeShown = this.context.globalState.get<boolean>(
+      NOTICE_SHOWN_KEY,
+      false,
+    );
+    if (!this.isEnabled() || noticeShown) {
+      this.capture(EXTENSION_ACTIVATED);
+      return;
+    }
+
+    this.disclosurePending = true;
+    void Promise.resolve(
+      this.context.globalState.update(NOTICE_SHOWN_KEY, true),
+    )
+      .catch(() => undefined)
+      .then(async () => {
+        const choice = await vscode.window.showInformationMessage(
+          "agent-strace anonymous extension telemetry is enabled by default. " +
+            "Prompts, trace contents, paths, session IDs, and command arguments are never sent.",
+          "Disable telemetry",
+          "Privacy details",
+        );
+        if (choice === "Disable telemetry") {
+          await this.setEnabled(false, "command");
+        } else if (choice === "Privacy details") {
+          await vscode.env.openExternal(
+            vscode.Uri.parse(
+              "https://github.com/Siddhant-K-code/agent-trace/blob/main/docs/telemetry.md",
+            ),
+          );
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        this.disclosurePending = false;
+        this.capture(EXTENSION_ACTIVATED);
+      });
+  }
+
+  isEnabled(): boolean {
+    // The editor-wide telemetry switch is a hard privacy boundary.
+    if (vscode.env.isTelemetryEnabled === false) {
+      return false;
+    }
+    if (parseBoolean(process.env.DO_NOT_TRACK) === true) {
+      return false;
+    }
+
+    const environmentOverride = parseBoolean(
+      process.env.AGENT_STRACE_TELEMETRY,
+    );
+    if (environmentOverride === false) {
+      return false;
+    }
+
+    return vscode.workspace
+      .getConfiguration(CONFIG_SECTION)
+      .get<boolean>(CONFIG_KEY, true);
+  }
+
+  async setEnabled(enabled: boolean, source: EnablementSource): Promise<void> {
+    this.settingFromCommand = source === "command";
+    try {
+      await vscode.workspace
+        .getConfiguration(CONFIG_SECTION)
+        .update(CONFIG_KEY, enabled, vscode.ConfigurationTarget.Global);
+    } finally {
+      this.settingFromCommand = false;
+    }
+
+    if (!enabled) {
+      await this.clearAnonymousId();
+      return;
+    }
+    this.capture(TELEMETRY_ENABLED, { source });
+  }
+
+  /** Handle changes made directly in the Settings UI. */
+  handleConfigurationChange(): void {
+    if (this.settingFromCommand) {
+      return;
+    }
+    if (!this.isEnabled()) {
+      void this.clearAnonymousId().catch(() => undefined);
+      return;
+    }
+    this.capture(TELEMETRY_ENABLED, { source: "settings" });
+  }
+
+  /** Respect changes to VS Code's global telemetry level immediately. */
+  handleEditorTelemetryChange(enabled: boolean): void {
+    if (!enabled) {
+      void this.clearAnonymousId().catch(() => undefined);
+      return;
+    }
+    if (this.isEnabled()) {
+      this.capture(TELEMETRY_ENABLED, { source: "editor_setting" });
+    }
+  }
+
+  captureSessionStarted(): void {
+    this.capture(SESSION_STARTED);
+  }
+
+  captureSessionCompleted(state: SessionState): void {
+    const startedAtMs = Math.max(0, state.meta.started_at * 1000);
+    const endedAtMs = state.meta.ended_at
+      ? state.meta.ended_at * 1000
+      : Date.now();
+    this.capture(SESSION_COMPLETED, {
+      success: state.errorCount === 0,
+      duration_ms: Math.max(0, endedAtMs - startedAtMs),
+      tool_call_count: state.toolCallCount,
+      error_count: state.errorCount,
+    });
+  }
+
+  trackCommand(
+    command: ExtensionCommand,
+    handler: (...args: unknown[]) => unknown,
+  ): (...args: unknown[]) => unknown {
+    return (...args: unknown[]): unknown => {
+      const startedAt = Date.now();
+      try {
+        const result = handler(...args);
+        if (
+          result !== null &&
+          typeof result === "object" &&
+          "then" in result &&
+          typeof (result as { then?: unknown }).then === "function"
+        ) {
+          return Promise.resolve(result).then(
+            (value) => {
+              this.capture(COMMAND_COMPLETED, {
+                command,
+                success: true,
+                duration_ms: Date.now() - startedAt,
+              });
+              return value;
+            },
+            (error: unknown) => {
+              this.capture(COMMAND_COMPLETED, {
+                command,
+                success: false,
+                duration_ms: Date.now() - startedAt,
+                error_type: errorType(error),
+              });
+              throw error;
+            },
+          );
+        }
+        this.capture(COMMAND_COMPLETED, {
+          command,
+          success: true,
+          duration_ms: Date.now() - startedAt,
+        });
+        return result;
+      } catch (error) {
+        this.capture(COMMAND_COMPLETED, {
+          command,
+          success: false,
+          duration_ms: Date.now() - startedAt,
+          error_type: errorType(error),
+        });
+        throw error;
+      }
+    };
+  }
+
+  capture(
+    event: ExtensionTelemetryEvent,
+    properties: Record<string, unknown> = {},
+  ): void {
+    if (!this.isEnabled() || this.disclosurePending) {
+      return;
+    }
+    const clean = sanitiseEventProperties(event, properties);
+    if (clean === null) {
+      return;
+    }
+
+    const body = JSON.stringify({
+      api_key: POSTHOG_PROJECT_TOKEN,
+      event,
+      distinct_id: this.getAnonymousId(),
+      properties: {
+        ...clean,
+        $process_person_profile: false,
+        $geoip_disable: true,
+        $lib: "agent-strace-vscode",
+        $lib_version: this.context.extension.packageJSON.version,
+        telemetry_schema_version: TELEMETRY_SCHEMA_VERSION,
+        extension_version: this.context.extension.packageJSON.version,
+        editor: editorName(),
+        editor_version: vscode.version,
+        ui_kind: vscode.env.uiKind === vscode.UIKind.Web ? "web" : "desktop",
+        remote: Boolean(vscode.env.remoteName),
+        os: process.platform,
+      },
+      timestamp: new Date().toISOString(),
+      uuid: crypto.randomUUID(),
+    });
+
+    try {
+      const req = https.request(
+        new URL(POSTHOG_HOST + "/i/v0/e/"),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+            "User-Agent": `agent-strace-vscode/${this.context.extension.packageJSON.version}`,
+          },
+        },
+        (response) => response.resume(),
+      );
+      this.requests.add(req);
+      req.on("close", () => this.requests.delete(req));
+      req.on("error", () => this.requests.delete(req));
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => req.destroy());
+      req.end(body);
+    } catch {
+      // Product telemetry is always best-effort and never affects extension UI.
+    }
+  }
+
+  private getAnonymousId(): string {
+    if (!this.anonymousId) {
+      this.anonymousId = crypto.randomBytes(16).toString("hex");
+      void Promise.resolve(
+        this.context.globalState.update(ANONYMOUS_ID_KEY, this.anonymousId),
+      ).catch(() => undefined);
+    }
+    return this.anonymousId;
+  }
+
+  private async clearAnonymousId(): Promise<void> {
+    this.anonymousId = undefined;
+    await this.context.globalState.update(ANONYMOUS_ID_KEY, undefined);
+  }
+
+  dispose(): void {
+    for (const request of this.requests) {
+      request.destroy();
+    }
+    this.requests.clear();
+  }
+}

--- a/vscode-extension/src/telemetryCore.test.ts
+++ b/vscode-extension/src/telemetryCore.test.ts
@@ -1,0 +1,53 @@
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  COMMAND_COMPLETED,
+  SESSION_COMPLETED,
+  sanitiseEventProperties,
+} from "./telemetryCore";
+
+test("drops unknown and sensitive command properties", () => {
+  const clean = sanitiseEventProperties(COMMAND_COMPLETED, {
+    command: "open_panel",
+    success: true,
+    duration_ms: 12.9,
+    workspace_path: "/private/repository",
+    session_id: "secret-session",
+    arguments: "--token secret",
+  });
+
+  assert.deepEqual(clean, {
+    command: "open_panel",
+    success: true,
+    duration_ms: 12,
+  });
+});
+
+test("rejects unknown events and command names", () => {
+  assert.equal(sanitiseEventProperties("unknown", {}), null);
+  assert.deepEqual(
+    sanitiseEventProperties(COMMAND_COMPLETED, {
+      command: "open /private/path",
+      success: true,
+    }),
+    { success: true },
+  );
+});
+
+test("validates and bounds aggregate session metrics", () => {
+  assert.deepEqual(
+    sanitiseEventProperties(SESSION_COMPLETED, {
+      success: false,
+      duration_ms: -20,
+      tool_call_count: 1_500_000,
+      error_count: 3,
+      prompt: "never send me",
+    }),
+    {
+      success: false,
+      duration_ms: 0,
+      tool_call_count: 1_000_000,
+      error_count: 3,
+    },
+  );
+});

--- a/vscode-extension/src/telemetryCore.ts
+++ b/vscode-extension/src/telemetryCore.ts
@@ -1,0 +1,116 @@
+/** Pure helpers and schema for privacy-preserving extension telemetry. */
+
+export const EXTENSION_ACTIVATED = "agent_strace_vscode_extension_activated";
+export const COMMAND_COMPLETED = "agent_strace_vscode_command_completed";
+export const SESSION_STARTED = "agent_strace_vscode_session_started";
+export const SESSION_COMPLETED = "agent_strace_vscode_session_completed";
+export const TELEMETRY_ENABLED = "agent_strace_vscode_telemetry_enabled";
+
+export type ExtensionTelemetryEvent =
+  | typeof EXTENSION_ACTIVATED
+  | typeof COMMAND_COMPLETED
+  | typeof SESSION_STARTED
+  | typeof SESSION_COMPLETED
+  | typeof TELEMETRY_ENABLED;
+
+export type ExtensionCommand =
+  | "pause_agent"
+  | "resume_agent"
+  | "open_panel"
+  | "clear_decorations"
+  | "open_live_stream"
+  | "open_post_mortem"
+  | "refresh_session_browser"
+  | "reveal_session"
+  | "enable_telemetry"
+  | "disable_telemetry";
+
+type Validator = (value: unknown) => unknown | undefined;
+
+const SAFE_TEXT = /^[A-Za-z0-9_.:/-]{1,80}$/;
+const COMMANDS = new Set<ExtensionCommand>([
+  "pause_agent",
+  "resume_agent",
+  "open_panel",
+  "clear_decorations",
+  "open_live_stream",
+  "open_post_mortem",
+  "refresh_session_browser",
+  "reveal_session",
+  "enable_telemetry",
+  "disable_telemetry",
+]);
+const ENABLEMENT_SOURCES = new Set(["command", "settings", "editor_setting"]);
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function boundedInteger(maximum: number): Validator {
+  return (value: unknown): number | undefined => {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return undefined;
+    }
+    return Math.max(0, Math.min(Math.trunc(value), maximum));
+  };
+}
+
+function safeText(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_TEXT.test(value) ? value : undefined;
+}
+
+function allowedValue(values: ReadonlySet<string>): Validator {
+  return (value: unknown): string | undefined =>
+    typeof value === "string" && values.has(value) ? value : undefined;
+}
+
+const EVENT_FIELDS: Record<
+  ExtensionTelemetryEvent,
+  Record<string, Validator>
+> = {
+  [EXTENSION_ACTIVATED]: {},
+  [COMMAND_COMPLETED]: {
+    command: allowedValue(COMMANDS),
+    success: booleanValue,
+    duration_ms: boundedInteger(2_678_400_000),
+    error_type: safeText,
+  },
+  [SESSION_STARTED]: {},
+  [SESSION_COMPLETED]: {
+    success: booleanValue,
+    duration_ms: boundedInteger(2_678_400_000),
+    tool_call_count: boundedInteger(1_000_000),
+    error_count: boundedInteger(1_000_000),
+  },
+  [TELEMETRY_ENABLED]: {
+    source: allowedValue(ENABLEMENT_SOURCES),
+  },
+};
+
+export function isExtensionTelemetryEvent(
+  event: string,
+): event is ExtensionTelemetryEvent {
+  return Object.prototype.hasOwnProperty.call(EVENT_FIELDS, event);
+}
+
+/** Drop every property that is not explicitly allowed for this event. */
+export function sanitiseEventProperties(
+  event: string,
+  properties: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!isExtensionTelemetryEvent(event)) {
+    return null;
+  }
+
+  const clean: Record<string, unknown> = {};
+  for (const [name, validator] of Object.entries(EVENT_FIELDS[event])) {
+    if (!Object.prototype.hasOwnProperty.call(properties, name)) {
+      continue;
+    }
+    const value = validator(properties[name]);
+    if (value !== undefined) {
+      clean[name] = value;
+    }
+  }
+  return clean;
+}


### PR DESCRIPTION
## Summary

- add extension-native PostHog telemetry for activation, fixed command outcomes, and session lifecycle aggregates
- enable it by default behind a one-time non-blocking disclosure
- add application-scoped enable/disable commands and `agentTrace.telemetry.enabled`
- honor VS Code's editor-wide telemetry switch, `DO_NOT_TRACK=1`, and `AGENT_STRACE_TELEMETRY=0`
- use a strict event/property allowlist with disabled PostHog person profiles and GeoIP enrichment
- add no runtime dependencies; delivery uses Node.js built-ins with a 500 ms timeout
- bump the extension from `0.2.1` to `0.3.0`
- document the complete schema and add Node 20 extension tests to CI

No prompts, responses, trace/event contents, paths, repositories, session IDs, command arguments, endpoints, usernames, hostnames, or exception messages are sent. Session events contain only success, duration, and aggregate tool/error counts.

## Testing

- `npm ci && npm test` — TypeScript compilation and 3 schema tests passed
- `python -m unittest discover -s tests -v` — 1,627 passed
- `npx @vscode/vsce package --out /tmp/agent-strace-0.3.0.vsix` — packaged successfully
- `git diff --check`

## Release

After merge, manually dispatch **Publish VS Code Extension** on `main` to publish `0.3.0` to the VS Marketplace and Open VSX.