### PR TITLE
Add Temporal trace parenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | Command | What it does |
 |---|---|
 | [`agent-strace export --format otlp-genai`](docs/production.md) | Export to Datadog, Honeycomb, Grafana, Jaeger |
+| [`agent-strace export --format temporal`](docs/integrations.md#temporal-workflows) | Nest agent spans under Temporal activities |
 | [`agent-strace export --format eu-ai-act`](docs/commands.md#export) | Generate Article 12/13 audit packages |
 | [`agent-strace export --metrics`](docs/production.md#behavioral-metrics) | Export per-session behavioral metrics as OTLP gauges |
 | [`agent-strace identity show`](docs/commands.md#identity) | Machine identity — sign and verify sessions |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -588,12 +588,17 @@ Track changes to AGENTS.md and other config files. `check` exits 1 when config h
 
 ### `export`
 ```
-agent-strace export <session-id> [--format json|csv|ndjson|otlp|otlp-genai|eu-ai-act]
+agent-strace export <session-id> [--format json|csv|ndjson|otlp|otlp-genai|temporal|eu-ai-act]
                     [--endpoint URL] [--header KEY:VALUE] [--service-name NAME]
                     [--anonymize] [--scores] [--metrics] [--backend otlp|langfuse]
                     [--all] [--since DURATION_OR_DATE] [--until DATE] [--output FILE]
 ```
 Export a session. See [production.md](production.md) for per-backend OTLP setup.
+
+`--format temporal` emits OTLP/HTTP JSON using the upstream W3C trace ID and
+Temporal activity parent span previously captured by `watch`. It can be written
+to a file or sent directly with `--endpoint`. See
+[Temporal workflows](integrations.md#temporal-workflows).
 
 `--format eu-ai-act` writes a structured JSON package with Article 12 logging
 evidence, Article 13 transparency documentation, hash-chain integrity metadata,

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -206,3 +206,37 @@ if ctx:
 Pass `trace_id` from the extracted context into `inject_traceparent` on any further outbound calls to propagate the same trace ID through the full call chain.
 
 The implementation follows [W3C Trace Context Level 1](https://www.w3.org/TR/trace-context/). No third-party dependencies required.
+
+---
+
+## Temporal workflows
+
+Agent spans can be attached beneath an existing Temporal activity span without
+adding the Temporal SDK to agent-strace. Expose the activity's W3C `traceparent`
+to the agent process as `AGENT_STRACE_TEMPORAL_TRACE_PARENT` (preferred) or
+`TEMPORAL_TRACE_PARENT`, then start the normal watcher:
+
+```bash
+export AGENT_STRACE_TEMPORAL_TRACE_PARENT="00-<trace-id>-<activity-span-id>-01"
+agent-strace watch "$AGENT_SESSION_ID"
+```
+
+The watcher validates the value and stores the upstream trace ID, parent span
+ID, and trace flags in additive session metadata. This makes later exports work
+after the activity process exits:
+
+```bash
+# Write inspectable OTLP/JSON
+agent-strace export "$AGENT_SESSION_ID" --format temporal --output temporal-trace.json
+
+# Or send it to Jaeger, Tempo, Datadog, or another OTLP/HTTP collector
+agent-strace export "$AGENT_SESSION_ID" --format temporal \
+  --endpoint http://localhost:4318 \
+  --header "Authorization: Bearer $OTLP_TOKEN"
+```
+
+The session root span reuses Temporal's trace ID and sets the Temporal activity
+span as its parent; LLM and tool spans remain children of the session root. The
+setup belongs in the activity worker or agent launcher, so Temporal workflow
+definitions do not need to change. Export remains HTTP/JSON only and uses no
+Temporal, OpenTelemetry, or gRPC runtime dependency.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.85.0"
+__version__ = "0.86.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -376,10 +376,11 @@ def cmd_export(args: argparse.Namespace) -> int:
         for e in events:
             sys.stdout.write(e.to_json() + "\n")
 
-    elif args.format in ("otlp", "otlp-genai"):
+    elif args.format in ("otlp", "otlp-genai", "temporal"):
         from .otlp import export_otlp, session_to_otlp, session_to_otlp_genai
 
         use_genai = args.format == "otlp-genai"
+        use_temporal = args.format == "temporal"
         endpoint = args.endpoint
 
         # When --endpoint is set and format is plain otlp, default to otlp-genai
@@ -391,13 +392,20 @@ def cmd_export(args: argparse.Namespace) -> int:
         if not endpoint:
             # No endpoint: write OTLP JSON to --output file or stdout
             meta = store.load_meta(session_id)
-            if use_genai:
-                payload = session_to_otlp_genai(meta, events, service_name=args.service_name)
-            else:
-                payload = session_to_otlp(meta, events, service_name=args.service_name)
+            try:
+                if use_temporal:
+                    from .temporal import session_to_temporal_otlp
+                    payload = session_to_temporal_otlp(meta, events, service_name=args.service_name)
+                elif use_genai:
+                    payload = session_to_otlp_genai(meta, events, service_name=args.service_name)
+                else:
+                    payload = session_to_otlp(meta, events, service_name=args.service_name)
+            except ValueError as exc:
+                sys.stderr.write(f"Temporal export failed: {exc}\n")
+                return 1
             output_path = getattr(args, "output", "") or ""
             if not output_path:
-                fmt_suffix = "otlp-genai" if use_genai else "otlp"
+                fmt_suffix = args.format
                 output_path = f"trace-{session_id[:12]}-{fmt_suffix}.json"
             with open(output_path, "w") as f:
                 f.write(json.dumps(payload, indent=2) + "\n")
@@ -412,7 +420,17 @@ def cmd_export(args: argparse.Namespace) -> int:
                 key, val = h.split(":", 1)
                 headers[key.strip()] = val.strip()
 
-        if use_genai:
+        if use_temporal:
+            from .temporal import export_temporal_otlp
+            ok = export_temporal_otlp(
+                store=store,
+                session_id=session_id,
+                endpoint=endpoint,
+                headers=headers,
+                service_name=args.service_name,
+            )
+            return 0 if ok else 1
+        elif use_genai:
             # Export using GenAI conventions
             import urllib.request, urllib.error
             meta = store.load_meta(session_id)
@@ -984,9 +1002,9 @@ def build_parser() -> argparse.ArgumentParser:
     # export
     p_export = sub.add_parser("export", help="export a session")
     p_export.add_argument("session_id", nargs="?", help="session ID or prefix")
-    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp", "otlp-genai", "eu-ai-act"],
+    p_export.add_argument("--format", choices=["json", "csv", "ndjson", "otlp", "otlp-genai", "temporal", "eu-ai-act"],
                           default="json",
-                          help="output format (otlp-genai uses strict OTel GenAI semantic conventions)")
+                          help="output format (temporal preserves an upstream activity parent span)")
     p_export.add_argument("--endpoint", help="OTLP collector URL (e.g. http://localhost:4318)")
     p_export.add_argument("--header", action="append", help="HTTP header for OTLP (e.g. 'x-honeycomb-team: KEY')")
     p_export.add_argument("--service-name", default="agent-trace", help="OTel service name (default: agent-trace)")

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -97,6 +97,12 @@ class SessionMeta:
     workspace_id: str = ""
     # Attribution (who/what started this session)
     attribution: dict = field(default_factory=dict)
+    # Upstream W3C trace context (optional).  Integrations such as Temporal
+    # persist these fields so an offline OTLP export can retain the original
+    # distributed trace and parent span.
+    trace_id: str = ""
+    parent_span_id: str = ""
+    trace_flags: str = ""
     # True when secret redaction changed or protected session metadata
     redacted: bool = False
 

--- a/src/agent_trace/otlp.py
+++ b/src/agent_trace/otlp.py
@@ -708,6 +708,21 @@ def export_otlp(
         return False
 
     payload = session_to_otlp(meta, events, service_name)
+    return export_otlp_payload(
+        payload,
+        endpoint,
+        headers=headers,
+        event_count=len(events),
+    )
+
+
+def export_otlp_payload(
+    payload: dict,
+    endpoint: str,
+    headers: dict[str, str] | None = None,
+    event_count: int = 0,
+) -> bool:
+    """Send a prepared ExportTraceServiceRequest via OTLP/HTTP JSON."""
     body = json.dumps(payload).encode("utf-8")
 
     # POST to /v1/traces
@@ -725,7 +740,7 @@ def export_otlp(
         with urllib.request.urlopen(req, timeout=30) as resp:
             status = resp.status
             if status in (200, 202):
-                sys.stderr.write(f"Exported {len(events)} events to {url} (HTTP {status})\n")
+                sys.stderr.write(f"Exported {event_count} events to {url} (HTTP {status})\n")
                 return True
             else:
                 sys.stderr.write(f"OTLP export returned HTTP {status}\n")

--- a/src/agent_trace/temporal.py
+++ b/src/agent_trace/temporal.py
@@ -1,0 +1,170 @@
+"""Temporal trace-context integration.
+
+Temporal's OpenTelemetry interceptor propagates W3C trace context to
+activities.  Agent processes can expose that context through
+``AGENT_STRACE_TEMPORAL_TRACE_PARENT`` (or the shorter
+``TEMPORAL_TRACE_PARENT`` compatibility name).  This module stores the
+upstream trace and span IDs on the session and emits GenAI OTLP/HTTP JSON
+spans beneath the Temporal activity span.
+
+No Temporal or OpenTelemetry SDK is required.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .models import SessionMeta, TraceEvent
+from .otlp import export_otlp_payload, session_to_otlp_genai
+from .propagation import extract_traceparent
+from .store import TraceStore
+
+
+TEMPORAL_TRACE_PARENT_ENV = "AGENT_STRACE_TEMPORAL_TRACE_PARENT"
+TEMPORAL_TRACE_PARENT_FALLBACK_ENV = "TEMPORAL_TRACE_PARENT"
+
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+_FLAGS_RE = re.compile(r"^[0-9a-f]{2}$")
+
+
+@dataclass(frozen=True)
+class TemporalTraceContext:
+    """The upstream Temporal activity's W3C trace context."""
+
+    trace_id: str
+    parent_span_id: str
+    trace_flags: str
+    source_env: str = TEMPORAL_TRACE_PARENT_ENV
+
+
+def _validate_ids(trace_id: str, parent_span_id: str, trace_flags: str) -> None:
+    """Validate the W3C fields needed by the OTLP exporter."""
+    if not _TRACE_ID_RE.fullmatch(trace_id) or trace_id == "0" * 32:
+        raise ValueError("traceparent contains an invalid trace ID")
+    if not _SPAN_ID_RE.fullmatch(parent_span_id) or parent_span_id == "0" * 16:
+        raise ValueError("traceparent contains an invalid parent span ID")
+    if not _FLAGS_RE.fullmatch(trace_flags):
+        raise ValueError("traceparent contains invalid trace flags")
+
+
+def parse_temporal_traceparent(
+    value: str,
+    source_env: str = TEMPORAL_TRACE_PARENT_ENV,
+) -> TemporalTraceContext:
+    """Parse a Temporal W3C ``traceparent`` environment value.
+
+    ``ValueError`` is raised for malformed or unusable trace context so a
+    configured activity never silently exports into a separate trace.
+    """
+    parsed = extract_traceparent({"traceparent": value})
+    if parsed is None or parsed["version"] == "ff":
+        raise ValueError(f"{source_env} is not a valid W3C traceparent")
+
+    trace_id = parsed["trace_id"]
+    parent_span_id = parsed["parent_id"]
+    trace_flags = parsed["flags"]
+    _validate_ids(trace_id, parent_span_id, trace_flags)
+    return TemporalTraceContext(
+        trace_id=trace_id,
+        parent_span_id=parent_span_id,
+        trace_flags=trace_flags,
+        source_env=source_env,
+    )
+
+
+def get_temporal_trace_context(
+    environ: Mapping[str, str] | None = None,
+) -> TemporalTraceContext | None:
+    """Read Temporal trace context from the supported environment names.
+
+    The agent-strace-specific name takes precedence when both are set.
+    """
+    env = os.environ if environ is None else environ
+    for name in (TEMPORAL_TRACE_PARENT_ENV, TEMPORAL_TRACE_PARENT_FALLBACK_ENV):
+        value = env.get(name, "").strip()
+        if value:
+            return parse_temporal_traceparent(value, source_env=name)
+    return None
+
+
+def attach_temporal_trace_context(
+    store: TraceStore,
+    session_id: str,
+    environ: Mapping[str, str] | None = None,
+) -> TemporalTraceContext | None:
+    """Persist the current Temporal activity context on a stored session."""
+    context = get_temporal_trace_context(environ)
+    if context is None:
+        return None
+
+    meta = store.load_meta(session_id)
+    meta.trace_id = context.trace_id
+    meta.parent_span_id = context.parent_span_id
+    meta.trace_flags = context.trace_flags
+    store.update_meta(meta)
+    return context
+
+
+def session_to_temporal_otlp(
+    meta: SessionMeta,
+    events: list[TraceEvent],
+    service_name: str = "agent-trace",
+) -> dict:
+    """Convert a session into OTLP JSON parented to a Temporal activity."""
+    trace_id = meta.trace_id.lower()
+    parent_span_id = meta.parent_span_id.lower()
+    trace_flags = (meta.trace_flags or "01").lower()
+    if not trace_id or not parent_span_id:
+        raise ValueError(
+            "session has no Temporal trace context; run watch with "
+            f"{TEMPORAL_TRACE_PARENT_ENV} set"
+        )
+    _validate_ids(trace_id, parent_span_id, trace_flags)
+
+    payload = session_to_otlp_genai(
+        meta,
+        events,
+        service_name=service_name,
+        parent_span_id=parent_span_id,
+        parent_trace_id=trace_id,
+    )
+
+    # OTLP Span.flags carries the W3C sampled/debug bits.  Apply it to the
+    # complete local subtree so collectors preserve the upstream decision.
+    flags = int(trace_flags, 16)
+    for resource_spans in payload.get("resourceSpans", []):
+        for scope_spans in resource_spans.get("scopeSpans", []):
+            for span in scope_spans.get("spans", []):
+                span["flags"] = flags
+    return payload
+
+
+def export_temporal_otlp(
+    store: TraceStore,
+    session_id: str,
+    endpoint: str,
+    headers: dict[str, str] | None = None,
+    service_name: str = "agent-trace",
+) -> bool:
+    """Export one Temporal-parented session via OTLP/HTTP JSON."""
+    meta = store.load_meta(session_id)
+    events = store.load_events(session_id)
+    if not events:
+        sys.stderr.write(f"No events for session {session_id}\n")
+        return False
+    try:
+        payload = session_to_temporal_otlp(meta, events, service_name=service_name)
+    except ValueError as exc:
+        sys.stderr.write(f"Temporal export failed: {exc}\n")
+        return False
+    return export_otlp_payload(
+        payload,
+        endpoint,
+        headers=headers,
+        event_count=len(events),
+    )

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -1121,6 +1121,22 @@ def watch_session(
         out.write(f"[watch] events file not found: {events_file}\n")
         return
 
+    # Temporal's OTel interceptor can pass the activity's W3C traceparent to
+    # the agent process.  Persist it before tailing so later/offline exports
+    # remain children of the activity span even after the environment is gone.
+    try:
+        from .temporal import attach_temporal_trace_context
+
+        temporal_context = attach_temporal_trace_context(store, session_id)
+    except ValueError as exc:
+        out.write(f"[watch] Invalid Temporal trace context: {exc}\n")
+        temporal_context = None
+    if temporal_context is not None:
+        out.write(
+            "[watch] Attached Temporal parent span "
+            f"{temporal_context.parent_span_id}\n"
+        )
+
     state = WatchState(start_time=time.time())
 
     mode = " [dry-run]" if dry_run else ""

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,250 @@
+"""Tests for Temporal W3C parenting and OTLP export (issue #209)."""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agent_trace.cli import build_parser, cmd_export
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.store import TraceStore
+from agent_trace.temporal import (
+    TEMPORAL_TRACE_PARENT_ENV,
+    TEMPORAL_TRACE_PARENT_FALLBACK_ENV,
+    attach_temporal_trace_context,
+    export_temporal_otlp,
+    get_temporal_trace_context,
+    parse_temporal_traceparent,
+    session_to_temporal_otlp,
+)
+from agent_trace.watch import WatcherConfig, watch_session
+
+
+TRACE_ID = "a" * 32
+PARENT_SPAN_ID = "b" * 16
+TRACEPARENT = f"00-{TRACE_ID}-{PARENT_SPAN_ID}-01"
+
+
+def _spans(payload):
+    return payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
+
+
+class TestTemporalTraceContext(unittest.TestCase):
+    def test_reads_agent_strace_environment_name(self):
+        context = get_temporal_trace_context({
+            TEMPORAL_TRACE_PARENT_ENV: TRACEPARENT,
+        })
+
+        self.assertIsNotNone(context)
+        self.assertEqual(context.trace_id, TRACE_ID)
+        self.assertEqual(context.parent_span_id, PARENT_SPAN_ID)
+        self.assertEqual(context.trace_flags, "01")
+
+    def test_supports_temporal_fallback_environment_name(self):
+        context = get_temporal_trace_context({
+            TEMPORAL_TRACE_PARENT_FALLBACK_ENV: TRACEPARENT,
+        })
+
+        self.assertIsNotNone(context)
+        self.assertEqual(context.source_env, TEMPORAL_TRACE_PARENT_FALLBACK_ENV)
+
+    def test_agent_strace_name_takes_precedence(self):
+        other = f"00-{'c' * 32}-{'d' * 16}-00"
+        context = get_temporal_trace_context({
+            TEMPORAL_TRACE_PARENT_ENV: TRACEPARENT,
+            TEMPORAL_TRACE_PARENT_FALLBACK_ENV: other,
+        })
+
+        self.assertEqual(context.trace_id, TRACE_ID)
+
+    def test_returns_none_without_temporal_environment(self):
+        self.assertIsNone(get_temporal_trace_context({}))
+
+    def test_rejects_malformed_traceparent(self):
+        with self.assertRaisesRegex(ValueError, "valid W3C traceparent"):
+            parse_temporal_traceparent("not-a-traceparent")
+
+    def test_rejects_zero_trace_or_span_ids(self):
+        with self.assertRaisesRegex(ValueError, "invalid trace ID"):
+            parse_temporal_traceparent(f"00-{'0' * 32}-{PARENT_SPAN_ID}-01")
+        with self.assertRaisesRegex(ValueError, "invalid parent span ID"):
+            parse_temporal_traceparent(f"00-{TRACE_ID}-{'0' * 16}-01")
+
+
+class TestTemporalSessionParenting(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = TraceStore(self.temp_dir.name)
+        self.meta = SessionMeta(agent_name="temporal-agent")
+        self.store.create_session(self.meta)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_attach_persists_context_in_session_metadata(self):
+        context = attach_temporal_trace_context(
+            self.store,
+            self.meta.session_id,
+            {TEMPORAL_TRACE_PARENT_ENV: TRACEPARENT},
+        )
+
+        restored = self.store.load_meta(self.meta.session_id)
+        self.assertEqual(context.parent_span_id, PARENT_SPAN_ID)
+        self.assertEqual(restored.trace_id, TRACE_ID)
+        self.assertEqual(restored.parent_span_id, PARENT_SPAN_ID)
+        self.assertEqual(restored.trace_flags, "01")
+
+        roundtrip = SessionMeta.from_json(restored.to_json())
+        self.assertEqual(roundtrip.parent_span_id, PARENT_SPAN_ID)
+
+    def test_watch_attaches_context_before_monitoring(self):
+        end = TraceEvent(
+            event_type=EventType.SESSION_END,
+            session_id=self.meta.session_id,
+        )
+        output = io.StringIO()
+        with patch.dict(os.environ, {TEMPORAL_TRACE_PARENT_ENV: TRACEPARENT}), \
+             patch("agent_trace.watch._tail_events", return_value=iter([end])):
+            watch_session(
+                self.store,
+                self.meta.session_id,
+                WatcherConfig(),
+                out=output,
+            )
+
+        restored = self.store.load_meta(self.meta.session_id)
+        self.assertEqual(restored.trace_id, TRACE_ID)
+        self.assertEqual(restored.parent_span_id, PARENT_SPAN_ID)
+        self.assertIn("Attached Temporal parent span", output.getvalue())
+
+
+class TestTemporalOtlp(unittest.TestCase):
+    def _meta_and_events(self):
+        meta = SessionMeta(
+            agent_name="temporal-agent",
+            trace_id=TRACE_ID,
+            parent_span_id=PARENT_SPAN_ID,
+            trace_flags="01",
+        )
+        request = TraceEvent(
+            event_type=EventType.LLM_REQUEST,
+            timestamp=10.0,
+            data={"model": "gpt-4o", "input_tokens": 12},
+        )
+        response = TraceEvent(
+            event_type=EventType.LLM_RESPONSE,
+            timestamp=11.0,
+            parent_id=request.event_id,
+            data={"model": "gpt-4o", "output_tokens": 7},
+        )
+        call = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            timestamp=12.0,
+            data={"tool_name": "read", "arguments": {"path": "README.md"}},
+        )
+        result = TraceEvent(
+            event_type=EventType.TOOL_RESULT,
+            timestamp=13.0,
+            parent_id=call.event_id,
+            duration_ms=1000,
+            data={"tool_name": "read", "result": "ok"},
+        )
+        return meta, [request, response, call, result]
+
+    def test_export_uses_temporal_trace_and_parent_span(self):
+        meta, events = self._meta_and_events()
+        payload = session_to_temporal_otlp(meta, events)
+        spans = _spans(payload)
+        root = spans[0]
+
+        self.assertEqual(root["traceId"], TRACE_ID)
+        self.assertEqual(root["parentSpanId"], PARENT_SPAN_ID)
+        self.assertEqual(root["flags"], 1)
+        self.assertTrue(any(s["name"] == "gen_ai.client.operation" for s in spans))
+        self.assertTrue(any(s["name"] == "gen_ai.tool.call/read" for s in spans))
+        self.assertTrue(all(s["traceId"] == TRACE_ID for s in spans))
+        self.assertTrue(all(s["flags"] == 1 for s in spans))
+        self.assertTrue(all(
+            s["parentSpanId"] == root["spanId"] for s in spans[1:]
+        ))
+
+    def test_export_requires_stored_temporal_context(self):
+        with self.assertRaisesRegex(ValueError, "no Temporal trace context"):
+            session_to_temporal_otlp(SessionMeta(), [])
+
+    def test_http_export_without_context_fails_cleanly(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = TraceStore(temp_dir)
+            meta = SessionMeta()
+            store.create_session(meta)
+            store.append_event(meta.session_id, TraceEvent(
+                event_type=EventType.SESSION_START,
+                session_id=meta.session_id,
+            ))
+            with patch("agent_trace.temporal.sys.stderr", new=io.StringIO()) as err:
+                ok = export_temporal_otlp(
+                    store,
+                    meta.session_id,
+                    "http://tempo:4318",
+                )
+
+        self.assertFalse(ok)
+        self.assertIn("Temporal export failed", err.getvalue())
+
+    def test_http_export_posts_temporal_payload(self):
+        meta, events = self._meta_and_events()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = TraceStore(temp_dir)
+            store.create_session(meta)
+            for event in events:
+                event.session_id = meta.session_id
+                store.append_event(meta.session_id, event)
+
+            response = MagicMock()
+            response.status = 202
+            response.__enter__.return_value = response
+            response.__exit__.return_value = False
+            with patch("agent_trace.otlp.urllib.request.urlopen", return_value=response) as urlopen:
+                ok = export_temporal_otlp(
+                    store,
+                    meta.session_id,
+                    "http://tempo:4318/",
+                    headers={"Authorization": "Bearer test"},
+                )
+
+        self.assertTrue(ok)
+        request = urlopen.call_args.args[0]
+        body = json.loads(request.data.decode("utf-8"))
+        root = _spans(body)[0]
+        self.assertEqual(request.full_url, "http://tempo:4318/v1/traces")
+        self.assertEqual(root["traceId"], TRACE_ID)
+        self.assertEqual(root["parentSpanId"], PARENT_SPAN_ID)
+
+    def test_cli_writes_temporal_otlp_json(self):
+        meta, events = self._meta_and_events()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = TraceStore(temp_dir)
+            store.create_session(meta)
+            for event in events:
+                event.session_id = meta.session_id
+                store.append_event(meta.session_id, event)
+            output_path = os.path.join(temp_dir, "temporal.json")
+            args = build_parser().parse_args([
+                "--trace-dir", temp_dir,
+                "export", meta.session_id,
+                "--format", "temporal",
+                "--output", output_path,
+            ])
+
+            self.assertEqual(cmd_export(args), 0)
+            with open(output_path, encoding="utf-8") as exported:
+                root = _spans(json.load(exported))[0]
+
+        self.assertEqual(root["traceId"], TRACE_ID)
+        self.assertEqual(root["parentSpanId"], PARENT_SPAN_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- capture `AGENT_STRACE_TEMPORAL_TRACE_PARENT` (with `TEMPORAL_TRACE_PARENT` fallback) when watching an activity session
- validate and persist the upstream W3C trace ID, parent span ID, and trace flags as additive session metadata
- add `agent-strace export SESSION_ID --format temporal` for file or OTLP/HTTP JSON export
- reuse Temporal's trace ID, parent the agent session beneath the activity span, and retain LLM/tool child spans
- add a Temporal worker/launcher setup guide with no Temporal SDK, gRPC, workflow-definition, or runtime dependency changes
- bump `agent-strace` from 0.85.0 to 0.86.0

Closes #209

## Verification

- `PYTHONPATH=src python -m unittest tests.test_temporal tests.test_otlp tests.test_otlp_genai tests.test_otlp_improvements tests.test_propagation tests.test_watch tests.test_models tests.test_store -q` — 133 tests passed
- Ona `test` task — 1,683 Python tests and 3 VS Code extension tests passed
- `python -m compileall -q src/agent_trace && git diff --check`
- wheel build — `agent_strace-0.86.0-py3-none-any.whl`