### PR TITLE
Add eval-as-a-gate scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace tree`](docs/commands.md#tree) | Show parent/child session hierarchy |
 | [`agent-strace freeze`](docs/commands.md#freeze) | Freeze a tool-call sequence for regression checks |
 | [`agent-strace standup`](docs/commands.md#standup) | Plain-English summary of yesterday's sessions |
-| [`agent-strace eval <id>`](docs/commands.md#eval) | Score a session against behavioural baselines |
-| [`agent-strace eval ci`](docs/commands.md#eval) | Fail CI on behavioural regression |
+| [`agent-strace eval <id>`](docs/commands.md#eval) | Gate a session on named quality criteria and baselines |
+| [`agent-strace eval ci`](docs/commands.md#eval) | Run the legacy normalized-score CI workflow |
 
 ### Export and integrate
 

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,8 @@ inputs:
     description: Path to baseline scores file (optional)
     default: ""
   save-baseline:
-    description: Save scores as new baseline after run
-    default: "false"
+    description: Path to save current scores as a new baseline (optional)
+    default: ""
   tolerance:
     description: Regression tolerance (0.0–1.0, default 0.05)
     default: "0.05"
@@ -58,30 +58,31 @@ runs:
       id: eval
       shell: bash
       env:
-        GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
+        EVAL_CONFIG: ${{ inputs.config }}
+        EVAL_BASELINE: ${{ inputs.baseline }}
+        EVAL_SAVE_BASELINE: ${{ inputs.save-baseline }}
+        EVAL_TOLERANCE: ${{ inputs.tolerance }}
+        EVAL_TRACE_DIR: ${{ inputs.trace-dir }}
       run: |
-        ARGS="--config ${{ inputs.config }} --trace-dir ${{ inputs.trace-dir }}"
-        ARGS="$ARGS --tolerance ${{ inputs.tolerance }}"
-        ARGS="$ARGS --github-summary"
+        ARGS=(--config "$EVAL_CONFIG" --tolerance "$EVAL_TOLERANCE")
 
-        if [ -n "${{ inputs.baseline }}" ]; then
-          ARGS="$ARGS --baseline ${{ inputs.baseline }}"
+        if [ -n "$EVAL_BASELINE" ]; then
+          ARGS+=(--baseline "$EVAL_BASELINE")
         fi
 
-        if [ "${{ inputs.save-baseline }}" = "true" ]; then
-          ARGS="$ARGS --save-baseline"
+        if [ -n "$EVAL_SAVE_BASELINE" ]; then
+          ARGS+=(--save-baseline "$EVAL_SAVE_BASELINE")
         fi
 
-        if agent-strace eval ci $ARGS; then
+        if agent-strace --trace-dir "$EVAL_TRACE_DIR" eval "${ARGS[@]}"; then
           echo "passed=true" >> "$GITHUB_OUTPUT"
         else
           echo "passed=false" >> "$GITHUB_OUTPUT"
           exit 1
         fi
 
-        SUMMARY=".agent-traces/eval-summary.md"
-        if [ -f "$SUMMARY" ]; then
-          echo "summary-path=$SUMMARY" >> "$GITHUB_OUTPUT"
+        if [ -n "$GITHUB_STEP_SUMMARY" ] && [ -f "$GITHUB_STEP_SUMMARY" ]; then
+          echo "summary-path=$GITHUB_STEP_SUMMARY" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Upload trace artifacts

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -422,21 +422,47 @@ Flag bad behavior patterns: tool loops, reasoning spirals, budget proximity, con
 
 ### `eval`
 ```
-agent-strace eval [session-id] [--format text|json]
+agent-strace eval [session-id] [--config FILE] [--baseline FILE]
+                  [--save-baseline FILE] [--tolerance N] [--format table|json]
+agent-strace eval run [session-id]
 agent-strace eval compare <session-a> <session-b>
 agent-strace eval ci
 ```
-Score a session against configurable criteria. `eval ci` exits non-zero if any scorer fails.
+Gate the latest or selected session against named, raw-value criteria. The direct
+command exits `1` when a criterion fails or a score regresses beyond the allowed
+tolerance, making it suitable for CI. The `run`, `compare`, and `ci` subcommands
+remain available for legacy normalized scorers.
 
-Configure scorers in `.agent-evals.yaml`:
+Configure named criteria in `.agent-evals.yaml`:
 ```yaml
-scorers:
-  - type: no_errors
-  - type: cost_under
-    max_dollars: 0.10
-  - type: files_scoped
-    allowed_paths: ["src/", "tests/"]
+evals:
+  - name: cost-ceiling
+    scorer: cost_usd
+    threshold: 0.50
+    fail_on: above
+  - name: no-errors
+    scorer: error_count
+    threshold: 0
+    fail_on: above
+  - name: task-completed
+    scorer: session_status
+    expected: completed
+    fail_on: not_equal
 ```
+
+Built-in scorers are `cost_usd`, `error_count`, `session_status`,
+`redundant_read_ratio`, `tool_call_count`, `context_fill_ratio`,
+`duration_seconds`, and `lint_violations`. A custom Python callable can be
+referenced as `package.module:function` and receives session events plus any
+criterion-specific parameters it declares.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--config FILE` | `.agent-evals.yaml` | Named criteria configuration |
+| `--baseline FILE` | — | Compare current raw scores with a saved baseline |
+| `--save-baseline FILE` | — | Save current scores as versioned JSON |
+| `--tolerance N` | `0` | Allowed fractional regression from the baseline |
+| `--format table\|json` | `table` | Human-readable or machine-readable output |
 
 ### `budget-report`
 ```
@@ -666,14 +692,13 @@ The `agent-trace eval` composite action runs evals in CI, posts a scored table t
     config: .agent-evals.yaml
     baseline: .agent-evals-baseline.json
     tolerance: "0.05"
-    save-baseline: "false"
 ```
 
 | Input | Default | Description |
 |---|---|---|
 | `config` | `.agent-evals.yaml` | Eval config file |
 | `baseline` | none | Baseline scores file for regression gating |
