### PR TITLE
feat: add historical policy backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace watch --timeout 30m --budget $5`](docs/commands.md#watch) | Watchdog mode — kills on limit and heartbeats sessions for postmortems |
 | [`agent-strace mcp-scan`](docs/commands.md#mcp-scan) | Scan runtime MCP poisoning indicators |
 | [`agent-strace audit <id>`](docs/commands.md#audit) | Audit tool calls against a policy file |
+| [`agent-strace policy backtest`](docs/commands.md#policy) | Test policy impact against historical sessions |
 | [`agent-strace approval list`](docs/commands.md#approval) | Human-in-the-loop approval queue |
 | [`agent-strace rbac assign`](docs/commands.md#rbac) | Org and workspace-scoped role assignments |
 | [`agent-strace auth login`](docs/commands.md#auth) | SSO/OIDC login to a hosted collector |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -283,9 +283,29 @@ export package.
 
 ### `policy`
 ```
-agent-strace policy [--last N] [--output FILE]
+agent-strace policy [generate] [SESSION_ID ...] [--output FILE] [--dry-run]
+agent-strace policy backtest [--policy FILE] [--days N] [--show-sessions] [--format text|json]
+agent-strace policy diff OLD_POLICY NEW_POLICY [--days N] [--format text|json]
+agent-strace policy coverage [--policy FILE] [--days N] [--show-uncovered] [--format text|json]
 ```
-Generate `.agent-scope.json` from observed traces. Review and tighten before committing.
+Generate `.agent-scope.json` from observed traces, or evaluate a proposed policy
+offline against stored sessions before enforcement. The existing bare `policy`
+form remains an alias for `policy generate`.
+
+| Command / flag | Description |
+|---|---|
+| `generate [SESSION_ID ...]` | Suggest a policy from selected sessions, or all sessions by default |
+| `backtest` | Report per-rule matches and calls/sessions that would be blocked |
+| `diff OLD NEW` | Compare both policies over the identical history window |
+| `coverage` | Measure the fraction of tool calls matched by an explicit rule |
+| `--policy FILE` | Policy to evaluate (default: `.agent-scope.json`) |
+| `--days N` | Evaluate sessions started in the last N days (default: `30`) |
+| `--show-sessions` | List session IDs containing calls that would be blocked |
+| `--show-uncovered` | List calls that did not match an explicit rule |
+| `--format text\|json` | Human-readable or machine-readable output |
+
+Backtesting is read-only and uses the same matching semantics as `audit`; it
+never enforces a policy or contacts a remote service.
 
 ### `audit-tools`
 ```

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.86.0"
+__version__ = "0.87.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -54,6 +54,11 @@ from .eval import cmd_eval
 from .explain import cmd_explain
 from .jsonl_import import cmd_import
 from .policy import cmd_policy
+from .policy_backtest import (
+    cmd_policy_backtest,
+    cmd_policy_coverage,
+    cmd_policy_diff,
+)
 from .postmortem import cmd_postmortem
 from .project_budget import enforce_new_session_budget, load_project_budget_config
 from .share import cmd_share
@@ -1310,11 +1315,71 @@ def build_parser() -> argparse.ArgumentParser:
                             help="output format (default: text)")
 
     # policy
-    p_policy = sub.add_parser("policy", help="suggest a .agent-scope.json policy from observed traces")
-    p_policy.add_argument("session_ids", nargs="*", help="session IDs to analyse (default: all)")
-    p_policy.add_argument("--output", "-o", default=".agent-scope.json",
-                          help="output path (default: .agent-scope.json)")
-    p_policy.add_argument("--dry-run", action="store_true", help="print policy without writing")
+    p_policy = sub.add_parser("policy", help="generate and test .agent-scope.json policies")
+    policy_sub = p_policy.add_subparsers(dest="policy_command")
+
+    p_policy_generate = policy_sub.add_parser(
+        "generate", help="suggest a policy from observed traces"
+    )
+    p_policy_generate.add_argument(
+        "session_ids", nargs="*", help="session IDs to analyse (default: all)"
+    )
+    p_policy_generate.add_argument(
+        "--output", "-o", default=".agent-scope.json",
+        help="output path (default: .agent-scope.json)",
+    )
+    p_policy_generate.add_argument(
+        "--dry-run", action="store_true", help="print policy without writing"
+    )
+
+    p_policy_backtest = policy_sub.add_parser(
+        "backtest", help="simulate a policy against historical sessions"
+    )
+    p_policy_backtest.add_argument(
+        "--policy", default=".agent-scope.json",
+        help="policy file (default: .agent-scope.json)",
+    )
+    p_policy_backtest.add_argument(
+        "--days", type=int, default=30, help="history window in days (default: 30)"
+    )
+    p_policy_backtest.add_argument(
+        "--show-sessions", action="store_true", help="list sessions the policy would block"
+    )
+    p_policy_backtest.add_argument(
+        "--format", choices=("text", "json"), default="text",
+        help="output format (default: text)",
+    )
+
+    p_policy_diff = policy_sub.add_parser(
+        "diff", help="compare two policies against the same session history"
+    )
+    p_policy_diff.add_argument("old_policy", help="current policy file")
+    p_policy_diff.add_argument("new_policy", help="proposed policy file")
+    p_policy_diff.add_argument(
+        "--days", type=int, default=30, help="history window in days (default: 30)"
+    )
+    p_policy_diff.add_argument(
+        "--format", choices=("text", "json"), default="text",
+        help="output format (default: text)",
+    )
+
+    p_policy_coverage = policy_sub.add_parser(
+        "coverage", help="measure explicit-rule coverage over historical sessions"
+    )
+    p_policy_coverage.add_argument(
+        "--policy", default=".agent-scope.json",
+        help="policy file (default: .agent-scope.json)",
+    )
+    p_policy_coverage.add_argument(
+        "--days", type=int, default=30, help="history window in days (default: 30)"
+    )
+    p_policy_coverage.add_argument(
+        "--show-uncovered", action="store_true", help="list tool calls with no explicit rule"
+    )
+    p_policy_coverage.add_argument(
+        "--format", choices=("text", "json"), default="text",
+        help="output format (default: text)",
+    )
 
     # dashboard
     p_dash = sub.add_parser("dashboard", help="aggregate view across sessions")
@@ -1976,6 +2041,41 @@ def _run_with_product_telemetry(args: argparse.Namespace, handler):
 
 
 _EVAL_EXPLICIT_SUBCOMMANDS = {"gate", "run", "compare", "ci", "dataset"}
