### PR TITLE
Add provider cost dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace dashboard`](docs/commands.md#dashboard) | Multi-session overview |
 | [`agent-strace budget-report`](docs/commands.md#budget-report) | Weekly spend digest |
 | [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
+| [`agent-strace cost --breakdown provider`](docs/commands.md#cost) | Offline spend by provider and model |
 | [`agent-strace cognitive-debt`](docs/commands.md#cognitive-debt) | Unreviewed agent-written code by session |
 | [`agent-strace context-score`](docs/commands.md#context-score) | Score AGENTS.md and CLAUDE.md from session outcomes |
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -126,14 +126,31 @@ Trace the causal chain backwards from event `#N`. Run `replay` first to see even
 ### `cost`
 ```
 agent-strace cost [session-id] [--model MODEL] [--input-price N] [--output-price N]
+agent-strace cost --breakdown provider [--since DATE_OR_DURATION] [--csv] [--live-pricing]
 ```
 Token and dollar cost by phase. Flags wasted spend on failed phases.
+
+`--breakdown provider` aggregates all stored sessions in the selected window by
+inferred provider and model. It uses actual recorded token counters and a bundled,
+dated pricing snapshot, so the default path makes no network calls. CSV output has
+the stable columns `provider`, `model`, `session_id`, `input_tokens`,
+`output_tokens`, and `cost_usd`.
 
 | Flag | Default | Description |
 |---|---|---|
 | `--model` | `sonnet` | `sonnet`, `opus`, `haiku`, `gpt4`, `gpt4o` |
 | `--input-price` | — | Custom input price per 1M tokens (requires `--output-price`) |
 | `--output-price` | — | Custom output price per 1M tokens (requires `--input-price`) |