-| `save-baseline` | `false` | Overwrite baseline with current scores |
+| `save-baseline` | none | Path to write current scores as a new baseline |
 | `tolerance` | `0.05` | Max allowed score regression (0.0 to 1.0) |
 | `trace-dir` | `.agent-traces` | Session storage directory |
 | `python-version` | `3.12` | Python version |

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.83.0"
+__version__ = "0.84.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -1139,6 +1139,19 @@ def build_parser() -> argparse.ArgumentParser:
     p_eval = sub.add_parser("eval", help="score, compare, and regression-test agent sessions")
     eval_sub = p_eval.add_subparsers(dest="eval_command")
 
+    p_eval_gate = eval_sub.add_parser("gate", help="evaluate named criteria (default)")
+    p_eval_gate.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
+    p_eval_gate.add_argument("--config", default=".agent-evals.yaml",
+                             help="named eval config file (default: .agent-evals.yaml)")
+    p_eval_gate.add_argument("--baseline", metavar="FILE",
+                             help="fail on score regressions from a saved baseline")
+    p_eval_gate.add_argument("--save-baseline", dest="save_baseline", metavar="FILE",
+                             help="write current named scores to a baseline JSON file")
+    p_eval_gate.add_argument("--tolerance", type=float, default=0.0, metavar="N",
+                             help="allowed fractional regression from baseline (default: 0)")
+    p_eval_gate.add_argument("--format", choices=["table", "text", "json"], default="table",
+                             help="output format (default: table)")
+
     p_eval_run = eval_sub.add_parser("run", help="score a session against configured scorers")
     p_eval_run.add_argument("session_id", nargs="?", help="session ID or prefix (default: latest)")
     p_eval_run.add_argument("--format", choices=["table", "json"], default="table")
@@ -1936,9 +1949,45 @@ def _run_with_product_telemetry(args: argparse.Namespace, handler):
     return result
 
 
+_EVAL_EXPLICIT_SUBCOMMANDS = {"gate", "run", "compare", "ci", "dataset"}
+
+
+def _normalise_eval_argv(argv: list[str]) -> list[str]:
+    """Insert the default ``eval gate`` action for the direct CLI form.
+
+    Keeping the explicit legacy subcommands preserves compatibility while
+    allowing ``agent-strace eval [SESSION_ID] --baseline ...`` as documented.
+    """
+    normalised = list(argv)
+    command_index = 0
+    while command_index < len(normalised):
+        current = normalised[command_index]
+        if current == "--trace-dir":
+            command_index += 2
+            continue
+        if current.startswith("--trace-dir=") or current in {"--version"}:
+            command_index += 1
+            continue
+        break
+
+    if command_index >= len(normalised) or normalised[command_index] != "eval":
+        return normalised
+
+    next_index = command_index + 1
+    if next_index >= len(normalised):
+        normalised.insert(next_index, "gate")
+        return normalised
+
+    next_arg = normalised[next_index]
+    if next_arg in {"-h", "--help"} or next_arg in _EVAL_EXPLICIT_SUBCOMMANDS:
+        return normalised
+    normalised.insert(next_index, "gate")
+    return normalised
+
+
 def main() -> None:
     parser = build_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(_normalise_eval_argv(sys.argv[1:]))
 
     if not args.command:
         parser.print_help()

--- a/src/agent_trace/eval/__init__.py
+++ b/src/agent_trace/eval/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from .runner import cmd_eval_run, cmd_eval_compare, cmd_eval_ci
+from .runner import cmd_eval_run, cmd_eval_compare, cmd_eval_ci, cmd_eval_gate
 from .dataset import cmd_dataset
 
 
@@ -17,11 +17,14 @@ def cmd_eval(args: argparse.Namespace) -> int:
     eval_command = getattr(args, "eval_command", None)
     if not eval_command:
         sys.stderr.write(
-            "Usage: agent-strace eval <run|compare|ci|dataset> ...\n"
+            "Usage: agent-strace eval [SESSION_ID] [--config FILE] ...\n"
+            "       agent-strace eval <run|compare|ci|dataset> ...\n"
             "Run `agent-strace eval --help` for details.\n"
         )
         return 1
 
+    if eval_command == "gate":
+        return cmd_eval_gate(args)
     if eval_command == "run":
         return cmd_eval_run(args)
     if eval_command == "compare":

--- a/src/agent_trace/eval/config.py
+++ b/src/agent_trace/eval/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 
 @dataclass
@@ -19,8 +20,21 @@ class ScorerConfig:
 
 
 @dataclass
+class EvalCriterionConfig:
+    """One named, raw-value criterion from the ``evals`` config block."""
+
+    name: str
+    scorer: str
+    fail_on: str
+    threshold: Any = None
+    expected: Any = None
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class EvalConfig:
     scorers: list[ScorerConfig] = field(default_factory=list)
+    evals: list[EvalCriterionConfig] = field(default_factory=list)
     pass_threshold: float = 0.85
     warn_threshold: float = 0.70
 
@@ -220,4 +234,94 @@ def load_config(path: str | Path = ".agent-evals.yaml") -> EvalConfig:
     if not scorers:
         scorers = EvalConfig.default().scorers
 