+_POLICY_EXPLICIT_SUBCOMMANDS = {"generate", "backtest", "diff", "coverage"}
+
+
+def _command_index(argv: list[str]) -> int:
+    """Return the first non-global-option argument index."""
+    command_index = 0
+    while command_index < len(argv):
+        current = argv[command_index]
+        if current == "--trace-dir":
+            command_index += 2
+            continue
+        if current.startswith("--trace-dir=") or current in {"--version"}:
+            command_index += 1
+            continue
+        break
+    return command_index
+
+
+def _normalise_policy_argv(argv: list[str]) -> list[str]:
+    """Route the legacy bare ``policy`` form through ``policy generate``."""
+    normalised = list(argv)
+    command_index = _command_index(normalised)
+    if command_index >= len(normalised) or normalised[command_index] != "policy":
+        return normalised
+
+    next_index = command_index + 1
+    if next_index >= len(normalised):
+        normalised.insert(next_index, "generate")
+        return normalised
+
+    next_arg = normalised[next_index]
+    if next_arg in {"-h", "--help"} or next_arg in _POLICY_EXPLICIT_SUBCOMMANDS:
+        return normalised
+    normalised.insert(next_index, "generate")
+    return normalised
 
 
 def _normalise_eval_argv(argv: list[str]) -> list[str]:
