### PR TITLE
chore: add project-specific development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-strace",
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/python": {},
+    "ghcr.io/devcontainers/features/node": {}
+  },
+  "remoteEnv": {
+    "PATH": "${containerWorkspaceFolder}/.venv/bin:${containerEnv:PATH}"
+  }
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,56 @@
+tasks:
+  install-dependencies:
+    name: Install dependencies
+    description: Install agent-strace and the VS Code extension dependencies.
+    command: |
+      python -m venv .venv
+      .venv/bin/python -m pip install --editable .
+      if [ -f vscode-extension/package-lock.json ]; then
+        npm --prefix vscode-extension ci
+      else
+        npm --prefix vscode-extension install --no-package-lock
+      fi
+    triggeredBy:
+      - manual
+      - postDevcontainerStart
+      - prebuild
+
+  build:
+    name: Build
+    description: Build the Python package and compile the VS Code extension.
+    command: |
+      .venv/bin/python -m pip wheel --no-deps --wheel-dir /tmp/agent-strace-dist .
+      npm --prefix vscode-extension run compile
+    triggeredBy:
+      - manual
+    dependsOn:
+      - install-dependencies
+
+  test:
+    name: Test
+    description: Run the Python and VS Code extension test suites.
+    command: |
+      PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v
+      if node -e "const p = require('./vscode-extension/package.json'); process.exit(p.scripts?.test ? 0 : 1)"; then
+        npm --prefix vscode-extension test
+      else
+        npm --prefix vscode-extension run compile
+      fi
+    triggeredBy:
+      - manual
+    dependsOn:
+      - install-dependencies
+
+services:
+  agent-strace-server:
+    name: Agent Trace Server
+    description: Run the local agent-strace collector with a private forwarded port.
+    commands:
+      start: |
+        gitpod environment port open 4317 --dont-wait --admission creator_only --name "Agent Trace Server"
+        exec .venv/bin/agent-strace server --host 0.0.0.0 --port 4317 --storage .agent-traces
+      ready: |
+        curl --fail --silent http://localhost:4317/health >/dev/null
+    triggeredBy:
+      - manual
+      - postEnvironmentStart


### PR DESCRIPTION
## Summary

- add a Dockerfile-based Dev Container with official Python and Node features
- install agent-strace into a repository-local virtual environment and expose it on the terminal PATH
- add Ona tasks for dependency installation, package/extension builds, and Python/extension tests
- add an automatically started agent-strace collector with creator-only port forwarding on 4317

## Validation

- `gitpod environment devcontainer validate .devcontainer/devcontainer.json`
- `gitpod automations validate .ona/automations.yaml`
- rebuilt and resumed the Dev Container successfully
- Build automation: Python wheel built and VS Code extension compiled
- Test automation: 1,627 Python tests and 3 VS Code extension tests passed
- Agent Trace Server service reached `RUNNING` with port 4317 set to `creator_only`