-    return EvalConfig(scorers=scorers, pass_threshold=pass_t, warn_threshold=warn_t)
+    evals: list[EvalCriterionConfig] = []
+    for raw_eval in data.get("evals", []) or []:
+        try:
+            evals.append(_criterion_from_mapping(raw_eval))
+        except (TypeError, ValueError):
+            # ``load_config`` historically falls back instead of rejecting bad
+            # input.  The strict gate loader below reports schema errors to CI.
+            continue
+
+    return EvalConfig(
+        scorers=scorers,
+        evals=evals,
+        pass_threshold=pass_t,
+        warn_threshold=warn_t,
+    )
+
+
+_FAIL_MODES = {
+    "above",
+    "at_or_above",
+    "below",
+    "at_or_below",
+    "equal",
+    "not_equal",
+}
+
+
+def _criterion_from_mapping(raw: object) -> EvalCriterionConfig:
+    if not isinstance(raw, dict):
+        raise TypeError("each eval must be a mapping")
+
+    name = str(raw.get("name", "")).strip()
+    scorer = str(raw.get("scorer", "")).strip()
+    fail_on = str(raw.get("fail_on", "")).strip().lower().replace("-", "_")
+    if not name:
+        raise ValueError("each eval requires a name")
+    if not scorer:
+        raise ValueError(f"eval {name!r} requires a scorer")
+    if fail_on not in _FAIL_MODES:
+        modes = ", ".join(sorted(_FAIL_MODES))
+        raise ValueError(f"eval {name!r} has invalid fail_on {fail_on!r}; expected one of {modes}")
+
+    threshold = raw.get("threshold")
+    expected = raw.get("expected")
+    if fail_on in {"above", "at_or_above", "below", "at_or_below", "equal"}:
+        if "threshold" not in raw:
+            raise ValueError(f"eval {name!r} requires threshold for fail_on: {fail_on}")
+    elif "expected" not in raw:
+        raise ValueError(f"eval {name!r} requires expected for fail_on: {fail_on}")
+
+    reserved = {"name", "scorer", "threshold", "expected", "fail_on"}
+    params = {key: value for key, value in raw.items() if key not in reserved}
+    return EvalCriterionConfig(
+        name=name,
+        scorer=scorer,
+        fail_on=fail_on,
+        threshold=threshold,
+        expected=expected,
+        params=params,
+    )
+
+
+def load_gate_config(path: str | Path = ".agent-evals.yaml") -> EvalConfig:
+    """Load and strictly validate named eval criteria.
+
+    The legacy :func:`load_config` remains deliberately forgiving.  A CI gate
+    must not silently replace a missing or malformed policy with defaults, so
+    this entry point raises ``FileNotFoundError`` or ``ValueError`` instead.
+    """
+
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"eval config not found: {config_path}")
+    try:
+        data = _parse_minimal_yaml(config_path.read_text(encoding="utf-8"))
+    except OSError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"could not parse eval config {config_path}: {exc}") from exc
+
+    raw_evals = data.get("evals")
+    if not isinstance(raw_evals, list) or not raw_evals:
+        raise ValueError(f"eval config {config_path} must contain a non-empty 'evals' list")
+
+    evals = [_criterion_from_mapping(raw_eval) for raw_eval in raw_evals]
+    names: set[str] = set()
+    for criterion in evals:
+        if criterion.name in names:
+            raise ValueError(f"duplicate eval name: {criterion.name!r}")
+        names.add(criterion.name)
+    return EvalConfig(evals=evals)

--- a/src/agent_trace/eval/runner.py
+++ b/src/agent_trace/eval/runner.py
@@ -11,10 +11,11 @@ import os
 import sys
 from pathlib import Path
 from dataclasses import dataclass, field
+from typing import Any, TextIO
 
 from ..store import TraceStore
-from .config import EvalConfig, load_config
-from .scorers import ScoreResult, run_scorer
+from .config import EvalConfig, EvalCriterionConfig, load_config, load_gate_config
+from .scorers import MetricError, MetricValue, ScoreResult, measure_metric, run_scorer
 
 
 @dataclass