@@ -1985,16 +2085,7 @@ def _normalise_eval_argv(argv: list[str]) -> list[str]:
     allowing ``agent-strace eval [SESSION_ID] --baseline ...`` as documented.
     """
     normalised = list(argv)
-    command_index = 0
-    while command_index < len(normalised):
-        current = normalised[command_index]
-        if current == "--trace-dir":
-            command_index += 2
-            continue
-        if current.startswith("--trace-dir=") or current in {"--version"}:
-            command_index += 1
-            continue
-        break
+    command_index = _command_index(normalised)
 
     if command_index >= len(normalised) or normalised[command_index] != "eval":
         return normalised
@@ -2013,7 +2104,8 @@ def _normalise_eval_argv(argv: list[str]) -> list[str]:
 
 def main() -> None:
     parser = build_parser()
-    args = parser.parse_args(_normalise_eval_argv(sys.argv[1:]))
+    argv = _normalise_policy_argv(sys.argv[1:])
+    args = parser.parse_args(_normalise_eval_argv(argv))
 
     if not args.command:
         parser.print_help()
@@ -2056,7 +2148,11 @@ def main() -> None:
         "eval": cmd_eval,
         "watch": cmd_watch,
         "mcp-scan": cmd_mcp_scan,
-        "policy": cmd_policy,
+        "policy": {
+            "backtest": cmd_policy_backtest,
+            "diff": cmd_policy_diff,
+            "coverage": cmd_policy_coverage,
+        }.get(getattr(args, "policy_command", ""), cmd_policy),
         "dashboard": cmd_dashboard,
         "annotate": cmd_annotate,
         "token-budget": cmd_token_budget,

--- a/src/agent_trace/policy.py
+++ b/src/agent_trace/policy.py
@@ -278,6 +278,8 @@ def cmd_policy(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
 
     session_ids_raw: list[str] = getattr(args, "session_ids", []) or []
+    output_path = getattr(args, "output", None)
+    dry_run = getattr(args, "dry_run", False)
 
     # If no sessions specified, use all sessions
     if not session_ids_raw:
@@ -301,9 +303,6 @@ def cmd_policy(args: argparse.Namespace) -> int:
         resolved.append(full)
 
     suggestion = suggest_policy(store, resolved)
-
-    output_path = getattr(args, "output", None)
-    dry_run = getattr(args, "dry_run", False)
 
     if dry_run or not output_path:
         format_suggestion(suggestion, dry_run=True)

--- a/src/agent_trace/policy_backtest.py
+++ b/src/agent_trace/policy_backtest.py
@@ -1,0 +1,836 @@
+"""Backtest scope policies against stored agent sessions.
+
+The evaluator intentionally reuses the permission-audit policy model and
+matching helpers.  A backtest is read-only: it selects sessions from the
+existing :class:`~agent_trace.store.TraceStore`, evaluates every tool call,
+and returns structured reports suitable for terminal or JSON output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import sys
+import time
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, TextIO
+
+from .audit import (
+    Policy,
+    _audit_event,
+    _cmd_matches,
+    _extract_urls,
+    _glob_match,
+)
+from .models import EventType, SessionMeta, TraceEvent
+from .store import TraceStore
+
+
+RuleEffect = Literal["allow", "deny", "default"]
+
+
+class PolicyBacktestError(ValueError):
+    """Raised when a policy cannot be loaded or a window is invalid."""
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    """One explicit policy pattern, or the implicit unmatched default."""
+
+    key: str
+    label: str
+    scope: str
+    effect: RuleEffect
+    pattern: str = ""
+
+
+@dataclass
+class PolicyRuleStats:
+    """Observed outcomes attributed to a policy rule."""
+
+    rule: PolicyRule
+    matched: int = 0
+    would_block: int = 0
+    would_allow: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.rule.key,
+            "rule": self.rule.label,
+            "scope": self.rule.scope,
+            "effect": self.rule.effect,
+            "pattern": self.rule.pattern,
+            "matched": self.matched,
+            "would_block": self.would_block,
+            "would_allow": self.would_allow,
+        }
+
+
+@dataclass(frozen=True)
+class CallEvaluation:
+    """Policy outcome for one stored tool call."""
+
+    session_id: str
+    event_id: str
+    event_index: int
+    action: str
+    verdict: Literal["allowed", "denied"]
+    reason: str
+    rule_key: str | None = None
+    rule_label: str = "default (no rule matched)"
+
+    @property
+    def covered(self) -> bool:
+        return self.rule_key is not None
+
+    @property
+    def identity(self) -> tuple[str, int]:
+        # Event IDs were optional in early sessions, while the session-local
+        # event index is stable for the append-only event stream.
+        return (self.session_id, self.event_index)
+
+    def to_dict(self) -> dict:
+        return {
+            "session_id": self.session_id,
+            "event_id": self.event_id,
+            "event_index": self.event_index,
+            "action": self.action,
+            "verdict": self.verdict,
+            "reason": self.reason,
+            "covered": self.covered,
+            "rule": self.rule_label,
+        }
+
+
+@dataclass
+class BacktestReport:
+    """Aggregate result of simulating one policy over one history window."""
+
+    policy_path: str
+    days: int | None
+    window_start: float | None
+    window_end: float
+    session_count: int
+    calls: list[CallEvaluation] = field(default_factory=list)
+    rules: list[PolicyRuleStats] = field(default_factory=list)
+
+    @property
+    def total_tool_calls(self) -> int:
+        return len(self.calls)
+
+    @property
+    def covered_tool_calls(self) -> int:
+        return sum(1 for call in self.calls if call.covered)
+
+    @property
+    def uncovered_tool_calls(self) -> int:
+        return self.total_tool_calls - self.covered_tool_calls
+
+    @property
+    def coverage_percent(self) -> float:
+        if not self.total_tool_calls:
+            return 0.0
+        return self.covered_tool_calls / self.total_tool_calls * 100.0
+
+    @property
+    def blocked_calls(self) -> list[CallEvaluation]:
+        return [call for call in self.calls if call.verdict == "denied"]
+
+    @property
+    def affected_session_ids(self) -> list[str]:
+        return sorted({call.session_id for call in self.blocked_calls})
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "policy_backtest",
+            "policy": self.policy_path,
+            "days": self.days,
+            "window": {
+                "start": self.window_start,
+                "end": self.window_end,
+            },
+            "sessions": self.session_count,
+            "tool_calls": self.total_tool_calls,
+            "coverage": {
+                "matched": self.covered_tool_calls,
+                "uncovered": self.uncovered_tool_calls,
+                "percent": round(self.coverage_percent, 2),
+            },
+            "would_block": {
+                "tool_calls": len(self.blocked_calls),
+                "sessions": len(self.affected_session_ids),
+                "session_ids": self.affected_session_ids,
+            },
+            "rules": [rule.to_dict() for rule in self.rules],
+        }
+
+
+@dataclass
+class PolicyDiffReport:
+    """Behavioral difference between two policies on identical calls."""
+
+    old: BacktestReport
+    new: BacktestReport
+    introduced: list[CallEvaluation]
+    removed: list[CallEvaluation]
+
+    @property
+    def blocked_delta(self) -> int:
+        return len(self.new.blocked_calls) - len(self.old.blocked_calls)
+
+    @property
+    def affected_sessions_delta(self) -> int:
+        return (
+            len(self.new.affected_session_ids)
+            - len(self.old.affected_session_ids)
+        )
+
+    @staticmethod
+    def _by_rule(calls: list[CallEvaluation]) -> list[dict]:
+        counts = Counter(call.rule_label for call in calls)
+        return [
+            {"rule": rule, "tool_calls": count}
+            for rule, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        ]
+
+    def to_dict(self) -> dict:
+        return {
+            "type": "policy_diff",
+            "old_policy": self.old.policy_path,
+            "new_policy": self.new.policy_path,
+            "days": self.old.days,
+            "window": {
+                "start": self.old.window_start,
+                "end": self.old.window_end,
+            },
+            "sessions": self.old.session_count,
+            "tool_calls": self.old.total_tool_calls,
+            "old": {
+                "blocked": len(self.old.blocked_calls),
+                "affected_sessions": len(self.old.affected_session_ids),
+            },
+            "new": {
+                "blocked": len(self.new.blocked_calls),
+                "affected_sessions": len(self.new.affected_session_ids),
+            },
+            "delta": {
+                "blocked": self.blocked_delta,
+                "affected_sessions": self.affected_sessions_delta,
+            },
+            "new_blocks": {
+                "tool_calls": len(self.introduced),
+                "by_rule": self._by_rule(self.introduced),
+                "calls": [call.to_dict() for call in self.introduced],
+            },
+            "blocks_removed": {
+                "tool_calls": len(self.removed),
+                "by_rule": self._by_rule(self.removed),
+                "calls": [call.to_dict() for call in self.removed],
+            },
+        }
+
+
+@dataclass
+class CoverageReport:
+    """Explicit-rule coverage derived from a backtest."""
+
+    backtest: BacktestReport
+
+    @property
+    def total_tool_calls(self) -> int:
+        return self.backtest.total_tool_calls
+
+    @property
+    def covered_tool_calls(self) -> int:
+        return self.backtest.covered_tool_calls
+
+    @property
+    def uncovered_tool_calls(self) -> int:
+        return self.backtest.uncovered_tool_calls
+
+    @property
+    def coverage_percent(self) -> float:
+        return self.backtest.coverage_percent
+
+    @property
+    def uncovered(self) -> list[CallEvaluation]:
+        return [call for call in self.backtest.calls if not call.covered]
+
+    def to_dict(self, show_uncovered: bool = False) -> dict:
+        data = {
+            "type": "policy_coverage",
+            "policy": self.backtest.policy_path,
+            "days": self.backtest.days,
+            "window": {
+                "start": self.backtest.window_start,
+                "end": self.backtest.window_end,
+            },
+            "sessions": self.backtest.session_count,
+            "tool_calls": self.total_tool_calls,
+            "covered": self.covered_tool_calls,
+            "uncovered": self.uncovered_tool_calls,
+            "coverage_percent": round(self.coverage_percent, 2),
+        }
+        if show_uncovered:
+            data["uncovered_calls"] = [call.to_dict() for call in self.uncovered]
+        return data
+
+
+_DEFAULT_RULE = PolicyRule(
+    key="default",
+    label="default (no rule matched)",
+    scope="default",
+    effect="default",
+)
+
+_MALFORMED_ARGUMENTS_REASON = (
+    "malformed tool call arguments; no policy rule evaluated"
+)
+_MALFORMED_DATA_REASON = "malformed tool call data; no policy rule evaluated"
+
+
+def _rule_key(scope: str, effect: str, index: int) -> str:
+    return f"{scope}.{effect}.{index}"
+
+
+def _policy_rules(policy: Policy) -> list[PolicyRule]:
+    """Return policy patterns in a stable, human-readable order."""
+    rules: list[PolicyRule] = []
+
+    def add(scope: str, verb: str, effect: Literal["allow", "deny"], patterns: list[str]) -> None:
+        for index, pattern in enumerate(patterns):
+            rules.append(PolicyRule(
+                key=_rule_key(scope, effect, index),
+                label=f"{effect}: {verb} {pattern}",
+                scope=scope,
+                effect=effect,
+                pattern=pattern,
+            ))
+
+    add("files.read", "read", "deny", policy.file_read_deny)
+    add("files.read", "read", "allow", policy.file_read_allow)
+    add("files.write", "write", "deny", policy.file_write_deny)
+    add("files.write", "write", "allow", policy.file_write_allow)
+    add("commands", "bash", "deny", policy.cmd_deny)
+    add("commands", "bash", "allow", policy.cmd_allow)
+    add("network", "network", "allow", policy.network_allow)
+    if policy.network_deny_all:
+        rules.append(PolicyRule(
+            key="network.deny_all",
+            label="deny: network *",
+            scope="network",
+            effect="deny",
+            pattern="*",
+        ))
+    return rules
+
+
+def _first_path_rule(
+    path: str,
+    scope: str,
+    effect: Literal["allow", "deny"],
+    patterns: list[str],
+) -> str | None:
+    for index, pattern in enumerate(patterns):
+        if _glob_match(path, [pattern]):
+            return _rule_key(scope, effect, index)
+    return None
+
+
+def _first_command_rule(
+    command: str,
+    effect: Literal["allow", "deny"],
+    patterns: list[str],
+) -> str | None:
+    for index, pattern in enumerate(patterns):
+        if _cmd_matches(command, [pattern]):
+            return _rule_key("commands", effect, index)
+    return None
+
+
+def _first_network_allow_rule(host: str, policy: Policy) -> str | None:
+    for index, pattern in enumerate(policy.network_allow):
+        if host == pattern or fnmatch.fnmatch(host, pattern):
+            return _rule_key("network", "allow", index)
+    return None
+
+
+def _effective_rule(event: TraceEvent, policy: Policy) -> str | None:
+    """Return the explicit rule that determines a tool call's outcome.
+
+    A call is attributed to at most one rule so per-rule match totals remain
+    directly comparable with the total number of tool calls.  Deny rules take
+    precedence exactly as they do in ``audit --policy``.  Calls rejected only
+    because they fall outside an allow-list are intentionally uncovered: no
+    explicit pattern matched them.
+    """
+    tool_name = str(event.data.get("tool_name", "")).lower()
+    args = event.data.get("arguments", {}) or {}
+
+    if tool_name in ("read", "view", "grep", "glob"):
+        path = str(
+            args.get("file_path")
+            or args.get("path")
+            or args.get("pattern")
+            or ""
+        )
+        if not path:
+            return None
+        return (
+            _first_path_rule(path, "files.read", "deny", policy.file_read_deny)
+            or _first_path_rule(path, "files.read", "allow", policy.file_read_allow)
+        )
+
+    if tool_name in ("write", "edit", "create"):
+        path = str(args.get("file_path") or args.get("path") or "")
+        if not path:
+            return None
+        return (
+            _first_path_rule(path, "files.write", "deny", policy.file_write_deny)
+            or _first_path_rule(path, "files.write", "allow", policy.file_write_allow)
+        )
+
+    if tool_name != "bash":
+        return None
+
+    command = str(args.get("command", "")).strip()
+    if not command:
+        return None
+
+    network_fallback: str | None = None
+    if policy.network_deny_all:
+        for host in _extract_urls(command):
+            allow_rule = _first_network_allow_rule(host, policy)
+            if allow_rule is None:
+                return "network.deny_all"
+            if network_fallback is None:
+                network_fallback = allow_rule
+
+    deny_rule = _first_command_rule(command, "deny", policy.cmd_deny)
+    if deny_rule:
+        return deny_rule
+
+    allow_rule = _first_command_rule(command, "allow", policy.cmd_allow)
+    if allow_rule:
+        return allow_rule
+
+    # An unmatched command allow-list produces an implicit denial.  It must be
+    # reported as uncovered even when the command's URL matched a network rule.
+    if policy.cmd_allow:
+        return None
+    return network_fallback
+
+
+def _evaluate_call(
+    event: TraceEvent,
+    event_index: int,
+    session_id: str,
+    policy: Policy,
+    rules_by_key: dict[str, PolicyRule],
+) -> CallEvaluation:
+    if not isinstance(event.data, Mapping):
+        return CallEvaluation(
+            session_id=session_id,
+            event_id=event.event_id,
+            event_index=event_index,
+            action="Tool: ? (malformed data)",
+            verdict="allowed",
+            reason=_MALFORMED_DATA_REASON,
+        )
+
+    data = event.data
+    arguments = data.get("arguments", {})
+    if arguments is not None and not isinstance(arguments, Mapping):
+        tool_name = str(data.get("tool_name", "?"))
+        return CallEvaluation(
+            session_id=session_id,
+            event_id=event.event_id,
+            event_index=event_index,
+            action=f"Tool: {tool_name} (malformed arguments)",
+            verdict="allowed",
+            reason=_MALFORMED_ARGUMENTS_REASON,
+        )
+
+    entries = _audit_event(event, event_index, policy)
+    denied = next((entry for entry in entries if entry.verdict == "denied"), None)
+    verdict: Literal["allowed", "denied"] = "denied" if denied else "allowed"
+    selected = denied or (entries[-1] if entries else None)
+    action = selected.action if selected else f"Tool: {event.data.get('tool_name', '?')}"
+    reason = selected.reason if selected else "no policy rule matched"
+
+    rule_key = _effective_rule(event, policy)
+    rule = rules_by_key.get(rule_key or "")
+    return CallEvaluation(
+        session_id=session_id,
+        event_id=event.event_id,
+        event_index=event_index,
+        action=action,
+        verdict=verdict,
+        reason=reason,
+        rule_key=rule.key if rule else None,
+        rule_label=rule.label if rule else _DEFAULT_RULE.label,
+    )
+
+
+def _policy_mapping(value: object, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise PolicyBacktestError(f"policy field {field_name!r} must be an object")
+    return value
+
+
+def _policy_patterns(section: Mapping[str, object], key: str, field_name: str) -> list[str]:
+    value = section.get(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise PolicyBacktestError(
+            f"policy field {field_name!r} must be a list of strings"
+        )
+    return value
+
+
+def _load_policy(path: str | Path) -> Policy:
+    """Load and validate a policy before evaluating historical actions."""
+    policy_path = Path(path)
+    try:
+        raw = json.loads(policy_path.read_text())
+    except FileNotFoundError as exc:
+        raise PolicyBacktestError(f"Could not load policy file: {path}") from exc
+    except OSError as exc:
+        raise PolicyBacktestError(f"Could not load policy file: {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise PolicyBacktestError(f"Malformed policy file {path}: {exc}") from exc
+
+    root = _policy_mapping(raw, "<root>")
+    files = _policy_mapping(root.get("files", {}), "files")
+    reads = _policy_mapping(files.get("read", {}), "files.read")
+    writes = _policy_mapping(files.get("write", {}), "files.write")
+    commands = _policy_mapping(root.get("commands", {}), "commands")
+    network = _policy_mapping(root.get("network", {}), "network")
+
+    deny_all = network.get("deny_all", False)
+    if not isinstance(deny_all, bool):
+        raise PolicyBacktestError("policy field 'network.deny_all' must be a boolean")
+
+    return Policy(
+        file_read_allow=_policy_patterns(reads, "allow", "files.read.allow"),
+        file_read_deny=_policy_patterns(reads, "deny", "files.read.deny"),
+        file_write_allow=_policy_patterns(writes, "allow", "files.write.allow"),
+        file_write_deny=_policy_patterns(writes, "deny", "files.write.deny"),
+        cmd_allow=_policy_patterns(commands, "allow", "commands.allow"),
+        cmd_deny=_policy_patterns(commands, "deny", "commands.deny"),
+        network_deny_all=deny_all,
+        network_allow=_policy_patterns(network, "allow", "network.allow"),
+    )
+
+
+def _select_sessions(
+    store: TraceStore,
+    days: int | None,
+    now: float | None,
+) -> tuple[list[SessionMeta], float | None, float]:
+    if days is not None and days <= 0:
+        raise PolicyBacktestError("days must be greater than zero")
+    window_end = time.time() if now is None else now
+    window_start = None if days is None else window_end - days * 86400
+    sessions = [
+        meta for meta in store.list_sessions()
+        if (window_start is None or meta.started_at >= window_start)
+        and meta.started_at <= window_end
+    ]
+    return sessions, window_start, window_end
+
+
+def _snapshot_sessions(
+    store: TraceStore,
+    sessions: list[SessionMeta],
+) -> list[tuple[SessionMeta, list[TraceEvent]]]:
+    """Load each selected event stream exactly once.
+
+    Active sessions are append-only.  Keeping one in-memory snapshot ensures
+    policy diffs compare the same calls even when new events arrive while the
+    command is running.
+    """
+    return [
+        (meta, store.load_events(meta.session_id))
+        for meta in sessions
+    ]
+
+
+def _backtest_selected(
+    policy: Policy,
+    policy_path: str,
+    snapshots: list[tuple[SessionMeta, list[TraceEvent]]],
+    days: int | None,
+    window_start: float | None,
+    window_end: float,
+) -> BacktestReport:
+    declared_rules = _policy_rules(policy)
+    rules_by_key = {rule.key: rule for rule in declared_rules}
+    calls: list[CallEvaluation] = []
+
+    for meta, events in snapshots:
+        for event_index, event in enumerate(events, start=1):
+            if event.event_type != EventType.TOOL_CALL:
+                continue
+            calls.append(_evaluate_call(
+                event,
+                event_index,
+                meta.session_id,
+                policy,
+                rules_by_key,
+            ))
+
+    stats_by_key = {
+        rule.key: PolicyRuleStats(rule=rule)
+        for rule in [*declared_rules, _DEFAULT_RULE]
+    }
+    for call in calls:
+        key = call.rule_key or _DEFAULT_RULE.key
+        stats = stats_by_key[key]
+        stats.matched += 1
+        if call.verdict == "denied":
+            stats.would_block += 1
+        else:
+            stats.would_allow += 1
+
+    return BacktestReport(
+        policy_path=policy_path,
+        days=days,
+        window_start=window_start,
+        window_end=window_end,
+        session_count=len(snapshots),
+        calls=calls,
+        rules=[stats_by_key[rule.key] for rule in [*declared_rules, _DEFAULT_RULE]],
+    )
+
+
+def backtest_policy(
+    store: TraceStore,
+    policy_path: str | Path,
+    days: int | None = 30,
+    now: float | None = None,
+) -> BacktestReport:
+    """Simulate *policy_path* over sessions in the requested window."""
+    policy = _load_policy(policy_path)
+    sessions, window_start, window_end = _select_sessions(store, days, now)
+    snapshots = _snapshot_sessions(store, sessions)
+    return _backtest_selected(
+        policy,
+        str(policy_path),
+        snapshots,
+        days,
+        window_start,
+        window_end,
+    )
+
+
+def diff_policies(
+    store: TraceStore,
+    old_policy_path: str | Path,
+    new_policy_path: str | Path,
+    days: int | None = 30,
+    now: float | None = None,
+) -> PolicyDiffReport:
+    """Compare two policies against the exact same historical calls."""
+    old_policy = _load_policy(old_policy_path)
+    new_policy = _load_policy(new_policy_path)
+    sessions, window_start, window_end = _select_sessions(store, days, now)
+    snapshots = _snapshot_sessions(store, sessions)
+    old_report = _backtest_selected(
+        old_policy, str(old_policy_path), snapshots,
+        days, window_start, window_end,
+    )
+    new_report = _backtest_selected(
+        new_policy, str(new_policy_path), snapshots,
+        days, window_start, window_end,
+    )
+
+    old_by_id = {call.identity: call for call in old_report.calls}
+    new_by_id = {call.identity: call for call in new_report.calls}
+    introduced = [
+        call for identity, call in new_by_id.items()
+        if call.verdict == "denied"
+        and old_by_id[identity].verdict != "denied"
+    ]
+    removed = [
+        call for identity, call in old_by_id.items()
+        if call.verdict == "denied"
+        and new_by_id[identity].verdict != "denied"
+    ]
+    return PolicyDiffReport(
+        old=old_report,
+        new=new_report,
+        introduced=introduced,
+        removed=removed,
+    )
+
+
+def policy_coverage(
+    store: TraceStore,
+    policy_path: str | Path,
+    days: int | None = 30,
+    now: float | None = None,
+) -> CoverageReport:
+    """Report the fraction of tool calls matching an explicit rule."""
+    return CoverageReport(backtest_policy(store, policy_path, days=days, now=now))
+
+
+def format_backtest(
+    report: BacktestReport,
+    out: TextIO = sys.stdout,
+    show_sessions: bool = False,
+) -> None:
+    """Render a human-readable policy backtest."""
+    period = "all history" if report.days is None else f"last {report.days} days"
+    out.write(
+        f"Policy backtest — {period} "
+        f"({report.session_count:,} sessions, {report.total_tool_calls:,} tool calls)\n"
+    )
+    width = max(28, *(len(stats.rule.label) for stats in report.rules))
+    divider = "─" * (width + 43)
+    out.write(f"{divider}\n")
+    out.write(
+        f"{'Rule':<{width}}  {'Matched':>9}  {'Would block':>13}  {'Would allow':>13}\n"
+    )
+    out.write(f"{divider}\n")
+    for stats in report.rules:
+        out.write(
+            f"{stats.rule.label:<{width}}  {stats.matched:>9,}  "
+            f"{stats.would_block:>13,}  {stats.would_allow:>13,}\n"
+        )
+    out.write(f"{divider}\n")
+    out.write(
+        f"Coverage: {report.coverage_percent:.1f}% of tool calls matched an explicit rule\n"
+    )
+    out.write(
+        f"Would block: {len(report.blocked_calls):,} tool calls across "
+        f"{len(report.affected_session_ids):,} sessions\n"
+    )
+    if show_sessions and report.affected_session_ids:
+        out.write("Affected sessions:\n")
+        for session_id in report.affected_session_ids:
+            out.write(f"  {session_id}\n")
+
+
+def _signed(value: int) -> str:
+    return f"{value:+d}"
+
+
+def format_policy_diff(report: PolicyDiffReport, out: TextIO = sys.stdout) -> None:
+    """Render a human-readable comparison of two policy simulations."""
+    period = "all history" if report.old.days is None else f"last {report.old.days} days"
+    out.write(f"Policy diff — old vs new ({period})\n")
+    out.write("─" * 72 + "\n")
+    out.write(f"{'Change':<34} {'Old policy':>11} {'New policy':>12} {'Delta':>9}\n")
+    out.write("─" * 72 + "\n")
+    out.write(
+        f"{'Total blocked':<34} {len(report.old.blocked_calls):>11,} "
+        f"{len(report.new.blocked_calls):>12,} { _signed(report.blocked_delta):>9}\n"
+    )
+    out.write(
+        f"{'Sessions affected':<34} {len(report.old.affected_session_ids):>11,} "
+        f"{len(report.new.affected_session_ids):>12,} "
+        f"{_signed(report.affected_sessions_delta):>9}\n"
+    )
+    out.write(f"{'New blocks introduced':<34} {'—':>11} {len(report.introduced):>12,} {_signed(len(report.introduced)):>9}\n")
+    for item in PolicyDiffReport._by_rule(report.introduced):
+        out.write(f"  → {item['rule']:<52} {item['tool_calls']:>8,} new\n")
+    out.write(f"{'Blocks removed':<34} {len(report.removed):>11,} {'—':>12} {_signed(-len(report.removed)):>9}\n")
+    for item in PolicyDiffReport._by_rule(report.removed):
+        out.write(f"  → {item['rule']:<52} {item['tool_calls']:>8,} removed\n")
+    out.write("─" * 72 + "\n")
+    if report.introduced:
+        out.write(
+            f"Recommendation: review {len(report.introduced):,} new blocks before enforcing\n"
+        )
+    else:
+        out.write("No new blocks introduced.\n")
+
+
+def format_coverage(
+    report: CoverageReport,
+    out: TextIO = sys.stdout,
+    show_uncovered: bool = False,
+) -> None:
+    """Render a human-readable explicit-rule coverage report."""
+    backtest = report.backtest
+    period = "all history" if backtest.days is None else f"last {backtest.days} days"
+    out.write(
+        f"Policy coverage — {period} "
+        f"({backtest.session_count:,} sessions)\n"
+    )
+    out.write(f"Tool calls: {report.total_tool_calls:,}\n")
+    out.write(f"Explicitly covered: {report.covered_tool_calls:,}\n")
+    out.write(f"Uncovered: {report.uncovered_tool_calls:,}\n")
+    out.write(f"Coverage: {report.coverage_percent:.1f}%\n")
+    if show_uncovered and report.uncovered:
+        out.write("Uncovered tool calls:\n")
+        for call in report.uncovered:
+            out.write(
+                f"  {call.session_id} event #{call.event_index}: {call.action}\n"
+            )
+
+
+def _days_arg(args: argparse.Namespace) -> int | None:
+    return getattr(args, "days", 30)
+
+
+def cmd_policy_backtest(args: argparse.Namespace) -> int:
+    """CLI handler for ``policy backtest``."""
+    try:
+        report = backtest_policy(
+            TraceStore(args.trace_dir),
+            getattr(args, "policy", ".agent-scope.json"),
+            days=_days_arg(args),
+        )
+    except (OSError, PolicyBacktestError) as exc:
+        sys.stderr.write(f"Policy backtest failed: {exc}\n")
+        return 1
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps(report.to_dict(), indent=2) + "\n")
+    else:
+        format_backtest(report, show_sessions=getattr(args, "show_sessions", False))
+    return 0
+
+
+def cmd_policy_diff(args: argparse.Namespace) -> int:
+    """CLI handler for ``policy diff``."""
+    try:
+        report = diff_policies(
+            TraceStore(args.trace_dir),
+            args.old_policy,
+            args.new_policy,
+            days=_days_arg(args),
+        )
+    except (OSError, PolicyBacktestError) as exc:
+        sys.stderr.write(f"Policy diff failed: {exc}\n")
+        return 1
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(json.dumps(report.to_dict(), indent=2) + "\n")
+    else:
+        format_policy_diff(report)
+    return 0
+
+
+def cmd_policy_coverage(args: argparse.Namespace) -> int:
+    """CLI handler for ``policy coverage``."""
+    try:
+        report = policy_coverage(
+            TraceStore(args.trace_dir),
+            getattr(args, "policy", ".agent-scope.json"),
+            days=_days_arg(args),
+        )
+    except (OSError, PolicyBacktestError) as exc:
+        sys.stderr.write(f"Policy coverage failed: {exc}\n")
+        return 1
+    show_uncovered = getattr(args, "show_uncovered", False)
+    if getattr(args, "format", "text") == "json":
+        sys.stdout.write(
+            json.dumps(report.to_dict(show_uncovered=show_uncovered), indent=2) + "\n"
+        )
+    else:
+        format_coverage(report, show_uncovered=show_uncovered)
+    return 0

--- a/tests/test_policy_backtest.py
+++ b/tests/test_policy_backtest.py
@@ -1,0 +1,369 @@
+"""Tests for historical policy backtesting (issue #211)."""
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_trace.cli import _normalise_policy_argv, build_parser
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.policy_backtest import (
+    PolicyBacktestError,
+    backtest_policy,
+    diff_policies,
+    format_backtest,
+    format_coverage,
+    format_policy_diff,
+    policy_coverage,
+)
+from agent_trace.store import TraceStore
+
+
+NOW = 2_000_000_000.0
+DAY = 86400.0
+
+
+def _tool(tool_name: str, **arguments) -> TraceEvent:
+    return TraceEvent(
+        event_type=EventType.TOOL_CALL,
+        timestamp=NOW,
+        data={"tool_name": tool_name, "arguments": arguments},
+    )
+
+
+class PolicyBacktestTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = TraceStore(Path(self.tmp.name) / "traces", redact=False)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def add_session(
+        self,
+        session_id: str,
+        started_at: float,
+        events: list[TraceEvent],
+    ) -> None:
+        meta = SessionMeta(session_id=session_id, started_at=started_at)
+        self.store.create_session(meta)
+        for event in events:
+            event.session_id = session_id
+            self.store.append_event(session_id, event)
+
+    def write_policy(self, name: str, policy: dict) -> Path:
+        path = Path(self.tmp.name) / name
+        path.write_text(json.dumps(policy))
+        return path
+
+
+class TestPolicyBacktest(PolicyBacktestTestCase):
+    def setUp(self):
+        super().setUp()
+        self.policy = self.write_policy("policy.json", {
+            "files": {
+                "read": {"allow": ["src/**"]},
+                "write": {"deny": ["/etc/**"]},
+            },
+            "commands": {
+                "allow": ["git *"],
+                "deny": ["rm -rf *"],
+            },
+        })
+
+    def test_backtest_filters_window_and_counts_each_rule(self):
+        self.add_session("recent", NOW - 3600, [
+            _tool("Read", file_path="src/main.py"),
+            _tool("Write", file_path="/etc/hosts"),
+            _tool("Bash", command="git status"),
+            _tool("Bash", command="rm -rf build"),
+            _tool("Read", file_path="README.md"),
+            _tool("TodoWrite", todos=[]),
+        ])
+        self.add_session("too-old", NOW - 31 * DAY, [
+            _tool("Write", file_path="/etc/passwd"),
+        ])
+
+        report = backtest_policy(self.store, self.policy, days=30, now=NOW)
+
+        self.assertEqual(report.session_count, 1)
+        self.assertEqual(report.total_tool_calls, 6)
+        self.assertEqual(report.covered_tool_calls, 4)
+        self.assertEqual(report.uncovered_tool_calls, 2)
+        self.assertAlmostEqual(report.coverage_percent, 100 * 4 / 6)
+        self.assertEqual(len(report.blocked_calls), 3)
+        self.assertEqual(report.affected_session_ids, ["recent"])
+
+        by_label = {stats.rule.label: stats for stats in report.rules}
+        self.assertEqual(by_label["allow: read src/**"].matched, 1)
+        self.assertEqual(by_label["allow: read src/**"].would_allow, 1)
+        self.assertEqual(by_label["deny: write /etc/**"].would_block, 1)
+        self.assertEqual(by_label["allow: bash git *"].would_allow, 1)
+        self.assertEqual(by_label["deny: bash rm -rf *"].would_block, 1)
+
+        # README.md is denied by the implicit allow-list default while the
+        # arbitrary tool is allowed by default. Neither matched a pattern.
+        default = by_label["default (no rule matched)"]
+        self.assertEqual(default.matched, 2)
+        self.assertEqual(default.would_block, 1)
+        self.assertEqual(default.would_allow, 1)
+
+    def test_all_history_includes_old_sessions(self):
+        self.add_session("old", NOW - 90 * DAY, [
+            _tool("Read", file_path="src/old.py"),
+        ])
+        report = backtest_policy(self.store, self.policy, days=None, now=NOW)
+        self.assertEqual(report.session_count, 1)
+        self.assertEqual(report.total_tool_calls, 1)
+        self.assertIsNone(report.window_start)
+
+    def test_zero_call_history_has_zero_coverage(self):
+        self.add_session("empty", NOW - 60, [
+            TraceEvent(event_type=EventType.USER_PROMPT, data={"prompt": "hello"}),
+        ])
+        report = backtest_policy(self.store, self.policy, now=NOW)
+        self.assertEqual(report.total_tool_calls, 0)
+        self.assertEqual(report.coverage_percent, 0.0)
+        self.assertTrue(all(stats.matched == 0 for stats in report.rules))
+
+    def test_missing_policy_and_invalid_window_are_errors(self):
+        with self.assertRaises(PolicyBacktestError):
+            backtest_policy(self.store, Path(self.tmp.name) / "missing.json", now=NOW)
+        with self.assertRaisesRegex(PolicyBacktestError, "greater than zero"):
+            backtest_policy(self.store, self.policy, days=0, now=NOW)
+
+    def test_structurally_invalid_policy_fields_are_rejected(self):
+        invalid_policies = [
+            (["not", "an", "object"], "<root>"),
+            ({"files": []}, "files"),
+            ({"files": {"read": {"allow": "src/**"}}}, "files.read.allow"),
+            ({"commands": {"deny": ["rm *", 7]}}, "commands.deny"),
+            ({"network": {"deny_all": "false"}}, "network.deny_all"),
+            ({"network": {"allow": "localhost"}}, "network.allow"),
+        ]
+        for index, (policy_data, field_name) in enumerate(invalid_policies):
+            with self.subTest(field=field_name):
+                path = self.write_policy(f"invalid-{index}.json", policy_data)
+                with self.assertRaisesRegex(PolicyBacktestError, field_name.replace(".", r"\.")):
+                    backtest_policy(self.store, path, now=NOW)
+
+    def test_malformed_tool_arguments_are_uncovered_instead_of_aborting(self):
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            timestamp=NOW,
+            data={"tool_name": "Bash", "arguments": "rm -rf /tmp/build"},
+        )
+        self.add_session("malformed", NOW - 1, [event])
+
+        report = backtest_policy(self.store, self.policy, now=NOW)
+
+        self.assertEqual(report.total_tool_calls, 1)
+        self.assertEqual(report.covered_tool_calls, 0)
+        self.assertEqual(len(report.blocked_calls), 0)
+        self.assertEqual(
+            report.calls[0].reason,
+            "malformed tool call arguments; no policy rule evaluated",
+        )
+        self.assertEqual(
+            report.calls[0].action,
+            "Tool: Bash (malformed arguments)",
+        )
+        default = next(stats for stats in report.rules if stats.rule.effect == "default")
+        self.assertEqual(default.would_allow, 1)
+
+    def test_backtest_json_is_machine_readable(self):
+        self.add_session("recent", NOW - 1, [_tool("Read", file_path="src/a.py")])
+        report = backtest_policy(self.store, self.policy, now=NOW)
+        data = json.loads(json.dumps(report.to_dict()))
+        self.assertEqual(data["type"], "policy_backtest")
+        self.assertEqual(data["tool_calls"], 1)
+        self.assertEqual(data["coverage"]["percent"], 100.0)
+        self.assertIn("session_ids", data["would_block"])
+
+    def test_show_sessions_lists_affected_ids(self):
+        self.add_session("blocked-session", NOW - 1, [
+            _tool("Write", file_path="/etc/hosts"),
+        ])
+        report = backtest_policy(self.store, self.policy, now=NOW)
+        out = io.StringIO()
+        format_backtest(report, out=out, show_sessions=True)
+        text = out.getvalue()
+        self.assertIn("Policy backtest", text)
+        self.assertIn("Affected sessions", text)
+        self.assertIn("blocked-session", text)
+
+
+class TestNetworkBacktest(PolicyBacktestTestCase):
+    def test_network_rules_are_attributed_once_per_call(self):
+        policy = self.write_policy("network.json", {
+            "network": {"deny_all": True, "allow": ["localhost"]},
+        })
+        self.add_session("network", NOW - 1, [
+            _tool("Bash", command="curl http://localhost:8080/health"),
+            _tool("Bash", command="curl https://example.com/data"),
+            _tool("Bash", command="printf done"),
+        ])
+
+        report = backtest_policy(self.store, policy, now=NOW)
+
+        self.assertEqual(report.total_tool_calls, 3)
+        self.assertEqual(report.covered_tool_calls, 2)
+        self.assertEqual(len(report.blocked_calls), 1)
+        by_label = {stats.rule.label: stats for stats in report.rules}
+        self.assertEqual(by_label["allow: network localhost"].would_allow, 1)
+        self.assertEqual(by_label["deny: network *"].would_block, 1)
+        self.assertEqual(by_label["default (no rule matched)"].would_allow, 1)
+
+
+class TestPolicyDiff(PolicyBacktestTestCase):
+    def test_diff_uses_one_snapshot_when_active_session_grows(self):
+        self.add_session("active", NOW - 1, [
+            _tool("Read", file_path="src/main.py"),
+        ])
+        old = self.write_policy("old.json", {})
+        new = self.write_policy("new.json", {
+            "files": {"write": {"deny": ["tmp/**"]}},
+        })
+        appended = _tool("Write", file_path="tmp/cache.txt")
+        appended.session_id = "active"
+        original_load_events = self.store.load_events
+        load_count = 0
+
+        def load_then_grow(session_id: str):
+            nonlocal load_count
+            events = original_load_events(session_id)
+            load_count += 1
+            if load_count == 1:
+                self.store.append_event(session_id, appended)
+            return events
+
+        self.store.load_events = load_then_grow
+        try:
+            report = diff_policies(self.store, old, new, days=30, now=NOW)
+        finally:
+            self.store.load_events = original_load_events
+
+        self.assertEqual(load_count, 1)
+        self.assertEqual(report.old.total_tool_calls, 1)
+        self.assertEqual(report.new.total_tool_calls, 1)
+        self.assertEqual(report.introduced, [])
+
+    def test_diff_finds_introduced_and_removed_blocks(self):
+        self.add_session("writes", NOW - 1, [
+            _tool("Write", file_path="tmp/cache.txt"),
+        ])
+        self.add_session("network", NOW - 2, [
+            _tool("Bash", command="curl https://example.com/data"),
+        ])
+        old = self.write_policy("old.json", {
+            "files": {"write": {"allow": ["**"]}},
+            "commands": {"deny": ["curl *"]},
+        })
+        new = self.write_policy("new.json", {
+            "files": {"write": {"deny": ["tmp/**"]}},
+            "commands": {"allow": ["curl *"]},
+        })
+
+        report = diff_policies(self.store, old, new, days=30, now=NOW)
+
+        self.assertEqual(len(report.old.blocked_calls), 1)
+        self.assertEqual(len(report.new.blocked_calls), 1)
+        self.assertEqual(report.blocked_delta, 0)
+        self.assertEqual(len(report.introduced), 1)
+        self.assertEqual(len(report.removed), 1)
+        self.assertEqual(report.introduced[0].session_id, "writes")
+        self.assertEqual(report.introduced[0].rule_label, "deny: write tmp/**")
+        self.assertEqual(report.removed[0].session_id, "network")
+        self.assertEqual(report.removed[0].rule_label, "deny: bash curl *")
+
+        data = report.to_dict()
+        self.assertEqual(data["new_blocks"]["tool_calls"], 1)
+        self.assertEqual(data["blocks_removed"]["tool_calls"], 1)
+        self.assertEqual(data["new_blocks"]["by_rule"][0]["tool_calls"], 1)
+
+    def test_diff_format_recommends_reviewing_new_blocks(self):
+        self.add_session("writes", NOW - 1, [
+            _tool("Write", file_path="tmp/cache.txt"),
+        ])
+        old = self.write_policy("old.json", {})
+        new = self.write_policy("new.json", {
+            "files": {"write": {"deny": ["tmp/**"]}},
+        })
+        report = diff_policies(self.store, old, new, now=NOW)
+        out = io.StringIO()
+        format_policy_diff(report, out=out)
+        text = out.getvalue()
+        self.assertIn("New blocks introduced", text)
+        self.assertIn("review 1 new blocks", text)
+
+
+class TestPolicyCoverage(PolicyBacktestTestCase):
+    def test_coverage_reports_and_lists_uncovered_calls(self):
+        policy = self.write_policy("coverage.json", {
+            "files": {"read": {"allow": ["src/**"]}},
+        })
+        self.add_session("coverage", NOW - 1, [
+            _tool("Read", file_path="src/main.py"),
+            _tool("Read", file_path="README.md"),
+            _tool("Agent", prompt="delegate"),
+        ])
+
+        report = policy_coverage(self.store, policy, now=NOW)
+
+        self.assertEqual(report.total_tool_calls, 3)
+        self.assertEqual(report.covered_tool_calls, 1)
+        self.assertEqual(report.uncovered_tool_calls, 2)
+        self.assertAlmostEqual(report.coverage_percent, 100 / 3)
+        data = report.to_dict(show_uncovered=True)
+        self.assertEqual(len(data["uncovered_calls"]), 2)
+
+        out = io.StringIO()
+        format_coverage(report, out=out, show_uncovered=True)
+        text = out.getvalue()
+        self.assertIn("Coverage: 33.3%", text)
+        self.assertIn("README.md", text)
+        self.assertIn("Tool: Agent", text)
+
+
+class TestPolicyBacktestCLI(unittest.TestCase):
+    def test_parses_policy_subcommands(self):
+        parser = build_parser()
+        backtest = parser.parse_args([
+            "policy", "backtest", "--policy", "scope.json", "--days", "14",
+            "--show-sessions", "--format", "json",
+        ])
+        self.assertEqual(backtest.policy_command, "backtest")
+        self.assertEqual(backtest.policy, "scope.json")
+        self.assertEqual(backtest.days, 14)
+        self.assertTrue(backtest.show_sessions)
+        self.assertEqual(backtest.format, "json")
+
+        diff = parser.parse_args(["policy", "diff", "old.json", "new.json"])
+        self.assertEqual(diff.policy_command, "diff")
+        self.assertEqual(diff.old_policy, "old.json")
+        self.assertEqual(diff.new_policy, "new.json")
+
+        coverage = parser.parse_args([
+            "policy", "coverage", "--show-uncovered",
+        ])
+        self.assertEqual(coverage.policy_command, "coverage")
+        self.assertTrue(coverage.show_uncovered)
+
+    def test_legacy_policy_generation_is_normalised(self):
+        self.assertEqual(
+            _normalise_policy_argv(["policy", "abc123", "--dry-run"]),
+            ["policy", "generate", "abc123", "--dry-run"],
+        )
+        self.assertEqual(
+            _normalise_policy_argv(["--trace-dir", "traces", "policy"]),
+            ["--trace-dir", "traces", "policy", "generate"],
+        )
+        self.assertEqual(
+            _normalise_policy_argv(["policy", "backtest"]),
+            ["policy", "backtest"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add read-only `policy backtest`, `policy diff`, and `policy coverage` commands
- preserve the existing bare policy-generation syntax through `policy generate`
- reuse audit matching semantics with per-rule counts, session impact, JSON output, and strict policy validation
- snapshot active sessions once for deterministic policy comparisons and tolerate malformed historical tool arguments
- document the workflow and bump the package to 0.87.0

Closes #211

## Verification

- `python -m unittest tests.test_policy_backtest tests.test_audit tests.test_policy -v` (69 passed)
- Ona `test` task (1,738 Python tests passed; 3 VS Code tests passed)
- `python -m compileall -q src/agent_trace tests/test_policy_backtest.py`
- `git diff --check`
- 5,000-call benchmark completes well under the issue's 5-second target