### PR TITLE
fix: restore editor session lifecycle tracking

### DIFF
--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.82.0"
+__version__ = "0.83.0"

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -130,6 +130,11 @@ def _active_session_path(provider: str = "claude") -> Path:
     return Path(_get_store_dir()) / f".active-session{_state_suffix(provider)}"
 
 
+def _canonical_active_session_path() -> Path:
+    """Return the active-session marker consumed by editor integrations."""
+    return Path(_get_store_dir()) / ".active-session"
+
+
 def _pending_calls_path(provider: str = "claude") -> Path:
     suffix = _state_suffix(provider)
     name = _PENDING_FILE.replace(".json", f"{suffix}.json")
@@ -157,6 +162,11 @@ def _resolve_session_id(input_data: dict, provider: str = "claude") -> str | Non
     """
     raw = input_data.get("session_id", "")
     if raw:
+        raw = str(raw)
+        # Hook events run in separate processes, so restore the provider-scoped
+        # state suffix from every payload rather than relying on SessionStart's
+        # process-local environment mutation.
+        os.environ[_provider_env(provider)] = raw
         return raw[:16]
     return _read_active_session(provider)
 
@@ -166,11 +176,37 @@ def _write_active_session(session_id: str, provider: str = "claude") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(session_id)
 
+    # Provider-scoped markers preserve concurrent hook state. The canonical
+    # marker is a compatibility pointer for the VS Code/OpenVSX extension and
+    # other consumers defined by ADR-0002.
+    canonical = _canonical_active_session_path()
+    if path != canonical:
+        canonical.write_text(session_id)
+
 
 def _clear_active_session(provider: str = "claude") -> None:
     path = _active_session_path(provider)
+    session_id = ""
     if path.exists():
+        session_id = path.read_text().strip()
         path.unlink()
+
+    canonical = _canonical_active_session_path()
+    if path == canonical:
+        # Some providers omit the conversation ID from SessionEnd. Remove any
+        # scoped marker that points at the same local session as the canonical
+        # fallback so stale state cannot survive the completed session.
+        if session_id:
+            for scoped in canonical.parent.glob(".active-session.*"):
+                if scoped.read_text().strip() == session_id:
+                    scoped.unlink()
+        return
+
+    if not session_id:
+        raw = os.environ.get(_provider_env(provider), "")
+        session_id = raw[:16]
+    if canonical.exists() and canonical.read_text().strip() == session_id:
+        canonical.unlink()
 
 
 def _read_pending_calls(provider: str = "claude") -> dict:
@@ -213,7 +249,10 @@ def _normalise_payload(input_data: dict, provider: str, event: str) -> dict:
     if provider not in ("codex", "gemini", "cursor", "copilot"):
         return data
 
-    data.setdefault("session_id", data.get("sessionId") or "")
+    data.setdefault(
+        "session_id",
+        data.get("sessionId") or data.get("conversation_id") or "",
+    )
     data.setdefault("turn_id", data.get("turnId") or "")
     data.setdefault("tool_use_id", data.get("toolUseId") or "")
     data.setdefault("stop_reason", data.get("stopReason") or "")

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -16,6 +16,7 @@ from agent_trace.hooks import (
     handle_file_write,
     handle_post_tool,
     handle_pre_tool,
+    handle_session_end,
     handle_session_start,
     handle_stop,
     handle_user_prompt,
@@ -37,8 +38,9 @@ class TestCursorHooks(unittest.TestCase):
         os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
 
     def test_cursor_session_start_creates_session(self):
+        raw_session_id = "cursorsession123456789"
         handle_session_start({
-            "session_id": "cursorsession123456789",
+            "session_id": raw_session_id,
             "source": "startup",
             "model": "cursor-agent",
             "cwd": "/work/repo",
@@ -54,6 +56,23 @@ class TestCursorHooks(unittest.TestCase):
         self.assertEqual(events[0].event_type, EventType.SESSION_START)
         self.assertEqual(events[0].data["provider"], "cursor")
         self.assertEqual(events[0].data["mode"], "cursor-agent-hooks")
+
+        canonical = Path(self.tmpdir) / ".active-session"
+        scoped = Path(self.tmpdir) / f".active-session.{raw_session_id}"
+        self.assertEqual(canonical.read_text(), session_id)
+        self.assertEqual(scoped.read_text(), session_id)
+
+        # Cursor invokes each hook in a fresh process, so SessionStart's
+        # process-local environment does not survive until SessionEnd.
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
+        with patch("agent_trace.hooks._product_telemetry.capture"):
+            handle_session_end(
+                {"session_id": raw_session_id, "reason": "completed"},
+                provider="cursor",
+            )
+
+        self.assertFalse(canonical.exists())
+        self.assertFalse(scoped.exists())
 
     def test_cursor_shell_execution_is_linked(self):
         handle_session_start({"session_id": "cursorshell123456", "source": "startup"}, provider="cursor")
@@ -75,6 +94,22 @@ class TestCursorHooks(unittest.TestCase):
         results = [event for event in events if event.event_type == EventType.TOOL_RESULT]
         self.assertEqual(calls[0].data["arguments"]["command"], "pytest tests/")
         self.assertEqual(results[0].parent_id, calls[0].event_id)
+
+    def test_cursor_session_end_without_id_clears_matching_scoped_marker(self):
+        raw_session_id = "cursorfallback123456789"
+        handle_session_start(
+            {"session_id": raw_session_id, "source": "startup"},
+            provider="cursor",
+        )
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
+
+        with patch("agent_trace.hooks._product_telemetry.capture"):
+            handle_session_end({}, provider="cursor")
+
+        self.assertFalse((Path(self.tmpdir) / ".active-session").exists())
+        self.assertFalse(
+            (Path(self.tmpdir) / f".active-session.{raw_session_id}").exists()
+        )
 
     def test_cursor_prompt_response_and_file_edit(self):
         handle_session_start({"session_id": "cursorprompt12345", "source": "startup"}, provider="cursor")
@@ -103,29 +138,38 @@ class TestCursorHooks(unittest.TestCase):
         self.assertIn("Refactor", responses[0].data["text"])
 
     def test_hook_main_accepts_cursor_aliases(self):
-        handle_session_start({"session_id": "cursoralias12345", "source": "startup"}, provider="cursor")
-        session_id = _read_active_session(provider="cursor")
+        conversation_id = "cursoralias123456789"
+        start_payload = json.dumps({
+            "conversation_id": conversation_id,
+            "hook_event_name": "sessionStart",
+        })
+        with patch.object(sys, "stdin", io.StringIO(start_payload)):
+            hook_main(["--provider", "cursor", "sessionStart"])
+        session_id = conversation_id[:16]
 
         shell_payload = json.dumps({
-            "session_id": "cursoralias12345",
+            "conversation_id": conversation_id,
             "command": "python -m pytest",
         })
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
         with patch.object(sys, "stdin", io.StringIO(shell_payload)):
             hook_main(["--provider", "cursor", "before-shell-execution"])
 
         result_payload = json.dumps({
-            "session_id": "cursoralias12345",
+            "conversation_id": conversation_id,
             "command": "python -m pytest",
             "tool_response": {"exit_code": 1, "output": "failed"},
         })
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
         with patch.object(sys, "stdin", io.StringIO(result_payload)):
             hook_main(["--provider", "cursor", "after-shell-execution"])
 
         payload = json.dumps({
-            "session_id": "cursoralias12345",
+            "conversation_id": conversation_id,
             "file_path": "src/app.py",
             "diff": "+x",
         })
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
         with patch.object(sys, "stdin", io.StringIO(payload)):
             hook_main(["--provider", "cursor", "after-file-edit"])
 
@@ -137,6 +181,22 @@ class TestCursorHooks(unittest.TestCase):
         self.assertEqual(calls[0].data["arguments"]["command"], "python -m pytest")
         self.assertEqual(errors[0].parent_id, calls[0].event_id)
         self.assertEqual(writes[0].data["path"], "src/app.py")
+
+        os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
+        end_payload = json.dumps({
+            "conversation_id": conversation_id,
+            "hook_event_name": "sessionEnd",
+        })
+        with (
+            patch.object(sys, "stdin", io.StringIO(end_payload)),
+            patch("agent_trace.hooks._product_telemetry.capture"),
+        ):
+            hook_main(["--provider", "cursor", "sessionEnd"])
+
+        self.assertFalse((Path(self.tmpdir) / ".active-session").exists())
+        self.assertFalse(
+            (Path(self.tmpdir) / f".active-session.{conversation_id}").exists()
+        )
 
 
 class TestCursorSetup(unittest.TestCase):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -474,6 +474,27 @@ class TestConcurrentAgentIsolation(unittest.TestCase):
         os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent1session00001"
         self.assertEqual(_read_active_session(), sid1)
 
+    def test_ending_older_session_preserves_newer_canonical_marker(self):
+        """An older concurrent session must not clear the extension pointer."""
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent1session00001"
+        _write_active_session("agent1session000")
+
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent2session00002"
+        _write_active_session("agent2session000")
+
+        canonical = os.path.join(self.tmpdir, ".active-session")
+        with open(canonical) as fh:
+            self.assertEqual(fh.read(), "agent2session000")
+
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent1session00001"
+        _clear_active_session()
+        with open(canonical) as fh:
+            self.assertEqual(fh.read(), "agent2session000")
+
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent2session00002"
+        _clear_active_session()
+        self.assertFalse(os.path.exists(canonical))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- mirror provider-scoped hook sessions to the canonical `.active-session` marker consumed by the VS Code/OpenVSX extension
- map Cursor's documented `conversation_id` into session identity across fresh hook processes
- clean up matching scoped markers safely without clearing a newer concurrent session
- bump `agent-strace` from 0.82.0 to 0.83.0

## Validation

- `python -m unittest discover -s tests -q` — 1,629 tests passed
- `npm test` in `vscode-extension/` — compile and 3 tests passed
- real process-boundary Cursor lifecycle smoke test — `session_start`, `tool_call`, `tool_result`, `session_end`
- wheel build — `agent_strace-0.83.0-py3-none-any.whl`