@@ -121,6 +122,316 @@ def format_report_json(report: EvalReport, out=sys.stdout) -> None:
         ],
     }
     out.write(json.dumps(data, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Named eval gates
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CriterionResult:
+    name: str
+    scorer: str
+    score: MetricValue | None
+    fail_on: str
+    threshold: Any = None
+    expected: Any = None
+    criterion_passed: bool = False
+    baseline: MetricValue | None = None
+    regressed: bool = False
+    reason: str = ""
+
+    @property
+    def target(self) -> Any:
+        return self.expected if self.fail_on == "not_equal" else self.threshold
+
+    @property
+    def passed(self) -> bool:
+        return self.criterion_passed and not self.regressed
+
+
+@dataclass
+class GateReport:
+    session_id: str
+    results: list[CriterionResult]
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for result in self.results if not result.passed)
+
+    @property
+    def passed(self) -> int:
+        return len(self.results) - self.failed
+
+    @property
+    def regressions(self) -> int:
+        return sum(1 for result in self.results if result.regressed)
+
+    @property
+    def overall_passed(self) -> bool:
+        return bool(self.results) and self.failed == 0
+
+
+def _numeric(value: object, label: str) -> float:
+    if isinstance(value, bool):
+        raise MetricError(f"{label} must be numeric")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise MetricError(f"{label} must be numeric") from exc
+    if number != number or number in (float("inf"), float("-inf")):
+        raise MetricError(f"{label} must be finite")
+    return number
+
+
+def _criterion_failed(score: MetricValue, criterion: EvalCriterionConfig) -> bool:
+    mode = criterion.fail_on
+    target = criterion.expected if mode == "not_equal" else criterion.threshold
+    if mode in {"above", "at_or_above", "below", "at_or_below"}:
+        actual_number = _numeric(score, f"score from {criterion.scorer!r}")
+        target_number = _numeric(target, f"threshold for {criterion.name!r}")
+        if mode == "above":
+            return actual_number > target_number
+        if mode == "at_or_above":
+            return actual_number >= target_number
+        if mode == "below":
+            return actual_number < target_number
+        return actual_number <= target_number
+    if mode == "equal":
+        return score == target
+    if mode == "not_equal":
+        return score != target
+    raise MetricError(f"unsupported fail_on mode: {mode}")
+
+
+def _is_regression(
+    current: MetricValue,
+    baseline: MetricValue,
+    fail_on: str,
+    tolerance: float,
+) -> bool:
+    lower_is_better = fail_on in {"above", "at_or_above"}
+    higher_is_better = fail_on in {"below", "at_or_below"}
+    if lower_is_better or higher_is_better:
+        current_number = _numeric(current, "current score")
+        baseline_number = _numeric(baseline, "baseline score")
+        # Tolerance is a fractional change.  For a zero baseline, treating the
+        # fraction itself as an absolute allowance keeps zero-cost/count gates
+        # usable while still catching a one-error regression at tolerance .05.
+        allowance = abs(baseline_number) * tolerance
+        if baseline_number == 0:
+            allowance = tolerance
+        if lower_is_better:
+            return current_number > baseline_number + allowance
+        return current_number < baseline_number - allowance
+    return current != baseline
+
+
+def run_eval_gate(
+    store: TraceStore,
+    session_id: str,
+    config: EvalConfig,
+    baseline: dict[str, MetricValue] | None = None,
+    tolerance: float = 0.0,
+) -> GateReport:
+    """Measure and gate one session against named raw-value criteria."""
+
+    if tolerance < 0:
+        raise ValueError("tolerance must be non-negative")
+    events = store.load_events(session_id)
+    results: list[CriterionResult] = []
+    baseline = baseline or {}
+
+    for criterion in config.evals:
+        try:
+            score = measure_metric(
+                criterion.scorer,
+                events,
+                store,
+                session_id,
+                criterion.params,
+            )
+            failed = _criterion_failed(score, criterion)
+            result = CriterionResult(
+                name=criterion.name,
+                scorer=criterion.scorer,
+                score=score,
+                fail_on=criterion.fail_on,
+                threshold=criterion.threshold,
+                expected=criterion.expected,
+                criterion_passed=not failed,
+            )
+            if criterion.name in baseline:
+                result.baseline = baseline[criterion.name]
+                result.regressed = _is_regression(
+                    score,
+                    result.baseline,
+                    criterion.fail_on,
+                    tolerance,
+                )
+                if result.regressed:
+                    result.reason = f"regressed from baseline {result.baseline!r}"
+        except Exception as exc:
+            result = CriterionResult(
+                name=criterion.name,
+                scorer=criterion.scorer,
+                score=None,
+                fail_on=criterion.fail_on,
+                threshold=criterion.threshold,
+                expected=criterion.expected,
+                criterion_passed=False,
+                reason=str(exc),
+            )
+        results.append(result)
+    return GateReport(session_id=session_id, results=results)
+
+
+def _display_value(value: object, scorer: str = "") -> str:
+    if value is None:
+        return "—"
+    if scorer == "cost_usd" and isinstance(value, (int, float)):
+        return f"${value:.4f}"
+    if isinstance(value, float):
+        return f"{value:.4f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def format_gate_table(report: GateReport, out: TextIO = sys.stdout) -> None:
+    """Render a human-readable named-eval result table."""
+
+    name_width = max(20, *(len(result.name) for result in report.results))
+    out.write(f"Eval results — session {report.session_id}\n")
+    out.write("─" * 72 + "\n")
+    out.write(f"{'Eval':<{name_width}}  {'Score':<14}  {'Threshold':<14}  Result\n")
+    out.write("─" * 72 + "\n")
+    for result in report.results:
+        score = _display_value(result.score, result.scorer)
+        target = _display_value(result.target, result.scorer)
+        status = "pass" if result.passed else "fail"
+        suffix = f" — {result.reason}" if result.reason else ""
+        out.write(f"{result.name:<{name_width}}  {score:<14}  {target:<14}  {status}{suffix}\n")
+    out.write("─" * 72 + "\n")
+    overall = "PASS" if report.overall_passed else "FAIL"
+    out.write(f"Overall: {overall} ({report.failed}/{len(report.results)} evals failed)\n")
+
+
+def gate_report_data(report: GateReport) -> dict[str, Any]:
+    return {
+        "session_id": report.session_id,
+        "passed": report.overall_passed,
+        "pass_count": report.passed,
+        "fail_count": report.failed,
+        "regression_count": report.regressions,
+        "results": [
+            {
+                "name": result.name,
+                "scorer": result.scorer,
+                "score": result.score,
+                "threshold": result.threshold,
+                "expected": result.expected,
+                "fail_on": result.fail_on,
+                "baseline": result.baseline,
+                "regressed": result.regressed,
+                "criterion_passed": result.criterion_passed,
+                "passed": result.passed,
+                "reason": result.reason,
+            }
+            for result in report.results
+        ],
+    }
+
+
+def format_gate_json(report: GateReport, out: TextIO = sys.stdout) -> None:
+    out.write(json.dumps(gate_report_data(report), indent=2) + "\n")
+
+
+def save_gate_baseline(path: str | Path, report: GateReport) -> None:
+    """Save raw named scores in a versioned, machine-readable baseline."""
+
+    unavailable = [result.name for result in report.results if result.score is None]
+    if unavailable:
+        raise ValueError(f"cannot save unavailable scores: {', '.join(unavailable)}")
+    baseline_path = Path(path)
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "version": 1,
+        "session_id": report.session_id,
+        "scores": {result.name: result.score for result in report.results},
+    }
+    baseline_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def load_gate_baseline(path: str | Path) -> dict[str, MetricValue]:
+    """Load a named baseline, accepting both versioned and flat mappings."""
+
+    baseline_path = Path(path)
+    try:
+        data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise ValueError(f"baseline not found: {baseline_path}") from None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read baseline {baseline_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"baseline {baseline_path} must be a JSON object")
+    raw_scores = data.get("scores", data)
+    if not isinstance(raw_scores, dict):
+        raise ValueError(f"baseline {baseline_path} has invalid scores")
+
+    scores: dict[str, MetricValue] = {}
+    for name, raw_value in raw_scores.items():
+        value = raw_value.get("score") if isinstance(raw_value, dict) else raw_value
+        if not isinstance(value, (int, float, str, bool)) or value is None:
+            raise ValueError(f"baseline score for {name!r} has an unsupported value")
+        scores[str(name)] = value
+    return scores
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def write_gate_github_summary(
+    report: GateReport,
+    path: str | Path | None = None,
+) -> Path | None:
+    """Append a Markdown result table to the GitHub Actions step summary."""
+
+    destination = Path(path) if path else None
+    if destination is None:
+        env_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if not env_path:
+            return None
+        destination = Path(env_path)
+
+    lines = [
+        "## agent-strace eval",
+        "",
+        "| Eval | Scorer | Score | Threshold | Baseline | Result |",
+        "|---|---|---:|---:|---:|---|",
+    ]
+    for result in report.results:
+        status = "✅ pass" if result.passed else "❌ fail"
+        lines.append(
+            "| "
+            + " | ".join(
+                _markdown_cell(value)
+                for value in (
+                    result.name,
+                    result.scorer,
+                    _display_value(result.score, result.scorer),
+                    _display_value(result.target, result.scorer),
+                    _display_value(result.baseline, result.scorer),
+                    status,
+                )
+            )
+            + " |"
+        )
+    overall = "PASS" if report.overall_passed else "FAIL"
+    lines.extend(("", f"**Overall: {overall}** — {report.failed}/{len(report.results)} evals failed.", ""))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+    return destination
 
 
 # ---------------------------------------------------------------------------