+| `--breakdown provider` | — | Aggregate Anthropic, OpenAI, AWS Bedrock, and Gemini usage |
+| `--since DATE_OR_DURATION` | `30d` | ISO date or duration such as `7d`, `24h`, or `2w` |
+| `--csv` | off | Emit raw per-session/model rows instead of the dashboard |
+| `--live-pricing` | off | Request authoritative live rates; error when compatible provider APIs are unavailable rather than scrape or guess |
+
+Pricing estimates exclude caching, batch discounts, regional or service-tier
+differences, long-context premiums, and non-token charges. To update the bundled
+table, check the official URLs in `PRICING_SOURCES`, update `PRICING` and
+`_MODEL_PROVIDERS`, advance `PRICING_SNAPSHOT_DATE`, and extend
+`tests/test_provider_cost.py` for every added model family.
 
 ### `diff`
 ```

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.84.0"
+__version__ = "0.85.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -1102,6 +1102,14 @@ def build_parser() -> argparse.ArgumentParser:
                         help="custom input price per 1M tokens (overrides --model)")
     p_cost.add_argument("--output-price", type=float, dest="output_price",
                         help="custom output price per 1M tokens (overrides --model)")
+    p_cost.add_argument("--breakdown", choices=["provider"],
+                        help="aggregate stored sessions by provider and model")
+    p_cost.add_argument("--since", default="30d", metavar="DATE_OR_DURATION",
+                        help="provider report start date or duration (default: 30d)")
+    p_cost.add_argument("--csv", action="store_true",
+                        help="export raw provider cost rows as CSV")
+    p_cost.add_argument("--live-pricing", dest="live_pricing", action="store_true",
+                        help="request live prices; fail safely when authoritative APIs are unavailable")
 
     # audit
     p_audit = sub.add_parser("audit", help="check session tool calls against a policy file")

--- a/src/agent_trace/cost.py
+++ b/src/agent_trace/cost.py
@@ -7,10 +7,14 @@ tokens to dollar cost using configurable per-model pricing. No API calls.
 from __future__ import annotations
 
 import argparse
+import csv
+import datetime as _datetime
 import json
+import re
 import sys
+import time as _time
 from dataclasses import dataclass, field
-from typing import TextIO
+from typing import Any, Mapping, TextIO
 
 from .explain import ExplainResult, Phase, explain_session
 from .models import EventType, TraceEvent
@@ -21,14 +25,93 @@ from .store import TraceStore
 # Pricing table  (dollars per 1M tokens)
 # ---------------------------------------------------------------------------
 
+PRICING_SNAPSHOT_DATE = "2026-08-16"
+"""Effective date of the bundled, offline pricing snapshot.
+
+Rates are estimates in USD per one million text tokens.  They intentionally
+exclude provider-specific discounts, caching, batch rates, regional pricing,
+long-context tiers, and non-token charges.  Updating this table requires
+checking each URL in ``PRICING_SOURCES``, updating ``PRICING`` and
+``_MODEL_PROVIDERS``, advancing the snapshot date, and extending the
+provider-cost tests for every added model family.
+"""
+
+PRICING_SOURCES: dict[str, str] = {
+    "Anthropic": "https://platform.claude.com/docs/en/about-claude/pricing",
+    "OpenAI": "https://openai.com/api/pricing/",
+    "AWS Bedrock": "https://aws.amazon.com/bedrock/pricing/",
+    "Gemini": "https://ai.google.dev/gemini-api/docs/pricing",
+}
+
+
 PRICING: dict[str, dict[str, float]] = {
+    # Backward-compatible short names used by the existing per-session report.
     "sonnet": {"input": 3.00,  "output": 15.00},
     "opus":   {"input": 15.00, "output": 75.00},
     "haiku":  {"input": 0.25,  "output": 1.25},
     "gpt4":   {"input": 30.00, "output": 60.00},
     "gpt4o":  {"input": 5.00,  "output": 15.00},
+
+    # Anthropic direct API.
+    "claude-opus-4-6": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-5": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-1": {"input": 15.00, "output": 75.00},
+    "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+    "claude-3-7-sonnet": {"input": 3.00, "output": 15.00},
+    "claude-3-5-sonnet": {"input": 3.00, "output": 15.00},
+    "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+    "claude-3-haiku": {"input": 0.25, "output": 1.25},
+    "claude-3-opus": {"input": 15.00, "output": 75.00},
+
+    # OpenAI direct API (standard, non-batch text-token rates).
+    "gpt-4.1": {"input": 2.00, "output": 8.00},
+    "gpt-4.1-mini": {"input": 0.40, "output": 1.60},
+    "gpt-4.1-nano": {"input": 0.10, "output": 0.40},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "o3": {"input": 2.00, "output": 8.00},
+    "o3-mini": {"input": 1.10, "output": 4.40},
+    "o4-mini": {"input": 1.10, "output": 4.40},
+
+    # Amazon models through AWS Bedrock.  Actual charges can vary by region
+    # and inference tier; these are standard on-demand snapshot rates.
+    "amazon.nova-pro-v1": {"input": 0.80, "output": 3.20},
+    "amazon.nova-lite-v1": {"input": 0.06, "output": 0.24},
+    "amazon.nova-micro-v1": {"input": 0.035, "output": 0.14},
+
+    # Google Gemini Developer API paid tier.  The 2.5 Pro entry uses the
+    # <=200k-token tier; long-context requests can cost more.
+    "gemini-2.5-pro": {"input": 1.25, "output": 10.00},
+    "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
+    "gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40},
+    "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
 }
 DEFAULT_MODEL = "sonnet"
+
+
+_MODEL_PROVIDERS: dict[str, str] = {
+    model: provider
+    for provider, models in {
+        "Anthropic": (
+            "claude-opus-4-6", "claude-opus-4-5", "claude-opus-4-1",
+            "claude-sonnet-4", "claude-3-7-sonnet", "claude-3-5-sonnet",
+            "claude-haiku-4-5", "claude-3-haiku", "claude-3-opus",
+        ),
+        "OpenAI": (
+            "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o",
+            "gpt-4o-mini", "o3", "o3-mini", "o4-mini",
+        ),
+        "AWS Bedrock": (
+            "amazon.nova-pro-v1", "amazon.nova-lite-v1",
+            "amazon.nova-micro-v1",
+        ),
+        "Gemini": (
+            "gemini-2.5-pro", "gemini-2.5-flash",
+            "gemini-2.5-flash-lite", "gemini-2.0-flash",
+        ),
+    }.items()
+    for model in models
+}
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +141,89 @@ class CostResult:
     output_tokens: int
     phase_costs: list[PhaseCost]
     wasted_cost: float      # cost from failed phases
+
+
+@dataclass(frozen=True)
+class ModelPrice:
+    """One model's bundled, offline token rates."""
+
+    model_key: str
+    provider: str
+    input_per_million: float
+    output_per_million: float
+
+
+@dataclass(frozen=True)
+class ProviderCostRecord:
+    """Raw provider cost for one model used in one session."""
+
+    provider: str
+    model: str
+    session_id: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class ProviderCostSummary:
+    """Aggregated provider/model totals used by the text dashboard."""
+
+    provider: str
+    model: str
+    sessions: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
+@dataclass
+class ProviderCostReport:
+    """Provider cost records for a selected time window."""
+
+    records: list[ProviderCostRecord]
+    since: str
+    since_timestamp: float
+    generated_at: float
+    pricing_snapshot_date: str = PRICING_SNAPSHOT_DATE
+
+    @property
+    def summaries(self) -> list[ProviderCostSummary]:
+        grouped: dict[tuple[str, str], dict[str, float | int]] = {}
+        for record in self.records:
+            key = (record.provider, record.model)
+            values = grouped.setdefault(
+                key,
+                {"sessions": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
+            )
+            values["sessions"] += 1
+            values["input_tokens"] += record.input_tokens
+            values["output_tokens"] += record.output_tokens
+            values["cost_usd"] += record.cost_usd
+        summaries = [
+            ProviderCostSummary(
+                provider=provider,
+                model=model,
+                sessions=int(values["sessions"]),
+                input_tokens=int(values["input_tokens"]),
+                output_tokens=int(values["output_tokens"]),
+                cost_usd=float(values["cost_usd"]),
+            )
+            for (provider, model), values in grouped.items()
+        ]
+        return sorted(summaries, key=lambda row: (-row.cost_usd, row.provider, row.model))
+
+    @property
+    def total_cost_usd(self) -> float:
+        return sum(record.cost_usd for record in self.records)
+
+    @property
+    def session_count(self) -> int:
+        return len({record.session_id for record in self.records})
+
+
+class LivePricingUnavailable(RuntimeError):
+    """Raised when live pricing is requested without reliable provider APIs."""
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +264,303 @@ def _dollars(input_tokens: int, output_tokens: int, model: str) -> float:
     return (
         input_tokens  / 1_000_000 * pricing["input"] +
         output_tokens / 1_000_000 * pricing["output"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider cost dashboard helpers
+# ---------------------------------------------------------------------------
+
+_BEDROCK_MODEL_RE = re.compile(
+    r"^(?:(?:us|eu|apac|global)\.)?"
+    r"(?:amazon|anthropic|ai21|cohere|meta|mistral|openai|qwen|writer)\."
+)
+_RELATIVE_SINCE_RE = re.compile(r"^(\d+(?:\.\d+)?)([dhw])$", re.IGNORECASE)
+
+
+def infer_provider(model: str) -> str:
+    """Infer a billing provider from a stored model identifier.
+
+    Bedrock inference-profile IDs are detected before their underlying model
+    vendor, so ``us.anthropic.claude-*`` is correctly attributed to AWS rather
+    than Anthropic's direct API.
+    """
+    value = str(model or "").strip().lower()
+    if not value:
+        return "Unknown"
+    if value.startswith(("bedrock/", "aws/bedrock/")) or _BEDROCK_MODEL_RE.match(value):
+        return "AWS Bedrock"
+    if "claude" in value or value.startswith("anthropic/"):
+        return "Anthropic"
+    if "gemini" in value or value.startswith(("google/", "models/gemini")):
+        return "Gemini"
+    if (
+        value.startswith(("gpt-", "chatgpt-", "openai/", "azure/openai/"))
+        or re.match(r"^o[134](?:-|$)", value)
+    ):
+        return "OpenAI"
+    return "Unknown"
+
+
+def _pricing_candidates(model: str) -> list[str]:
+    value = str(model or "").strip().lower()
+    candidates = [value]
+
+    for prefix in ("bedrock/", "aws/bedrock/", "openai/", "anthropic/", "google/"):
+        if value.startswith(prefix):
+            candidates.append(value[len(prefix):])
+    if value.startswith("models/"):
+        candidates.append(value[len("models/"):])
+
+    for candidate in list(candidates):
+        without_region = re.sub(r"^(?:us|eu|apac|global)\.", "", candidate)
+        candidates.append(without_region)
+
+    # Keep order deterministic while removing duplicates.
+    return list(dict.fromkeys(candidates))
+
+
+def get_model_pricing(
+    model: str,
+    pricing_table: Mapping[str, Mapping[str, float]] = PRICING,
+) -> ModelPrice | None:
+    """Return bundled pricing for *model*, including dated model variants.
+
+    Unknown models deliberately return ``None`` rather than silently using the
+    Sonnet fallback retained by :func:`_dollars` for backward compatibility.
+    This keeps the cross-provider dashboard from fabricating spend.
+    """
+    model_keys = sorted(_MODEL_PROVIDERS, key=len, reverse=True)
+    for candidate in _pricing_candidates(model):
+        for key in model_keys:
+            if (
+                candidate == key
+                or candidate.startswith(f"{key}:")
+                or candidate.startswith(f"{key}@")
+                or candidate.startswith(f"{key}-")
+            ):
+                rates = pricing_table.get(key)
+                if rates is None:
+                    return None
+                return ModelPrice(
+                    model_key=key,
+                    provider=infer_provider(model),
+                    input_per_million=float(rates["input"]),
+                    output_per_million=float(rates["output"]),
+                )
+    return None
+
+
+def parse_since(value: str | None, now: float | None = None) -> float:
+    """Parse ``Nd``/``Nh``/``Nw`` or an ISO date into an epoch cutoff.
+
+    Date-only values are interpreted as midnight UTC, making reports stable
+    across machines with different local time zones.
+    """
+    current = _time.time() if now is None else float(now)
+    raw = (value or "30d").strip()
+    match = _RELATIVE_SINCE_RE.fullmatch(raw)
+    if match:
+        amount = float(match.group(1))
+        unit_seconds = {"d": 86400, "h": 3600, "w": 7 * 86400}
+        return current - amount * unit_seconds[match.group(2).lower()]
+
+    try:
+        parsed = _datetime.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot parse --since value: {raw!r}. "
+            "Use an ISO date (2026-06-01) or relative duration (30d)."
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_datetime.timezone.utc)
+    return parsed.timestamp()
+
+
+_INPUT_TOKEN_KEYS = (
+    "input_tokens", "prompt_tokens", "inputTokens", "promptTokenCount",
+    "prompt_token_count",
+)
+_OUTPUT_TOKEN_KEYS = (
+    "output_tokens", "completion_tokens", "outputTokens", "candidatesTokenCount",
+    "completion_token_count",
+)
+
+
+def _token_value(data: Mapping[str, Any], keys: tuple[str, ...]) -> tuple[int, bool]:
+    for key in keys:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, bool):
+            continue
+        try:
+            number = int(value)
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if number >= 0:
+            return number, True
+    return 0, False
+
+
+def _usage_tokens(data: Mapping[str, Any]) -> tuple[int, int, bool, bool]:
+    """Read common provider token-counter shapes without an SDK dependency."""
+    input_tokens, has_input = _token_value(data, _INPUT_TOKEN_KEYS)
+    output_tokens, has_output = _token_value(data, _OUTPUT_TOKEN_KEYS)
+    if has_input or has_output:
+        return input_tokens, output_tokens, has_input, has_output
+
+    nested_candidates = (
+        data.get("usage"),
+        data.get("usage_metadata"),
+        data.get("usageMetadata"),
+        data.get("token_usage"),
+    )
+    response_metadata = data.get("response_metadata")
+    if isinstance(response_metadata, Mapping):
+        nested_candidates += (response_metadata.get("token_usage"),)
+    for nested in nested_candidates:
+        if not isinstance(nested, Mapping):
+            continue
+        input_tokens, has_input = _token_value(nested, _INPUT_TOKEN_KEYS)
+        output_tokens, has_output = _token_value(nested, _OUTPUT_TOKEN_KEYS)
+        if has_input or has_output:
+            return input_tokens, output_tokens, has_input, has_output
+    return 0, 0, False, False
+
+
+def _event_model(data: Mapping[str, Any]) -> str:
+    for key in ("model", "model_id", "modelId"):
+        value = data.get(key)
+        if value:
+            return str(value).strip()
+    return ""
+
+
+@dataclass
+class _UsageSample:
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    has_input: bool = False
+    has_output: bool = False
+
+
+def _session_model_usage(events: list[TraceEvent]) -> dict[str, tuple[int, int]]:
+    """Aggregate usage by model while avoiding request/response double counts."""
+    samples: list[_UsageSample] = []
+    pending: set[int] = set()
+    request_indexes: dict[str, int] = {}
+
+    for event in events:
+        if event.event_type not in {
+            EventType.LLM_REQUEST,
+            EventType.LLM_RESPONSE,
+            EventType.ASSISTANT_RESPONSE,
+        }:
+            continue
+
+        model = _event_model(event.data)
+        inp, out, has_inp, has_out = _usage_tokens(event.data)
+
+        if event.event_type == EventType.LLM_REQUEST:
+            if not model:
+                continue
+            sample = _UsageSample(model, inp, out, has_inp, has_out)
+            samples.append(sample)
+            index = len(samples) - 1
+            pending.add(index)
+            if event.event_id:
+                request_indexes[event.event_id] = index
+            continue
+
+        index = request_indexes.get(event.parent_id) if event.parent_id else None
+        if index is None:
+            for candidate in reversed(range(len(samples))):
+                if candidate in pending and (not model or samples[candidate].model == model):
+                    index = candidate
+                    break
+
+        if index is None:
+            if not model:
+                continue
+            samples.append(_UsageSample(model))
+            index = len(samples) - 1
+        sample = samples[index]
+        if not model:
+            model = sample.model
+        if has_inp:
+            sample.input_tokens = inp
+            sample.has_input = True
+        if has_out:
+            sample.output_tokens = out
+            sample.has_output = True
+        pending.discard(index)
+
+    usage: dict[str, list[int]] = {}
+    for sample in samples:
+        totals = usage.setdefault(sample.model, [0, 0])
+        totals[0] += sample.input_tokens
+        totals[1] += sample.output_tokens
+    return {model: (values[0], values[1]) for model, values in usage.items()}
+
+
+def build_provider_cost_report(
+    store: TraceStore,
+    since: str | None = "30d",
+    *,
+    now: float | None = None,
+    live_pricing: bool = False,
+    pricing_table: Mapping[str, Mapping[str, float]] = PRICING,
+) -> ProviderCostReport:
+    """Aggregate stored session usage by inferred provider and model.
+
+    The default mode is fully offline.  Live pricing fails explicitly because
+    the four providers do not expose a compatible, authoritative pricing API;
+    scraping their billing pages would be less reliable than a dated snapshot.
+    """
+    if live_pricing:
+        raise LivePricingUnavailable(
+            "Live pricing is unavailable: Anthropic, OpenAI, AWS Bedrock, and "
+            "Gemini do not expose one compatible pricing API. Use the bundled "
+            f"offline estimate (snapshot {PRICING_SNAPSHOT_DATE})."
+        )
+
+    generated_at = _time.time() if now is None else float(now)
+    since_value = since or "30d"
+    cutoff = parse_since(since_value, now=generated_at)
+    records: list[ProviderCostRecord] = []
+
+    for meta in store.list_sessions():
+        if meta.started_at < cutoff or meta.started_at > generated_at:
+            continue
+        try:
+            events = store.load_events(meta.session_id)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        for model, (input_tokens, output_tokens) in _session_model_usage(events).items():
+            price = get_model_pricing(model, pricing_table=pricing_table)
+            cost = 0.0
+            if price is not None:
+                cost = (
+                    input_tokens / 1_000_000 * price.input_per_million
+                    + output_tokens / 1_000_000 * price.output_per_million
+                )
+            records.append(ProviderCostRecord(
+                provider=infer_provider(model),
+                model=model,
+                session_id=meta.session_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost,
+            ))
+
+    records.sort(key=lambda row: (row.provider, row.model, row.session_id))
+    return ProviderCostReport(
+        records=records,
+        since=since_value,
+        since_timestamp=cutoff,
+        generated_at=generated_at,
     )
 
 
@@ -181,6 +644,72 @@ def format_cost(result: CostResult, out: TextIO = sys.stdout) -> None:
         w(f"Wasted on failed phases: ${result.wasted_cost:.4f} ({wasted_pct:.0f}%)\n\n")
 
 
+def _since_description(value: str) -> str:
+    match = _RELATIVE_SINCE_RE.fullmatch(value.strip())
+    if not match:
+        return f"since {value}"
+    amount = float(match.group(1))
+    unit = match.group(2).lower()
+    labels = {"d": "day", "h": "hour", "w": "week"}
+    display_amount = str(int(amount)) if amount.is_integer() else str(amount)
+    plural = "" if amount == 1 else "s"
+    return f"last {display_amount} {labels[unit]}{plural}"
+
+
+def format_provider_cost_report(
+    report: ProviderCostReport,
+    out: TextIO = sys.stdout,
+) -> None:
+    """Write the offline provider/model cost dashboard."""
+    summaries = report.summaries
+    provider_width = max([len("Provider"), *(len(row.provider) for row in summaries)])
+    model_width = max([len("Model"), *(len(row.model) for row in summaries)])
+    model_width = min(max(model_width, 24), 44)
+    divider = "─" * (provider_width + model_width + 26)
+
+    out.write(
+        f"Cost breakdown — {_since_description(report.since)}\n"
+        f"Offline estimates · pricing snapshot {report.pricing_snapshot_date}\n"
+        f"{divider}\n"
+        f"{'Provider':<{provider_width}}  {'Model':<{model_width}}  {'Sessions':>8}  {'Cost':>10}\n"
+        f"{divider}\n"
+    )
+    for row in summaries:
+        model = row.model
+        if len(model) > model_width:
+            model = model[:model_width - 1] + "…"
+        out.write(
+            f"{row.provider:<{provider_width}}  {model:<{model_width}}  "
+            f"{row.sessions:>8}  ${row.cost_usd:>9.2f}\n"
+        )
+    out.write(f"{divider}\n")
+    out.write(
+        f"{'Total':<{provider_width}}  {'':<{model_width}}  "
+        f"{report.session_count:>8}  ${report.total_cost_usd:>9.2f}\n"
+    )
+    out.write(f"{divider}\n")
+
+
+def format_provider_cost_csv(
+    report: ProviderCostReport,
+    out: TextIO = sys.stdout,
+) -> None:
+    """Write raw per-session/model rows using the issue's stable columns."""
+    writer = csv.writer(out, lineterminator="\n")
+    writer.writerow([
+        "provider", "model", "session_id", "input_tokens", "output_tokens", "cost_usd",
+    ])
+    for row in report.records:
+        writer.writerow([
+            row.provider,
+            row.model,
+            row.session_id,
+            row.input_tokens,
+            row.output_tokens,
+            f"{row.cost_usd:.8f}",
+        ])
+
+
 # ---------------------------------------------------------------------------
 # CLI handler
 # ---------------------------------------------------------------------------
@@ -188,7 +717,27 @@ def format_cost(result: CostResult, out: TextIO = sys.stdout) -> None:
 def cmd_cost(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
 
-    session_id = args.session_id
+    breakdown = getattr(args, "breakdown", None)
+    if breakdown:
+        if breakdown != "provider":
+            sys.stderr.write(f"Unsupported cost breakdown: {breakdown}\n")
+            return 1
+        try:
+            report = build_provider_cost_report(
+                store,
+                since=getattr(args, "since", None) or "30d",
+                live_pricing=bool(getattr(args, "live_pricing", False)),
+            )
+        except (ValueError, LivePricingUnavailable) as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return 1
+        if getattr(args, "csv", False):
+            format_provider_cost_csv(report, out=sys.stdout)
+        else:
+            format_provider_cost_report(report, out=sys.stdout)
+        return 0
+
+    session_id = getattr(args, "session_id", None)
     if not session_id:
         session_id = store.get_latest_session_id()
     if not session_id:

--- a/tests/test_provider_cost.py
+++ b/tests/test_provider_cost.py
@@ -1,0 +1,283 @@
+"""Tests for the provider cost dashboard (issue #208)."""
+
+import argparse
+import csv
+import datetime
+import io
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from agent_trace.cost import (
+    LivePricingUnavailable,
+    PRICING_SNAPSHOT_DATE,
+    PRICING_SOURCES,
+    ProviderCostRecord,
+    ProviderCostReport,
+    build_provider_cost_report,
+    cmd_cost,
+    format_provider_cost_csv,
+    format_provider_cost_report,
+    get_model_pricing,
+    infer_provider,
+    parse_since,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+
+
+NOW = datetime.datetime(2026, 8, 16, tzinfo=datetime.timezone.utc).timestamp()
+
+
+class ProviderCostStore:
+    def __init__(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TraceStore(self.temp_dir.name)
+
+    def close(self):
+        self.temp_dir.cleanup()
+
+    def add_session(self, session_id, started_at, model, request_data=None, response_data=None):
+        meta = SessionMeta(session_id=session_id, started_at=started_at)
+        self.store.create_session(meta)
+        request = TraceEvent(
+            event_type=EventType.LLM_REQUEST,
+            timestamp=started_at,
+            session_id=session_id,
+            data={"model": model, **(request_data or {})},
+        )
+        response_payload = {"model": model, **(response_data or {})}
+        response = TraceEvent(
+            event_type=EventType.LLM_RESPONSE,
+            timestamp=started_at + 1,
+            session_id=session_id,
+            parent_id=request.event_id,
+            data=response_payload,
+        )
+        self.store.append_event(session_id, request)
+        self.store.append_event(session_id, response)
+        return meta
+
+
+class TestProviderInferenceAndPricing(unittest.TestCase):
+    def test_infers_all_supported_providers(self):
+        cases = {
+            "claude-opus-4-6": "Anthropic",
+            "openai/gpt-4o": "OpenAI",
+            "o3": "OpenAI",
+            "us.amazon.nova-pro-v1:0": "AWS Bedrock",
+            "us.anthropic.claude-sonnet-4-v1:0": "AWS Bedrock",
+            "models/gemini-2.5-pro": "Gemini",
+        }
+        for model, provider in cases.items():
+            with self.subTest(model=model):
+                self.assertEqual(infer_provider(model), provider)
+
+    def test_snapshot_has_a_rate_for_each_provider(self):
+        cases = (
+            ("claude-opus-4-6-20260801", "Anthropic"),
+            ("gpt-4o-2024-11-20", "OpenAI"),
+            ("us.amazon.nova-pro-v1:0", "AWS Bedrock"),
+            ("models/gemini-2.5-pro-preview", "Gemini"),
+        )
+        for model, provider in cases:
+            with self.subTest(model=model):
+                price = get_model_pricing(model)
+                self.assertIsNotNone(price)
+                self.assertEqual(price.provider, provider)
+                self.assertGreater(price.input_per_million, 0)
+                self.assertGreater(price.output_per_million, 0)
+
+    def test_unknown_model_does_not_use_a_silent_fallback(self):
+        self.assertIsNone(get_model_pricing("vendor/future-model"))
+
+    def test_pricing_snapshot_is_explicitly_versioned(self):
+        datetime.date.fromisoformat(PRICING_SNAPSHOT_DATE)
+        self.assertEqual(
+            set(PRICING_SOURCES), {"Anthropic", "OpenAI", "AWS Bedrock", "Gemini"},
+        )
+
+
+class TestParseSince(unittest.TestCase):
+    def test_relative_days(self):
+        self.assertEqual(parse_since("30d", now=NOW), NOW - 30 * 86400)
+
+    def test_relative_weeks(self):
+        self.assertEqual(parse_since("2w", now=NOW), NOW - 14 * 86400)
+
+    def test_date_is_midnight_utc(self):
+        expected = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc).timestamp()
+        self.assertEqual(parse_since("2026-06-01", now=NOW), expected)
+
+    def test_invalid_value_has_actionable_error(self):
+        with self.assertRaisesRegex(ValueError, "relative duration"):
+            parse_since("last month", now=NOW)
+
+
+class TestProviderCostReport(unittest.TestCase):
+    def setUp(self):
+        self.fixture = ProviderCostStore()
+
+    def tearDown(self):
+        self.fixture.close()
+
+    def test_aggregates_provider_model_sessions_and_actual_usage(self):
+        # Response usage replaces request-side counters for the same call,
+        # rather than double-counting the input tokens.
+        self.fixture.add_session(
+            "anthropic-1",
+            NOW - 86400,
+            "claude-opus-4-6",
+            request_data={"input_tokens": 123},
+            response_data={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        )
+        self.fixture.add_session(
+            "openai-1",
+            NOW - 86400,
+            "gpt-4o",
+            response_data={"usage": {"prompt_tokens": 1000, "completion_tokens": 2000}},
+        )
+        self.fixture.add_session(
+            "bedrock-1",
+            NOW - 86400,
+            "us.amazon.nova-pro-v1:0",
+            response_data={"usage": {"inputTokens": 3000, "outputTokens": 4000}},
+        )
+        self.fixture.add_session(
+            "gemini-1",
+            NOW - 86400,
+            "models/gemini-2.5-pro",
+            response_data={
+                "usageMetadata": {"promptTokenCount": 5000, "candidatesTokenCount": 6000}
+            },
+        )
+
+        report = build_provider_cost_report(self.fixture.store, since="7d", now=NOW)
+        self.assertEqual(len(report.records), 4)
+        self.assertEqual(
+            {row.provider for row in report.summaries},
+            {"Anthropic", "OpenAI", "AWS Bedrock", "Gemini"},
+        )
+        anthropic = next(row for row in report.records if row.provider == "Anthropic")
+        self.assertEqual(anthropic.input_tokens, 1_000_000)
+        self.assertEqual(anthropic.output_tokens, 1_000_000)
+        self.assertAlmostEqual(anthropic.cost_usd, 30.0)
+
+    def test_filters_old_and_future_sessions(self):
+        self.fixture.add_session(
+            "included", NOW - 2 * 86400, "gpt-4o",
+            response_data={"input_tokens": 100, "output_tokens": 100},
+        )
+        self.fixture.add_session(
+            "old", NOW - 31 * 86400, "gpt-4o",
+            response_data={"input_tokens": 100, "output_tokens": 100},
+        )
+        self.fixture.add_session(
+            "future", NOW + 86400, "gpt-4o",
+            response_data={"input_tokens": 100, "output_tokens": 100},
+        )
+        report = build_provider_cost_report(self.fixture.store, since="30d", now=NOW)
+        self.assertEqual([row.session_id for row in report.records], ["included"])
+
+    def test_groups_multiple_sessions_for_the_same_provider_model(self):
+        for session_id in ("one", "two"):
+            self.fixture.add_session(
+                session_id, NOW - 1, "gpt-4o",
+                response_data={"input_tokens": 100, "output_tokens": 200},
+            )
+        report = build_provider_cost_report(self.fixture.store, since="7d", now=NOW)
+        self.assertEqual(len(report.summaries), 1)
+        self.assertEqual(report.summaries[0].provider, "OpenAI")
+        self.assertEqual(report.summaries[0].sessions, 2)
+        self.assertEqual(report.summaries[0].input_tokens, 200)
+        self.assertEqual(report.summaries[0].output_tokens, 400)
+
+    def test_unknown_model_is_visible_with_zero_estimated_cost(self):
+        self.fixture.add_session(
+            "unknown", NOW - 1, "acme-future-1",
+            response_data={"input_tokens": 1000, "output_tokens": 2000},
+        )
+        report = build_provider_cost_report(self.fixture.store, since="7d", now=NOW)
+        self.assertEqual(report.records[0].provider, "Unknown")
+        self.assertEqual(report.records[0].cost_usd, 0.0)
+
+    def test_default_mode_makes_no_network_call(self):
+        self.fixture.add_session(
+            "offline", NOW - 1, "gpt-4o",
+            response_data={"input_tokens": 100, "output_tokens": 200},
+        )
+        with patch("socket.create_connection", side_effect=AssertionError("network called")):
+            report = build_provider_cost_report(self.fixture.store, since="7d", now=NOW)
+        self.assertEqual(len(report.records), 1)
+
+    def test_live_pricing_fails_instead_of_fabricating_rates(self):
+        with self.assertRaisesRegex(LivePricingUnavailable, "compatible pricing API"):
+            build_provider_cost_report(
+                self.fixture.store, since="7d", now=NOW, live_pricing=True,
+            )
+
+
+class TestProviderCostFormatting(unittest.TestCase):
+    def setUp(self):
+        self.fixture = ProviderCostStore()
+        self.fixture.add_session(
+            "csv-session", NOW - 1, "gpt-4o",
+            response_data={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        )
+        self.report = build_provider_cost_report(self.fixture.store, since="7d", now=NOW)
+
+    def tearDown(self):
+        self.fixture.close()
+
+    def test_csv_has_exact_raw_columns(self):
+        output = io.StringIO()
+        format_provider_cost_csv(self.report, output)
+        rows = list(csv.DictReader(io.StringIO(output.getvalue())))
+        self.assertEqual(
+            list(rows[0]),
+            ["provider", "model", "session_id", "input_tokens", "output_tokens", "cost_usd"],
+        )
+        self.assertEqual(rows[0]["session_id"], "csv-session")
+        self.assertEqual(rows[0]["input_tokens"], "1000000")
+
+    def test_text_marks_rates_as_offline_snapshot(self):
+        output = io.StringIO()
+        format_provider_cost_report(self.report, output)
+        text = output.getvalue()
+        self.assertIn("Cost breakdown — last 7 days", text)
+        self.assertIn("Offline estimates", text)
+        self.assertIn(PRICING_SNAPSHOT_DATE, text)
+        self.assertIn("OpenAI", text)
+
+    def test_text_total_counts_unique_sessions_not_model_rows(self):
+        report = ProviderCostReport(
+            records=[
+                ProviderCostRecord("OpenAI", "gpt-4o", "same", 10, 20, 0.1),
+                ProviderCostRecord("Anthropic", "claude-sonnet-4", "same", 10, 20, 0.2),
+            ],
+            since="7d",
+            since_timestamp=NOW - 7 * 86400,
+            generated_at=NOW,
+        )
+        output = io.StringIO()
+        format_provider_cost_report(report, output)
+        total_line = next(line for line in output.getvalue().splitlines() if line.startswith("Total"))
+        self.assertEqual(total_line.split()[-3], "1")
+
+    def test_command_handler_uses_provider_dashboard_path(self):
+        args = argparse.Namespace(
+            trace_dir=self.fixture.temp_dir.name,
+            session_id=None,
+            breakdown="provider",
+            since="7d",
+            csv=True,
+            live_pricing=False,
+        )
+        stdout = io.StringIO()
+        with patch("sys.stdout", stdout):
+            self.assertEqual(cmd_cost(args), 0)
+        self.assertTrue(stdout.getvalue().startswith("provider,model,session_id"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `agent-strace cost --breakdown provider` across stored Anthropic, OpenAI, AWS Bedrock, and Gemini sessions
- infer providers from recorded model IDs and calculate spend from actual input/output token counters
- bundle an explicitly dated offline pricing snapshot with official maintainer sources and no default network calls
- support ISO/relative `--since` filters and exact raw CSV export columns
- make `--live-pricing` fail explicitly when compatible authoritative pricing APIs are unavailable instead of scraping or inventing rates
- document pricing limitations/update steps and bump `agent-strace` from 0.84.0 to 0.85.0

Closes #208

## Verification

- `PYTHONPATH=src python -m unittest tests.test_cost tests.test_provider_cost tests.test_explain tests.test_timeline tests.test_telemetry -q` — 139 tests passed
- Ona `test` task — 1,682 Python tests and 3 VS Code extension tests passed
- `python -m compileall -q src/agent_trace && git diff --check`
- wheel build — `agent_strace-0.85.0-py3-none-any.whl`