@@ -340,3 +651,62 @@ def cmd_eval_ci(args: argparse.Namespace) -> int:
 
     sys.stderr.write("CI: PASS — all scorers passed\n")
     return 0
+
+
+def cmd_eval_gate(args: argparse.Namespace) -> int:
+    """CLI handler for the named eval-as-a-gate workflow."""
+
+    try:
+        config = load_gate_config(getattr(args, "config", ".agent-evals.yaml"))
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"Eval config error: {exc}\n")
+        return 1
+
+    store = TraceStore(args.trace_dir)
+    session_id = _resolve_session(store, getattr(args, "session_id", None))
+    if not session_id:
+        requested = getattr(args, "session_id", None)
+        if requested:
+            sys.stderr.write(f"Session not found: {requested}\n")
+        else:
+            sys.stderr.write("No sessions found.\n")
+        return 1
+
+    baseline: dict[str, MetricValue] = {}
+    baseline_path = getattr(args, "baseline", None)
+    if baseline_path:
+        try:
+            baseline = load_gate_baseline(baseline_path)
+        except ValueError as exc:
+            sys.stderr.write(f"Baseline error: {exc}\n")
+            return 1
+
+    try:
+        tolerance = float(getattr(args, "tolerance", 0.0) or 0.0)
+        report = run_eval_gate(store, session_id, config, baseline, tolerance)
+    except (OSError, TypeError, ValueError) as exc:
+        sys.stderr.write(f"Eval error: {exc}\n")
+        return 1
+
+    if getattr(args, "format", "table") == "json":
+        format_gate_json(report, out=sys.stdout)
+    else:
+        format_gate_table(report, out=sys.stdout)
+
+    save_path = getattr(args, "save_baseline", None)
+    if save_path:
+        try:
+            save_gate_baseline(save_path, report)
+        except (OSError, ValueError) as exc:
+            sys.stderr.write(f"Baseline error: {exc}\n")
+            return 1
+        sys.stderr.write(f"Baseline saved to {save_path}\n")
+
+    try:
+        write_gate_github_summary(report)
+    except OSError as exc:
+        sys.stderr.write(f"GitHub summary error: {exc}\n")
+        return 1
+    if save_path:
+        return 0
+    return 0 if report.overall_passed else 1

--- a/src/agent_trace/eval/scorers.py
+++ b/src/agent_trace/eval/scorers.py
@@ -7,9 +7,14 @@ built-in scorers.
 
 from __future__ import annotations
 
+import importlib
+import inspect
+import json
+import math
+import os
 import re
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 from ..cost import estimate_cost
 from ..models import EventType, TraceEvent
@@ -27,6 +32,319 @@ class ScoreResult:
     @property
     def status(self) -> str:
         return "pass" if self.passed else "fail"
+
+
+class MetricError(ValueError):
+    """Raised when a raw eval metric cannot be computed reliably."""
+
+
+MetricValue = int | float | str | bool
+
+
+_READ_TOOLS = {
+    "read",
+    "read_file",
+    "file_read",
+    "view",
+    "open_file",
+}
+
+
+def _as_number(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def measure_cost_usd(store: TraceStore, session_id: str) -> float:
+    """Return estimated total session cost in US dollars."""
+
+    return estimate_cost(store, session_id).total_cost
+
+
+def measure_error_count(events: list[TraceEvent]) -> int:
+    """Return the number of explicit error events."""
+
+    return sum(1 for event in events if event.event_type == EventType.ERROR)
+
+
+def measure_session_status(events: list[TraceEvent], meta: object | None = None) -> str:
+    """Classify a session as completed, killed, or timeout."""
+
+    end_event = next(
+        (event for event in reversed(events) if event.event_type == EventType.SESSION_END),
+        None,
+    )
+    if end_event is None:
+        return "completed" if getattr(meta, "ended_at", None) else "killed"
+
+    data = end_event.data
+    explicit = data.get("status") or data.get("session_status")
+    if explicit:
+        normalized = str(explicit).strip().lower().replace("-", "_")
+        if normalized in {"completed", "complete", "success", "succeeded"}:
+            return "completed"
+        if normalized in {"timeout", "timed_out"}:
+            return "timeout"
+        if normalized in {
+            "killed", "cancelled", "canceled", "interrupted", "terminated",
+            "failed", "failure", "aborted", "error",
+        }:
+            return "killed"
+
+    reason = " ".join(
+        str(data.get(key, ""))
+        for key in ("reason", "stop_reason", "termination_reason")
+    ).lower()
+    if "timeout" in reason or "timed out" in reason:
+        return "timeout"
+    if any(word in reason for word in ("kill", "cancel", "interrupt", "terminate")):
+        return "killed"
+
+    exit_code = _as_number(data.get("exit_code"))
+    if exit_code == 124:
+        return "timeout"
+    if exit_code is not None and exit_code != 0:
+        return "killed"
+    return "completed"
+
+
+def _read_path(event: TraceEvent) -> str:
+    if event.event_type == EventType.FILE_READ:
+        return str(
+            event.data.get("path")
+            or event.data.get("file_path")
+            or event.data.get("uri")
+            or ""
+        )
+    if event.event_type != EventType.TOOL_CALL:
+        return ""
+    tool_name = str(event.data.get("tool_name", "")).strip().lower().replace("-", "_")
+    if tool_name not in _READ_TOOLS and not tool_name.endswith(("read_file", "file_read")):
+        return ""
+    arguments = event.data.get("arguments", {}) or {}
+    if not isinstance(arguments, dict):
+        return ""
+    return str(arguments.get("file_path") or arguments.get("path") or arguments.get("uri") or "")
+
+
+def measure_redundant_read_ratio(events: list[TraceEvent]) -> float:
+    """Return repeated reads after the first read divided by all file reads."""
+
+    seen: set[str] = set()
+    reads = 0
+    redundant = 0
+    for event in events:
+        path = _read_path(event)
+        if not path:
+            continue
+        normalized = os.path.normcase(os.path.normpath(path))
+        reads += 1
+        if normalized in seen:
+            redundant += 1
+        else:
+            seen.add(normalized)
+    return redundant / reads if reads else 0.0
+
+
+def measure_tool_call_count(events: list[TraceEvent]) -> int:
+    """Return the number of tool-call events."""
+
+    return sum(1 for event in events if event.event_type == EventType.TOOL_CALL)
+
+
+def _context_payloads(data: dict[str, Any]) -> list[dict[str, Any]]:
+    payloads = [data]
+    usage = data.get("usage")
+    if isinstance(usage, dict):
+        payloads.insert(0, usage)
+    return payloads
+
+
+def measure_context_fill_ratio(
+    events: list[TraceEvent],
+    context_window: float = 200_000,
+) -> float:
+    """Return the maximum observed prompt/context window utilization."""
+
+    configured_window = _as_number(context_window)
+    if configured_window is None or configured_window <= 0:
+        raise MetricError("context_window must be greater than zero")
+
+    maximum = 0.0
+    for event in events:
+        if event.event_type not in {EventType.LLM_REQUEST, EventType.LLM_RESPONSE}:
+            continue
+        data = event.data
+        payloads = _context_payloads(data)
+
+        for payload in payloads:
+            for key in ("context_fill_ratio", "context_usage_ratio"):
+                explicit_ratio = _as_number(payload.get(key))
+                if explicit_ratio is not None:
+                    maximum = max(maximum, explicit_ratio)
+
+        input_tokens: float | None = None
+        for payload in payloads:
+            primary = next(
+                (
+                    number
+                    for key in ("input_tokens", "prompt_tokens")
+                    if (number := _as_number(payload.get(key))) is not None
+                ),
+                None,
+            )
+            if primary is not None:
+                cache_tokens = sum(
+                    _as_number(payload.get(key)) or 0.0
+                    for key in ("cache_read_input_tokens", "cache_creation_input_tokens")
+                )
+                input_tokens = primary + cache_tokens
+                break
+
+        if input_tokens is None and event.event_type == EventType.LLM_REQUEST:
+            context_content = {
+                key: data[key]
+                for key in ("messages", "prompt", "content")
+                if key in data
+            }
+            if context_content:
+                input_tokens = max(1, len(json.dumps(context_content, default=str)) // 4)
+
+        event_window = next(
+            (
+                number
+                for payload in payloads
+                for key in ("context_window", "context_window_tokens", "max_context_tokens")
+                if (number := _as_number(payload.get(key))) is not None and number > 0
+            ),
+            configured_window,
+        )
+        if input_tokens is not None:
+            maximum = max(maximum, input_tokens / event_window)
+    return maximum
+
+
+def measure_duration_seconds(events: list[TraceEvent], meta: object | None = None) -> float:
+    """Return wall-clock session duration in seconds."""
+
+    duration_ms = _as_number(getattr(meta, "total_duration_ms", None))
+    if duration_ms is not None and duration_ms > 0:
+        return duration_ms / 1000.0
+    started_at = _as_number(getattr(meta, "started_at", None))
+    ended_at = _as_number(getattr(meta, "ended_at", None))
+    if started_at is not None and ended_at is not None and ended_at >= started_at:
+        return ended_at - started_at
+    if len(events) < 2:
+        return 0.0
+    timestamps = [event.timestamp for event in events]
+    return max(0.0, max(timestamps) - min(timestamps))
+
+
+def measure_lint_violations(store: TraceStore, session_id: str) -> int:
+    """Return the total number of findings from all enabled lint rules."""
+
+    from ..lint import lint_session
+
+    return len(lint_session(store, session_id).findings)
+
+
+BUILTIN_METRICS = {
+    "cost_usd",
+    "error_count",
+    "session_status",
+    "redundant_read_ratio",
+    "tool_call_count",
+    "context_fill_ratio",
+    "max_context_fill_ratio",
+    "duration_seconds",
+    "lint_violations",
+}
+
+
+def _run_custom_metric(
+    reference: str,
+    events: list[TraceEvent],
+    store: TraceStore,
+    session_id: str,
+    params: dict[str, Any],
+) -> MetricValue:
+    module_name, separator, attribute = reference.partition(":")
+    if not separator:
+        module_name, dot, attribute = reference.rpartition(".")
+        if not dot:
+            raise MetricError(f"unknown scorer: {reference}")
+    if not module_name or not attribute:
+        raise MetricError(f"invalid custom scorer reference: {reference}")
+
+    try:
+        function = getattr(importlib.import_module(module_name), attribute)
+    except (ImportError, AttributeError) as exc:
+        raise MetricError(f"could not load custom scorer {reference!r}: {exc}") from exc
+    if not callable(function):
+        raise MetricError(f"custom scorer {reference!r} is not callable")
+
+    try:
+        signature = inspect.signature(function)
+        parameters = signature.parameters
+        has_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+        if "events" not in parameters and not has_kwargs:
+            return function(events)
+        available = {"events": events, "store": store, "session_id": session_id, **params}
+        kwargs = {
+            key: value
+            for key, value in available.items()
+            if has_kwargs or key in parameters
+        }
+        return function(**kwargs)
+    except MetricError:
+        raise
+    except Exception as exc:
+        raise MetricError(f"custom scorer {reference!r} failed: {exc}") from exc
+
+
+def measure_metric(
+    name: str,
+    events: list[TraceEvent],
+    store: TraceStore,
+    session_id: str,
+    params: dict[str, Any] | None = None,
+) -> MetricValue:
+    """Measure a raw built-in or importable custom scorer value."""
+
+    params = params or {}
+    meta = store.load_meta(session_id)
+    if name == "cost_usd":
+        value: MetricValue = measure_cost_usd(store, session_id)
+    elif name == "error_count":
+        value = measure_error_count(events)
+    elif name == "session_status":
+        value = measure_session_status(events, meta)
+    elif name == "redundant_read_ratio":
+        value = measure_redundant_read_ratio(events)
+    elif name == "tool_call_count":
+        value = measure_tool_call_count(events)
+    elif name in {"context_fill_ratio", "max_context_fill_ratio"}:
+        value = measure_context_fill_ratio(
+            events,
+            context_window=params.get("context_window", params.get("context_window_tokens", 200_000)),
+        )
+    elif name == "duration_seconds":
+        value = measure_duration_seconds(events, meta)
+    elif name == "lint_violations":
+        value = measure_lint_violations(store, session_id)
+    else:
+        value = _run_custom_metric(name, events, store, session_id, params)
+
+    if isinstance(value, float) and not math.isfinite(value):
+        raise MetricError(f"scorer {name!r} returned a non-finite number")
+    if not isinstance(value, (int, float, str, bool)):
+        raise MetricError(f"scorer {name!r} returned unsupported value {type(value).__name__}")
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_gate.py
+++ b/tests/test_eval_gate.py
@@ -1,0 +1,283 @@
+"""Tests for named raw-score eval gates (GitHub issue #210)."""
+
+import argparse
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_trace.eval.config import EvalConfig, EvalCriterionConfig, load_gate_config
+from agent_trace.eval.runner import (
+    cmd_eval_gate,
+    format_gate_json,
+    format_gate_table,
+    load_gate_baseline,
+    run_eval_gate,
+    save_gate_baseline,
+    write_gate_github_summary,
+)
+from agent_trace.eval.scorers import (
+    measure_context_fill_ratio,
+    measure_cost_usd,
+    measure_duration_seconds,
+    measure_error_count,
+    measure_lint_violations,
+    measure_metric,
+    measure_redundant_read_ratio,
+    measure_session_status,
+    measure_tool_call_count,
+)
+from agent_trace.cli import _normalise_eval_argv, build_parser
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+def custom_event_count(events):
+    return len(events)
+
+
+def _event(kind, timestamp, **data):
+    return TraceEvent(event_type=kind, timestamp=timestamp, session_id="gate-session", data=data)
+
+
+class GateTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = TraceStore(self.tmp.name, redact=False)
+        self.meta = SessionMeta(
+            session_id="gate-session",
+            started_at=1_000.0,
+            ended_at=1_042.0,
+            total_duration_ms=42_000,
+        )
+        self.store.create_session(self.meta)
+        self.events = [
+            _event(EventType.SESSION_START, 1_000.0),
+            _event(EventType.LLM_REQUEST, 1_001.0, messages=[{"role": "user", "content": "go"}]),
+            _event(EventType.TOOL_CALL, 1_002.0, tool_name="Read", arguments={"file_path": "src/a.py"}),
+            _event(EventType.TOOL_CALL, 1_003.0, tool_name="read_file", arguments={"path": "src/a.py"}),
+            _event(EventType.FILE_READ, 1_004.0, path="src/b.py"),
+            _event(EventType.TOOL_CALL, 1_005.0, tool_name="Write", arguments={"file_path": "out.txt"}),
+            _event(EventType.ERROR, 1_006.0, message="one error"),
+            _event(
+                EventType.LLM_RESPONSE,
+                1_041.0,
+                usage={"input_tokens": 180_000, "output_tokens": 500},
+                context_window=200_000,
+            ),
+            _event(EventType.SESSION_END, 1_042.0, exit_code=0),
+        ]
+        for event in self.events:
+            self.store.append_event(self.meta.session_id, event)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+
+class TestGateConfig(unittest.TestCase):
+    def test_loads_issue_example_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / ".agent-evals.yaml"
+            path.write_text(
+                "evals:\n"
+                "  - name: cost-ceiling\n"
+                "    scorer: cost_usd\n"
+                "    threshold: 0.50\n"
+                "    fail_on: above\n"
+                "  - name: task-completed\n"
+                "    scorer: session_status\n"
+                "    expected: completed\n"
+                "    fail_on: not_equal\n"
+            )
+            config = load_gate_config(path)
+        self.assertEqual([item.name for item in config.evals], ["cost-ceiling", "task-completed"])
+        self.assertEqual(config.evals[0].threshold, 0.5)
+        self.assertEqual(config.evals[1].expected, "completed")
+
+    def test_missing_eval_list_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "empty.yaml"
+            path.write_text("scorers:\n  - type: no_errors\n")
+            with self.assertRaisesRegex(ValueError, "evals"):
+                load_gate_config(path)
+
+    def test_duplicate_names_are_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "duplicate.yaml"
+            path.write_text(
+                "evals:\n"
+                "  - name: same\n    scorer: error_count\n    threshold: 0\n    fail_on: above\n"
+                "  - name: same\n    scorer: tool_call_count\n    threshold: 2\n    fail_on: above\n"
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                load_gate_config(path)
+
+
+class TestBuiltInMetrics(GateTestCase):
+    def test_cost_usd(self):
+        self.assertGreater(measure_cost_usd(self.store, self.meta.session_id), 0)
+
+    def test_error_count(self):
+        self.assertEqual(measure_error_count(self.events), 1)
+
+    def test_session_status(self):
+        self.assertEqual(measure_session_status(self.events, self.meta), "completed")
+        timeout = [_event(EventType.SESSION_END, 1, exit_code=124)]
+        self.assertEqual(measure_session_status(timeout), "timeout")
+        self.assertEqual(measure_session_status([]), "killed")
+
+    def test_redundant_read_ratio(self):
+        self.assertAlmostEqual(measure_redundant_read_ratio(self.events), 1 / 3)
+
+    def test_tool_call_count(self):
+        self.assertEqual(measure_tool_call_count(self.events), 3)
+
+    def test_context_fill_ratio(self):
+        self.assertAlmostEqual(measure_context_fill_ratio(self.events), 0.9)
+
+    def test_duration_seconds(self):
+        self.assertEqual(measure_duration_seconds(self.events, self.meta), 42.0)
+
+    def test_lint_violations(self):
+        self.assertIsInstance(measure_lint_violations(self.store, self.meta.session_id), int)
+
+    def test_custom_python_callable(self):
+        value = measure_metric(
+            "tests.test_eval_gate:custom_event_count",
+            self.events,
+            self.store,
+            self.meta.session_id,
+        )
+        self.assertEqual(value, len(self.events))
+
+
+class TestRunEvalGate(GateTestCase):
+    def _config(self):
+        return EvalConfig(evals=[
+            EvalCriterionConfig("no-errors", "error_count", "above", threshold=0),
+            EvalCriterionConfig("completed", "session_status", "not_equal", expected="completed"),
+            EvalCriterionConfig("context", "context_fill_ratio", "above", threshold=0.95),
+        ])
+
+    def test_named_criteria_fail_and_pass(self):
+        report = run_eval_gate(self.store, self.meta.session_id, self._config())
+        self.assertFalse(report.overall_passed)
+        self.assertEqual(report.failed, 1)
+        self.assertFalse(report.results[0].passed)
+        self.assertTrue(report.results[1].passed)
+
+    def test_direction_aware_baseline_regression(self):
+        config = EvalConfig(evals=[
+            EvalCriterionConfig("calls", "tool_call_count", "above", threshold=100),
+        ])
+        report = run_eval_gate(
+            self.store,
+            self.meta.session_id,
+            config,
+            baseline={"calls": 2},
+            tolerance=0.10,
+        )
+        self.assertTrue(report.results[0].criterion_passed)
+        self.assertTrue(report.results[0].regressed)
+        self.assertFalse(report.overall_passed)
+
+    def test_tolerance_allows_small_regression(self):
+        config = EvalConfig(evals=[
+            EvalCriterionConfig("context", "context_fill_ratio", "above", threshold=1.0),
+        ])
+        report = run_eval_gate(
+            self.store,
+            self.meta.session_id,
+            config,
+            baseline={"context": 0.85},
+            tolerance=0.10,
+        )
+        self.assertFalse(report.results[0].regressed)
+        self.assertTrue(report.overall_passed)
+
+    def test_unknown_scorer_is_a_failed_eval(self):
+        config = EvalConfig(evals=[
+            EvalCriterionConfig("unknown", "does_not_exist", "above", threshold=1),
+        ])
+        report = run_eval_gate(self.store, self.meta.session_id, config)
+        self.assertFalse(report.overall_passed)
+        self.assertIn("unknown scorer", report.results[0].reason)
+
+    def test_table_and_json_output(self):
+        report = run_eval_gate(self.store, self.meta.session_id, self._config())
+        table = io.StringIO()
+        format_gate_table(report, table)
+        self.assertIn("Eval results — session gate-session", table.getvalue())
+        self.assertIn("Overall: FAIL", table.getvalue())
+        machine = io.StringIO()
+        format_gate_json(report, machine)
+        data = json.loads(machine.getvalue())
+        self.assertEqual(data["session_id"], "gate-session")
+        self.assertEqual(data["fail_count"], 1)
+
+    def test_baseline_round_trip(self):
+        report = run_eval_gate(self.store, self.meta.session_id, self._config())
+        path = Path(self.tmp.name) / "baseline.json"
+        save_gate_baseline(path, report)
+        loaded = load_gate_baseline(path)
+        self.assertEqual(loaded["no-errors"], 1)
+        self.assertEqual(loaded["completed"], "completed")
+
+    def test_github_summary_markdown(self):
+        report = run_eval_gate(self.store, self.meta.session_id, self._config())
+        path = Path(self.tmp.name) / "summary.md"
+        write_gate_github_summary(report, path)
+        summary = path.read_text()
+        self.assertIn("| Eval | Scorer | Score | Threshold | Baseline | Result |", summary)
+        self.assertIn("**Overall: FAIL**", summary)
+
+
+class TestGateCommand(GateTestCase):
+    def test_direct_cli_form_routes_to_gate(self):
+        argv = _normalise_eval_argv(["eval", "gate-session", "--format", "json"])
+        args = build_parser().parse_args(argv)
+        self.assertEqual(args.eval_command, "gate")
+        self.assertEqual(args.session_id, "gate-session")
+        self.assertEqual(args.format, "json")
+
+    def test_legacy_eval_subcommand_is_preserved(self):
+        self.assertEqual(
+            _normalise_eval_argv(["eval", "ci"]),
+            ["eval", "ci"],
+        )
+
+    def test_trace_directory_named_eval_is_not_a_command(self):
+        self.assertEqual(
+            _normalise_eval_argv(["--trace-dir", "eval", "cost"]),
+            ["--trace-dir", "eval", "cost"],
+        )
+
+    def test_exit_one_on_failed_eval_and_json_output(self):
+        config_path = Path(self.tmp.name) / ".agent-evals.yaml"
+        config_path.write_text(
+            "evals:\n"
+            "  - name: no-errors\n"
+            "    scorer: error_count\n"
+            "    threshold: 0\n"
+            "    fail_on: above\n"
+        )
+        args = argparse.Namespace(
+            trace_dir=self.tmp.name,
+            session_id=self.meta.session_id,
+            config=str(config_path),
+            format="json",
+            baseline=None,
+            save_baseline=None,
+            tolerance=0.0,
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            code = cmd_eval_gate(args)
+        self.assertEqual(code, 1)
+        self.assertFalse(json.loads(stdout.getvalue())["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add named raw-value eval criteria for cost, errors, completion status, redundant reads, tool calls, context use, duration, and lint findings
- support versioned baselines, regression tolerance, JSON/table output, custom Python scorers, and GitHub Actions step summaries
- preserve the legacy eval subcommands while making `agent-strace eval [SESSION_ID]` the direct CI gate
- wire the existing composite action to the named-gate workflow safely
- document `.agent-evals.yaml` and bump `agent-strace` from 0.83.0 to 0.84.0

Closes #210

## Verification

- `PYTHONPATH=src python -m unittest tests.test_eval_gate tests.test_eval tests.test_eval_extensions -q` — 96 tests passed
- Ona `test` task — 1,680 Python tests and 3 VS Code extension tests passed
- `python -m compileall -q src/agent_trace && git diff --check`
- wheel build — `agent_strace-0.84.0-py3-none-any.whl`