### PR TITLE
feat: add context compaction analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace why <id> <event>`](docs/commands.md#why) | Causal chain for a specific decision |
 | [`agent-strace diff <id-a> <id-b>`](docs/commands.md#diff) | Structural or semantic session comparison |
 | [`agent-strace compare <id-a> <id-b>`](docs/commands.md#compare) | Regression report with verdict |
+| [`agent-strace compaction <id>`](docs/compaction.md) | Inspect context loss and behavior changes after compaction |
 
 ### Control and protect
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -175,6 +175,24 @@ agent-strace token-budget <session-id> [--model MODEL] [--warn-at PCT]
 ```
 Check token usage against model context limit.
 
+### `compaction`
+```
+agent-strace compaction [SESSION_ID] [--diff] [--behavior-diff]
+                         [--compaction-threshold RATIO]
+```
+Detect provider-reported input-token drops between consecutive model requests
+and report the context discarded by compaction.
+
+| Flag | Description |
+|---|---|
+| `SESSION_ID` | Session ID or prefix (default: latest) |
+| `--diff` | Classify constraints, decisions, and file context as survived or likely dropped |
+| `--behavior-diff` | Compare lint findings, re-reads, loops, and exploration around compaction |
+| `--compaction-threshold RATIO` | Minimum token drop ratio (default: `0.50`) |
+
+See the [context compaction guide](compaction.md) for interpretation and live
+checkpoint setup.
+
 ---
 
 ## Control and protection
@@ -184,7 +202,8 @@ Check token usage against model context limit.
 agent-strace watch [session-id] [--timeout DURATION] [--budget $N] [--on-violation ACTION]
                    [--on-death CMD] [--policy FILE] [--rules FILE_OR_BUILTINS] [--stream-to URL]
                    [--stream-batch-size N] [--stream-flush-interval S]
-                   [--loop-threshold N] [--loop-window N] [--max-context-pct N] [--dry-run]
+                   [--loop-threshold N] [--loop-window N] [--max-context-pct N]
+                   [--compaction-checkpoint] [--checkpoint-at RATIO] [--dry-run]
 ```
 Live session monitor with kill-switch rules.
 
@@ -196,6 +215,8 @@ Live session monitor with kill-switch rules.
 | `--loop-window N` | Number of recent events to scan for repeated identical tool calls; default is 10 |
 | `--on-violation terminal\|file\|kill` | Action when a rule fires |
 | `--on-death CMD` | Command to run after kill (receives `{post_mortem_path}`) |
+| `--compaction-checkpoint` | Write a recovery checkpoint before context saturation |
+| `--checkpoint-at RATIO` | Context fill ratio that triggers a checkpoint (default: `0.80`) |
 | `--policy FILE` | Scope policy file to enforce (default: `.agent-scope.json`) |
 | `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,loop:3/10,budget:$5,timeout:30m,cognitive-debt:0.8` |
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
@@ -453,7 +474,11 @@ Freeze a session's tool-call sequence as a JSON fixture containing tool names an
 ```
 agent-strace lint [session-id] [--all] [--since DURATION] [--strict] [--format text|json]
 ```
-Flag bad behavior patterns: tool loops, reasoning spirals, budget proximity, context saturation, redundant reads, error-retry loops, no-output sessions.
+Flag bad behavior patterns: tool loops, reasoning spirals, budget proximity,
+context saturation, redundant reads, error-retry loops, no-output sessions, and
+post-compaction regressions. The `post-compaction-regression` rule warns when
+re-reading, exploration, context saturation, or other lint findings increase
+after a detected compaction.
 
 `--strict` exits 1 on any WARN or ERROR. Configure rules via `.agent-strace-lint.json`.
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -1,0 +1,61 @@
+# Context compaction analysis
+
+Long agent sessions can exceed a model's working context. Runtimes often
+compact the conversation into a shorter summary and continue, which can drop
+constraints, decisions, and file context. agent-strace detects that boundary
+from recorded input-token counts; it does not call an LLM or send trace data to
+a service.
+
+## Inspect a session
+
+```bash
+agent-strace compaction SESSION_ID
+agent-strace compaction SESSION_ID --diff
+agent-strace compaction SESSION_ID --behavior-diff
+```
+
+A compaction is recorded when consecutive requests in the same conversation
+sidechain show an input-token drop greater than 50%. Change the threshold with
+`--compaction-threshold 0.65`. Provider-reported usage is required; estimated
+prompt sizes are never labeled or priced as compaction.
+
+The base report shows each boundary, input tokens before and after, dropped
+tokens, percentage, and estimated cost of the discarded input. `--diff`
+compares reconstructable pre-compaction facts with the recorded summary and
+marks likely losses. Constraints and decisions are high risk. The comparison
+is deterministic keyword analysis, so treat “likely dropped” as a review cue,
+not proof.
+
+`--behavior-diff` compares bounded windows before and after the boundary. It
+highlights file re-reads, repeated exploration, tool loops, context saturation,
+and increases in the normal lint rule set. `agent-strace lint` exposes the same
+signal as `post-compaction-regression` for CI use.
+
+## Imported Claude sessions
+
+Claude JSONL imports retain per-turn token usage, compaction summaries, and
+sidechain identity. Import and inspect them offline:
+
+```bash
+agent-strace import ~/.claude/projects/example/session.jsonl
+agent-strace compaction SESSION_ID --diff --behavior-diff
+```
+
+Independent sidechains or subagents are never compared with each other.
+
+## Write a recovery checkpoint while watching
+
+```bash
+agent-strace watch SESSION_ID --compaction-checkpoint
+agent-strace watch SESSION_ID --compaction-checkpoint --checkpoint-at 0.75
+```
+
+When provider usage reaches the configured fraction of the model context,
+`watch` writes `.agent-traces/checkpoints/SESSION_ID.md`. The sidecar captures
+the task, constraints, files read, decisions, modified files, and current
+state. It is written once per growth cycle and rearms after compaction.
+
+Checkpoint files can contain trace-derived project context and should receive
+the same access controls as `.agent-traces/`. Retention cleanup removes a
+session's checkpoint together with its event data. Checkpoints are additive;
+the NDJSON storage format is not changed or rewritten.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.88.0"
+__version__ = "0.89.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -70,6 +70,7 @@ from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
 from .team_report import cmd_team_report
 from .compare import cmd_compare
+from .compaction import cmd_compaction
 from .freeze import cmd_freeze, cmd_regression
 from .timeline import cmd_timeline
 from .config_watch import cmd_config_watch
@@ -1284,6 +1285,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument("--config", help="path to .agent-watch.json config file")
     p_watch.add_argument("--max-context-pct", type=int, default=90, dest="max_context_pct",
                          help="alert when context window is this %% full (default: 90)")
+    p_watch.add_argument(
+        "--compaction-checkpoint", action="store_true",
+        help="write a recovery checkpoint before context saturation",
+    )
+    p_watch.add_argument(
+        "--checkpoint-at", type=float, default=0.80, metavar="RATIO",
+        help="context fill ratio for compaction checkpoints (default: 0.80)",
+    )
     p_watch.add_argument("--policy", metavar="POLICY_FILE",
                          help="path to scope policy file (default: .agent-scope.json)")
     p_watch.add_argument("--rules", metavar="RULES_FILE",
@@ -1330,6 +1339,24 @@ def build_parser() -> argparse.ArgumentParser:
                                  help="minimum sessions per version before scoring (default: 5)")
     p_context_score.add_argument("--format", choices=["text", "json"], default="text",
                                  help="output format (default: text)")
+
+    # compaction
+    p_compaction = sub.add_parser(
+        "compaction", help="detect and analyse context compaction events"
+    )
+    p_compaction.add_argument(
+        "session_id", nargs="?", help="session ID or prefix (default: latest)"
+    )
+    p_compaction.add_argument(
+        "--diff", action="store_true", help="show constraints and decisions that survived or dropped"
+    )
+    p_compaction.add_argument(
+        "--behavior-diff", action="store_true", help="compare behavior and lint findings around compaction"
+    )
+    p_compaction.add_argument(
+        "--compaction-threshold", type=float, default=0.50, metavar="RATIO",
+        help="minimum input-token drop ratio (default: 0.50)",
+    )
 
     # mcp-scan
     p_mcp_scan = sub.add_parser("mcp-scan", help="scan runtime MCP tool poisoning indicators")
@@ -2171,6 +2198,7 @@ def main() -> None:
         "cost": cmd_cost,
         "cognitive-debt": cmd_cognitive_debt,
         "context-score": cmd_context_score,
+        "compaction": cmd_compaction,
         "diff": cmd_diff,
         "why": cmd_why,
         "audit": cmd_audit,

--- a/src/agent_trace/compaction.py
+++ b/src/agent_trace/compaction.py
@@ -1,0 +1,1124 @@
+"""Deterministic context-compaction analysis and checkpoint generation.
+
+Compaction is inferred from consecutive LLM request contexts: when the input
+token count drops by more than ``DEFAULT_COMPACTION_THRESHOLD``, the later
+request is treated as the first request after compaction.  The implementation
+uses stored events only; it never sends trace contents to an LLM or a remote
+service.
+
+Checkpoint files are additive Markdown sidecars under
+``.agent-traces/checkpoints``.  Event NDJSON and session metadata are never
+rewritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, TextIO
+
+from .cost import get_model_pricing
+from .models import EventType, TraceEvent
+from .store import TraceStore
+from .token_budget import DEFAULT_CONTEXT_LIMIT, _resolve_limit
+
+
+DEFAULT_COMPACTION_THRESHOLD = 0.50
+DEFAULT_CHECKPOINT_AT = 0.80
+DEFAULT_BEHAVIOR_WINDOW = 50
+
+_INPUT_TOKEN_KEYS = (
+    "input_tokens",
+    "prompt_tokens",
+    "inputTokens",
+    "promptTokenCount",
+    "prompt_token_count",
+)
+_CACHE_TOKEN_KEYS = (
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "cached_input_tokens",
+)
+_USAGE_KEYS = ("usage", "usage_metadata", "usageMetadata", "token_usage")
+_CONTEXT_LIMIT_KEYS = (
+    "context_window",
+    "context_window_tokens",
+    "max_context_tokens",
+)
+_READ_TOOLS = {"read", "read_file", "file_read"}
+_WRITE_TOOLS = {
+    "write",
+    "edit",
+    "create",
+    "str_replace",
+    "str_replace_based_edit_tool",
+    "multiedit",
+    "notebook_edit",
+}
+_CONSTRAINT_RE = re.compile(
+    r"\b(?:must|shall|required?|requirement|should|need(?:s)? to|"
+    r"do not|don't|never|only|ensure|cannot|can't|without)\b",
+    re.IGNORECASE,
+)
+_DECISION_RE = re.compile(
+    r"\b(?:decid(?:e|ed|ing)|chose|chosen|select(?:ed)?|"
+    r"reject(?:ed)?|abandon(?:ed)?|avoid(?:ed)?|instead of)\b",
+    re.IGNORECASE,
+)
+_EXPLORATION_RE = re.compile(
+    r"^\s*(?:ls(?:\s|$)|find(?:\s|$)|tree(?:\s|$)|"
+    r"rg\s+--files(?:\s|$)|git\s+ls-files(?:\s|$))",
+    re.IGNORECASE,
+)
+_SPACE_RE = re.compile(r"\s+")
+_WORD_RE = re.compile(r"[a-z0-9][a-z0-9_.:/-]*")
+_STOP_WORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+    "in", "is", "it", "of", "on", "or", "that", "the", "this", "to",
+    "was", "were", "with",
+}
+
+
+@dataclass
+class ContextItem:
+    """One reconstructable fact that may survive or be lost at compaction."""
+
+    kind: str
+    text: str
+    event_index: int
+    high_risk: bool = False
+
+
+@dataclass
+class CompactionContextDiff:
+    survived: list[ContextItem] = field(default_factory=list)
+    likely_dropped: list[ContextItem] = field(default_factory=list)
+    context_available: bool = True
+
+    @property
+    def high_risk_drops(self) -> list[ContextItem]:
+        return [item for item in self.likely_dropped if item.high_risk]
+
+
+@dataclass(frozen=True)
+class BehaviorMetrics:
+    unique_files_read: int
+    redundant_read_violations: int
+    tool_loop_violations: int
+    reexploration_calls: int
+    files_read: tuple[str, ...] = ()
+    context_saturation_violations: int = 0
+    lint_violations: tuple[tuple[str, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class CompactionBehaviorDiff:
+    before: BehaviorMetrics
+    after: BehaviorMetrics
+    reread_files: tuple[str, ...] = ()
+    regressions: tuple[str, ...] = ()
+    lint_deltas: tuple[tuple[str, int, int], ...] = ()
+
+    @property
+    def regressed(self) -> bool:
+        return bool(self.regressions)
+
+
+@dataclass
+class CompactionEvent:
+    sequence: int
+    event_index: int
+    before_event_index: int
+    before_request_index: int
+    after_request_index: int
+    timestamp: float
+    offset_seconds: float
+    tokens_before: int
+    tokens_after: int
+    tokens_dropped: int
+    drop_ratio: float
+    model: str
+    estimated_cost_usd: float
+    stream_id: str = "main"
+    context_boundary_index: int = -1
+    post_context: Mapping[str, Any] = field(default_factory=dict, repr=False)
+    context_diff: CompactionContextDiff | None = None
+    behavior_diff: CompactionBehaviorDiff | None = None
+
+
+@dataclass
+class CompactionReport:
+    session_id: str
+    threshold: float
+    events: list[CompactionEvent] = field(default_factory=list)
+
+    @property
+    def total_tokens_dropped(self) -> int:
+        return sum(event.tokens_dropped for event in self.events)
+
+    @property
+    def estimated_cost_usd(self) -> float:
+        return sum(event.estimated_cost_usd for event in self.events)
+
+
+@dataclass
+class _RequestSample:
+    request_index: int
+    event_index: int
+    timestamp: float
+    input_tokens: int
+    model: str
+    context_data: Mapping[str, Any]
+    estimated: bool = False
+    stream_id: str = "main"
+    context_boundary_index: int = -1
+
+
+def _event_stream(event: TraceEvent) -> str:
+    value = event.data.get("context_stream", "main")
+    return str(value) if value else "main"
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return number if number > 0 else None
+
+
+def _first_token_value(data: Mapping[str, Any], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        if key in data:
+            value = _positive_int(data[key])
+            if value is not None:
+                return value
+    return None
+
+
+def _input_token_count(data: Mapping[str, Any]) -> int | None:
+    """Read a provider token count, including Anthropic cache context."""
+    candidates: list[Mapping[str, Any]] = [data]
+    for key in _USAGE_KEYS:
+        nested = data.get(key)
+        if isinstance(nested, Mapping):
+            candidates.append(nested)
+    response_metadata = data.get("response_metadata")
+    if isinstance(response_metadata, Mapping):
+        nested = response_metadata.get("token_usage")
+        if isinstance(nested, Mapping):
+            candidates.append(nested)
+
+    for candidate in candidates:
+        primary = _first_token_value(candidate, _INPUT_TOKEN_KEYS)
+        cache = sum(
+            value or 0
+            for value in (_positive_int(candidate.get(key)) for key in _CACHE_TOKEN_KEYS)
+        )
+        if primary is not None or cache:
+            return (primary or 0) + cache
+    return None
+
+
+def _model_name(data: Mapping[str, Any]) -> str:
+    for key in ("model", "model_id", "modelId"):
+        value = data.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _estimate_request_tokens(data: Mapping[str, Any]) -> int:
+    ignored = set(_INPUT_TOKEN_KEYS) | set(_CACHE_TOKEN_KEYS) | set(_USAGE_KEYS)
+    payload = {key: value for key, value in data.items() if key not in ignored}
+    return max(1, len(json.dumps(payload, sort_keys=True, default=str)) // 4)
+
+
+def _request_samples(events: list[TraceEvent]) -> list[_RequestSample]:
+    """Build logical request samples from request/paired response events.
+
+    Several integrations learn provider usage only after the response.  Those
+    counts replace a request-side estimate.  Response-only samples also allow
+    imported logs to participate when their source exposes one usage-bearing
+    assistant event per turn.
+    """
+    samples: list[_RequestSample] = []
+    pending_by_stream: dict[str, int] = {}
+    summary_by_stream: dict[str, int] = {}
+
+    for event_index, event in enumerate(events):
+        stream_id = _event_stream(event)
+        if event.data.get("is_compaction_summary"):
+            summary_by_stream[stream_id] = event_index
+
+        if event.event_type == EventType.LLM_REQUEST:
+            explicit = _input_token_count(event.data)
+            boundary_index = summary_by_stream.pop(stream_id, event_index)
+            samples.append(_RequestSample(
+                request_index=len(samples) + 1,
+                event_index=event_index,
+                timestamp=event.timestamp,
+                input_tokens=explicit or _estimate_request_tokens(event.data),
+                model=_model_name(event.data),
+                context_data=event.data,
+                estimated=explicit is None,
+                stream_id=stream_id,
+                context_boundary_index=boundary_index,
+            ))
+            pending_by_stream[stream_id] = len(samples) - 1
+            continue
+
+        if event.event_type not in {EventType.LLM_RESPONSE, EventType.ASSISTANT_RESPONSE}:
+            continue
+
+        explicit = _input_token_count(event.data)
+        if explicit is None:
+            continue
+        pending_index = pending_by_stream.get(stream_id)
+        if pending_index is not None:
+            sample = samples[pending_index]
+            sample.input_tokens = explicit
+            sample.estimated = False
+            if not sample.model:
+                sample.model = _model_name(event.data)
+            summary = event.data.get("context_summary")
+            if isinstance(summary, str) and summary:
+                sample.context_data = {"context_summary": summary}
+                sample.context_boundary_index = summary_by_stream.pop(
+                    stream_id, sample.context_boundary_index,
+                )
+            pending_by_stream.pop(stream_id, None)
+        else:
+            summary = event.data.get("context_summary")
+            context_data = (
+                {"context_summary": summary}
+                if isinstance(summary, str) and summary else {}
+            )
+            samples.append(_RequestSample(
+                request_index=len(samples) + 1,
+                event_index=event_index,
+                timestamp=event.timestamp,
+                input_tokens=explicit,
+                model=_model_name(event.data),
+                context_data=context_data,
+                estimated=False,
+                stream_id=stream_id,
+                context_boundary_index=summary_by_stream.pop(stream_id, event_index),
+            ))
+    return samples
+
+
+def detect_compactions(
+    events: list[TraceEvent],
+    threshold: float = DEFAULT_COMPACTION_THRESHOLD,
+) -> list[CompactionEvent]:
+    """Return compactions inferred from consecutive logical LLM requests."""
+    if not 0 < threshold < 1:
+        raise ValueError("compaction threshold must be between 0 and 1")
+
+    samples = _request_samples(events)
+    base_timestamp = events[0].timestamp if events else 0.0
+    compactions: list[CompactionEvent] = []
+    previous_by_stream: dict[str, _RequestSample] = {}
+    for after in samples:
+        before = previous_by_stream.get(after.stream_id)
+        previous_by_stream[after.stream_id] = after
+        if before is None:
+            continue
+        # JSON-size estimates are useful for checkpointing but are not precise
+        # enough to claim or price a compaction event.
+        if before.estimated or after.estimated:
+            continue
+        if before.input_tokens <= 0 or after.input_tokens >= before.input_tokens:
+            continue
+        dropped = before.input_tokens - after.input_tokens
+        drop_ratio = dropped / before.input_tokens
+        if drop_ratio <= threshold:
+            continue
+        model = after.model or before.model
+        price = get_model_pricing(model)
+        input_rate = price.input_per_million if price is not None else 3.0
+        compactions.append(CompactionEvent(
+            sequence=len(compactions) + 1,
+            event_index=after.event_index,
+            before_event_index=before.event_index,
+            before_request_index=before.request_index,
+            after_request_index=after.request_index,
+            timestamp=after.timestamp,
+            offset_seconds=max(0.0, after.timestamp - base_timestamp),
+            tokens_before=before.input_tokens,
+            tokens_after=after.input_tokens,
+            tokens_dropped=dropped,
+            drop_ratio=drop_ratio,
+            model=model or "unknown",
+            estimated_cost_usd=dropped * input_rate / 1_000_000,
+            stream_id=after.stream_id,
+            context_boundary_index=(
+                after.context_boundary_index
+                if after.context_boundary_index >= 0 else after.event_index
+            ),
+            post_context=after.context_data,
+        ))
+    return compactions
+
+
+def _flatten_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        strings: list[str] = []
+        for key, nested in value.items():
+            if key in _USAGE_KEYS or key in _INPUT_TOKEN_KEYS or key in _CACHE_TOKEN_KEYS:
+                continue
+            strings.extend(_flatten_strings(nested))
+        return strings
+    if isinstance(value, (list, tuple)):
+        strings = []
+        for nested in value:
+            strings.extend(_flatten_strings(nested))
+        return strings
+    return []
+
+
+def _event_text(event: TraceEvent) -> str:
+    preferred = (
+        "prompt", "text", "content", "summary", "decision", "reason",
+        "message", "task", "goal",
+    )
+    for key in preferred:
+        value = event.data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return " ".join(_flatten_strings(event.data)).strip()
+
+
+def _statements(text: str) -> list[str]:
+    parts = re.split(r"(?:\r?\n)+|(?<=[.!?])\s+", text)
+    result: list[str] = []
+    for part in parts:
+        cleaned = re.sub(r"^\s*(?:[-*•]|\d+[.)])\s*", "", part).strip()
+        cleaned = _SPACE_RE.sub(" ", cleaned)
+        if len(cleaned) >= 4:
+            result.append(cleaned[:400])
+    return result
+
+
+def _read_path(event: TraceEvent) -> str:
+    if event.event_type == EventType.FILE_READ:
+        return str(
+            event.data.get("path") or event.data.get("file_path")
+            or event.data.get("uri") or ""
+        ).strip()
+    if event.event_type != EventType.TOOL_CALL:
+        return ""
+    tool = str(event.data.get("tool_name", "")).lower()
+    if tool not in _READ_TOOLS:
+        return ""
+    arguments = event.data.get("arguments", {})
+    if not isinstance(arguments, Mapping):
+        return ""
+    return str(arguments.get("file_path") or arguments.get("path") or "").strip()
+
+
+def _write_path(event: TraceEvent) -> str:
+    if event.event_type == EventType.FILE_WRITE:
+        return str(
+            event.data.get("path") or event.data.get("file_path")
+            or event.data.get("uri") or ""
+        ).strip()
+    if event.event_type != EventType.TOOL_CALL:
+        return ""
+    tool = str(event.data.get("tool_name", "")).lower()
+    if tool not in _WRITE_TOOLS:
+        return ""
+    arguments = event.data.get("arguments", {})
+    if not isinstance(arguments, Mapping):
+        return ""
+    return str(arguments.get("file_path") or arguments.get("path") or "").strip()
+
+
+def _normalise(value: str) -> str:
+    return " ".join(_WORD_RE.findall(value.lower()))
+
+
+def _context_items(
+    events: list[TraceEvent],
+    end_index: int,
+    stream_id: str | None = None,
+) -> list[ContextItem]:
+    items: list[ContextItem] = []
+    task_added = False
+    seen: set[tuple[str, str]] = set()
+
+    def add(kind: str, text: str, event_index: int, high_risk: bool = False) -> None:
+        text = _SPACE_RE.sub(" ", text).strip()[:400]
+        key = (kind, _normalise(text))
+        if not text or not key[1] or key in seen:
+            return
+        seen.add(key)
+        items.append(ContextItem(kind, text, event_index, high_risk))
+
+    for event_index, event in enumerate(events[:end_index]):
+        if stream_id is not None and _event_stream(event) != stream_id:
+            continue
+        path = _read_path(event)
+        if path:
+            add("File read", path, event_index)
+        path = _write_path(event)
+        if path:
+            add("File modified", path, event_index)
+
+        text = _event_text(event)
+        if event.event_type == EventType.USER_PROMPT and text:
+            statements = _statements(text)
+            if statements and not task_added:
+                add("Task goal", statements[0], event_index)
+                task_added = True
+            for statement in statements:
+                if _CONSTRAINT_RE.search(statement):
+                    add("Constraint", statement, event_index, high_risk=True)
+
+        if event.event_type == EventType.LLM_REQUEST and text:
+            for statement in _statements(text):
+                if _CONSTRAINT_RE.search(statement):
+                    add("Constraint", statement, event_index, high_risk=True)
+
+        if event.event_type == EventType.DECISION and text:
+            add("Decision", text, event_index, high_risk=True)
+        elif event.event_type == EventType.ASSISTANT_RESPONSE and text:
+            for statement in _statements(text):
+                if _DECISION_RE.search(statement):
+                    add("Decision", statement, event_index, high_risk=True)
+    return items
+
+
+def _item_survived(
+    item: ContextItem,
+    context_text: str,
+    context_words: set[str],
+) -> bool:
+    item_text = _normalise(item.text)
+    if not item_text or not context_text:
+        return False
+    if item_text in context_text:
+        return True
+    if item.kind in {"Task goal", "Decision"}:
+        ordered = [
+            word for word in item_text.split()
+            if word not in _STOP_WORDS and len(word) > 2
+        ]
+        if any(
+            f"{left} {right}" in context_text
+            for left, right in zip(ordered, ordered[1:])
+        ):
+            return True
+    significant = {
+        word for word in item_text.split()
+        if word not in _STOP_WORDS and len(word) > 2
+    }
+    if len(significant) < 3:
+        return False
+    return len(significant & context_words) / len(significant) >= 0.80
+
+
+def context_diff_for_compaction(
+    events: list[TraceEvent],
+    compaction: CompactionEvent,
+) -> CompactionContextDiff:
+    """Infer which reconstructable pre-compaction facts survived."""
+    boundary_index = (
+        compaction.context_boundary_index
+        if compaction.context_boundary_index >= 0 else compaction.event_index
+    )
+    items = _context_items(events, boundary_index, compaction.stream_id)
+    post_context = " ".join(_flatten_strings(compaction.post_context))
+    context_text = _normalise(post_context)
+    if not context_text:
+        return CompactionContextDiff(context_available=False)
+    context_words = set(context_text.split())
+    diff = CompactionContextDiff(context_available=True)
+    for item in items:
+        if _item_survived(item, context_text, context_words):
+            diff.survived.append(item)
+        else:
+            diff.likely_dropped.append(item)
+    return diff
+
+
+def _tool_loop_count(events: list[TraceEvent], threshold: int) -> int:
+    count = 0
+    run_tool = ""
+    run_length = 0
+    for event in events + [TraceEvent(event_type=EventType.SESSION_END)]:
+        if event.event_type == EventType.TOOL_CALL:
+            tool = str(event.data.get("tool_name", ""))
+            if tool and tool == run_tool:
+                run_length += 1
+            else:
+                if run_length >= threshold:
+                    count += 1
+                run_tool = tool
+                run_length = 1 if tool else 0
+        else:
+            if run_length >= threshold:
+                count += 1
+            run_tool = ""
+            run_length = 0
+    return count
+
+
+def _behavior_metrics(
+    events: list[TraceEvent],
+    redundant_read_threshold: int,
+    tool_loop_threshold: int,
+) -> BehaviorMetrics:
+    paths = [path for event in events if (path := _read_path(event))]
+    counts: dict[str, int] = {}
+    for path in paths:
+        counts[path] = counts.get(path, 0) + 1
+
+    reexploration_calls = 0
+    for event in events:
+        if event.event_type != EventType.TOOL_CALL:
+            continue
+        tool = str(event.data.get("tool_name", "")).lower()
+        arguments = event.data.get("arguments", {})
+        arguments = arguments if isinstance(arguments, Mapping) else {}
+        command = str(arguments.get("command", ""))
+        if tool in {"glob", "list", "list_dir", "directory_tree"}:
+            reexploration_calls += 1
+        elif tool in {"bash", "shell", "exec"} and _EXPLORATION_RE.search(command):
+            reexploration_calls += 1
+
+    # Reuse the registered lint rules so behavior diffs evolve with the lint
+    # command.  The compaction rule itself is excluded to avoid recursion.
+    from . import lint as lint_module
+
+    lint_counts: dict[str, int] = {}
+    for rule_name, rule_fn in lint_module._RULES.items():
+        if rule_name == "post-compaction-regression":
+            continue
+        rule_config = dict(lint_module.DEFAULT_CONFIG.get(rule_name, {}))
+        if rule_name == "redundant-read":
+            rule_config["threshold"] = redundant_read_threshold
+        elif rule_name == "tool-loop":
+            rule_config["threshold"] = tool_loop_threshold
+        try:
+            lint_counts[rule_name] = len(rule_fn(events, rule_config))
+        except Exception:
+            # Match lint_session's rule isolation without printing repeatedly
+            # while generating a behavior diff.
+            lint_counts[rule_name] = 0
+
+    explicit_context = [
+        context_fill_ratio(event)
+        for event in events
+        if _input_token_count(event.data) is not None
+    ]
+    if explicit_context:
+        saturation_threshold = float(
+            lint_module.DEFAULT_CONFIG["context-saturation"].get("threshold", 0.8)
+        )
+        lint_counts["context-saturation"] = int(any(
+            ratio is not None and ratio >= saturation_threshold
+            for ratio in explicit_context
+        ))
+
+    return BehaviorMetrics(
+        unique_files_read=len(set(paths)),
+        redundant_read_violations=sum(
+            1 for count in counts.values() if count >= redundant_read_threshold
+        ),
+        tool_loop_violations=_tool_loop_count(events, tool_loop_threshold),
+        reexploration_calls=reexploration_calls,
+        files_read=tuple(dict.fromkeys(paths)),
+        context_saturation_violations=lint_counts.get("context-saturation", 0),
+        lint_violations=tuple(sorted(lint_counts.items())),
+    )
+
+
+def behavior_diff_for_compaction(
+    events: list[TraceEvent],
+    compaction: CompactionEvent,
+    window: int = DEFAULT_BEHAVIOR_WINDOW,
+    redundant_read_threshold: int = 3,
+    tool_loop_threshold: int = 5,
+) -> CompactionBehaviorDiff:
+    """Compare bounded tool behavior before and after one compaction."""
+    if window <= 0:
+        raise ValueError("behavior window must be positive")
+    index = (
+        compaction.context_boundary_index
+        if compaction.context_boundary_index >= 0 else compaction.event_index
+    )
+    before_events = [
+        event for event in events[:index]
+        if _event_stream(event) == compaction.stream_id
+    ][-window:]
+    after_events = [
+        event for event in events[index:]
+        if _event_stream(event) == compaction.stream_id
+    ][:window]
+    before = _behavior_metrics(
+        before_events, redundant_read_threshold, tool_loop_threshold,
+    )
+    after = _behavior_metrics(
+        after_events, redundant_read_threshold, tool_loop_threshold,
+    )
+    all_prior_paths = {
+        _read_path(event) for event in events[:index]
+        if _event_stream(event) == compaction.stream_id
+    }
+    all_prior_paths.discard("")
+    reread_files = tuple(sorted(all_prior_paths & set(after.files_read)))
+
+    regressions: list[str] = []
+    if reread_files:
+        regressions.append(f"re-read {len(reread_files)} pre-compaction file(s)")
+    if after.reexploration_calls > before.reexploration_calls:
+        regressions.append(
+            "repository exploration calls increased "
+            f"{before.reexploration_calls} -> {after.reexploration_calls}"
+        )
+
+    before_lint = dict(before.lint_violations)
+    after_lint = dict(after.lint_violations)
+    lint_deltas = tuple(
+        (rule, before_lint.get(rule, 0), after_lint.get(rule, 0))
+        for rule in sorted(before_lint.keys() | after_lint.keys())
+    )
+    for rule, before_count, after_count in lint_deltas:
+        if after_count > before_count:
+            regressions.append(
+                f"{rule} lint violations increased {before_count} -> {after_count}"
+            )
+
+    return CompactionBehaviorDiff(
+        before=before,
+        after=after,
+        reread_files=reread_files,
+        regressions=tuple(regressions),
+        lint_deltas=lint_deltas,
+    )
+
+
+def analyze_compactions(
+    events: list[TraceEvent],
+    session_id: str = "",
+    threshold: float = DEFAULT_COMPACTION_THRESHOLD,
+    behavior_window: int = DEFAULT_BEHAVIOR_WINDOW,
+) -> CompactionReport:
+    """Build a complete deterministic compaction report from events."""
+    report = CompactionReport(session_id=session_id, threshold=threshold)
+    report.events = detect_compactions(events, threshold)
+    for compaction in report.events:
+        compaction.context_diff = context_diff_for_compaction(events, compaction)
+        compaction.behavior_diff = behavior_diff_for_compaction(
+            events, compaction, window=behavior_window,
+        )
+    return report
+
+
+def analyse_compactions(
+    events: list[TraceEvent],
+    session_id: str = "",
+    threshold: float = DEFAULT_COMPACTION_THRESHOLD,
+    behavior_window: int = DEFAULT_BEHAVIOR_WINDOW,
+) -> CompactionReport:
+    """British-English alias used by other analysis modules."""
+    return analyze_compactions(events, session_id, threshold, behavior_window)
+
+
+def analyse_compaction_session(
+    store: TraceStore,
+    session_id: str,
+    threshold: float = DEFAULT_COMPACTION_THRESHOLD,
+    behavior_window: int = DEFAULT_BEHAVIOR_WINDOW,
+) -> CompactionReport:
+    return analyze_compactions(
+        store.load_events(session_id), session_id, threshold, behavior_window,
+    )
+
+
+def _format_offset(seconds: float) -> str:
+    minutes, seconds = divmod(max(0, int(seconds)), 60)
+    return f"{minutes}m {seconds:02d}s"
+
+
+def format_compaction_report(
+    report: CompactionReport,
+    out: TextIO = sys.stdout,
+    show_diff: bool = False,
+    show_behavior_diff: bool = False,
+) -> None:
+    """Write a stable human-readable report."""
+    if not report.events:
+        out.write(f"No compaction events detected in session {report.session_id[:12]}.\n")
+        return
+
+    out.write(f"Compaction events - session {report.session_id[:12]}\n")
+    out.write("─" * 78 + "\n")
+    out.write("Event  Timestamp  Tokens before  Tokens after  Dropped\n")
+    out.write("─" * 78 + "\n")
+    for event in report.events:
+        out.write(
+            f"#{event.sequence:<5} {_format_offset(event.offset_seconds):<10} "
+            f"{event.tokens_before:>13,}  {event.tokens_after:>12,}  "
+            f"{event.tokens_dropped:>10,} ({event.drop_ratio * 100:.0f}%)\n"
+        )
+    out.write("─" * 78 + "\n")
+    out.write(
+        f"{len(report.events)} compaction event(s). "
+        f"{report.total_tokens_dropped:,} tokens dropped total.\n"
+        f"Estimated cost of dropped context: ${report.estimated_cost_usd:.4f}\n"
+    )
+
+    if show_diff:
+        for event in report.events:
+            diff = event.context_diff or CompactionContextDiff()
+            out.write(f"\nCompaction #{event.sequence} - context diff\n")
+            out.write("─" * 78 + "\n")
+            if not diff.context_available:
+                out.write(
+                    "Post-compaction summary/context was not captured; "
+                    "survival cannot be assessed.\n"
+                )
+                continue
+            out.write("Survived in summary:\n")
+            if diff.survived:
+                for item in diff.survived:
+                    out.write(f"  ✅ {item.kind}: {item.text}\n")
+            else:
+                out.write("  (none detected)\n")
+            out.write("Likely dropped:\n")
+            if diff.likely_dropped:
+                for item in diff.likely_dropped:
+                    out.write(f"  ❌ {item.kind} at event #{item.event_index + 1}: {item.text}\n")
+            else:
+                out.write("  (none detected)\n")
+            for item in diff.high_risk_drops:
+                out.write(f"⚠️  High-risk drop: {item.kind.lower()} {item.text!r}\n")
+
+    if show_behavior_diff:
+        for event in report.events:
+            behavior = event.behavior_diff
+            if behavior is None:
+                continue
+            out.write(f"\nBehavior change after compaction #{event.sequence}\n")
+            out.write("─" * 78 + "\n")
+            out.write(
+                f"Before: {behavior.before.unique_files_read} unique files read, "
+                f"{behavior.before.redundant_read_violations} redundant-read violations\n"
+                f"After:  {behavior.after.unique_files_read} unique files read, "
+                f"{behavior.after.redundant_read_violations} redundant-read violations\n"
+                "Lint delta:\n"
+            )
+            for rule, before_count, after_count in behavior.lint_deltas:
+                out.write(f"  {rule}: {before_count} -> {after_count}\n")
+            for regression in behavior.regressions:
+                out.write(f"  - {regression}\n")
+            verdict = "regressed" if behavior.regressed else "no measurable regression"
+            out.write(f"Verdict: behavior {verdict} after compaction #{event.sequence}\n")
+
+
+def _context_limit(data: Mapping[str, Any]) -> int:
+    for key in _CONTEXT_LIMIT_KEYS:
+        limit = _positive_int(data.get(key))
+        if limit is not None:
+            return limit
+    return _resolve_limit(_model_name(data)) or DEFAULT_CONTEXT_LIMIT
+
+
+def context_fill_ratio(event: TraceEvent) -> float | None:
+    """Return current-request context fill, or ``None`` without token usage."""
+    if event.event_type not in {
+        EventType.LLM_REQUEST, EventType.LLM_RESPONSE, EventType.ASSISTANT_RESPONSE,
+    }:
+        return None
+    input_tokens = _input_token_count(event.data)
+    if input_tokens is None:
+        return None
+    return input_tokens / _context_limit(event.data)
+
+
+def build_checkpoint_markdown(
+    events: list[TraceEvent],
+    session_id: str,
+    timestamp: float | None = None,
+) -> str:
+    """Summarize recoverable session state as deterministic Markdown."""
+    if timestamp is None:
+        timestamp = events[-1].timestamp if events else 0.0
+    base_timestamp = events[0].timestamp if events else timestamp
+    offset = max(0.0, timestamp - base_timestamp)
+    items = _context_items(events, len(events))
+    task = next((item.text for item in items if item.kind == "Task goal"), "Not detected")
+    constraints = [item.text for item in items if item.kind == "Constraint"]
+    decisions = [item.text for item in items if item.kind == "Decision"]
+
+    read_entries: list[tuple[str, float]] = []
+    seen_reads: set[str] = set()
+    modified: list[str] = []
+    seen_modified: set[str] = set()
+    for event in events:
+        path = _read_path(event)
+        if path and path not in seen_reads:
+            seen_reads.add(path)
+            read_entries.append((path, max(0.0, event.timestamp - base_timestamp)))
+        path = _write_path(event)
+        if path and path not in seen_modified:
+            seen_modified.add(path)
+            modified.append(path)
+
+    last_response = next(
+        (
+            _event_text(event) for event in reversed(events)
+            if event.event_type in {EventType.ASSISTANT_RESPONSE, EventType.LLM_RESPONSE}
+            and _event_text(event)
+        ),
+        "",
+    )
+    current_parts: list[str] = []
+    if modified:
+        current_parts.append("Modified files: " + ", ".join(modified))
+    if last_response:
+        current_parts.append("Latest agent state: " + _SPACE_RE.sub(" ", last_response)[:400])
+    if not current_parts:
+        current_parts.append("No file modifications or agent response detected yet")
+
+    lines = [
+        f"# Session checkpoint - {session_id} - {_format_offset(offset)}",
+        "",
+        "## Task",
+        task,
+        "",
+        "## Constraints",
+    ]
+    lines.extend(f"- {value}" for value in constraints)
+    if not constraints:
+        lines.append("- None detected")
+    lines.extend(["", "## Files read"])
+    lines.extend(
+        f"- {path} (read at {_format_offset(read_offset)})"
+        for path, read_offset in read_entries
+    )
+    if not read_entries:
+        lines.append("- None detected")
+    lines.extend(["", "## Decisions made"])
+    lines.extend(f"- {value}" for value in decisions)
+    if not decisions:
+        lines.append("- None detected")
+    lines.extend(["", "## Current state"])
+    lines.extend(f"- {value}" for value in current_parts)
+    return "\n".join(lines) + "\n"
+
+
+def write_checkpoint(
+    store: TraceStore,
+    session_id: str,
+    events: list[TraceEvent] | None = None,
+    timestamp: float | None = None,
+) -> Path:
+    """Write ``checkpoints/<session>.md`` without touching trace storage."""
+    if events is None:
+        events = store.load_events(session_id)
+    checkpoint_dir = store.base_dir / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_dir / f"{session_id}.md"
+    path.write_text(
+        build_checkpoint_markdown(events, session_id, timestamp), encoding="utf-8",
+    )
+    return path
+
+
+@dataclass
+class CompactionCheckpointWatcher:
+    """Stateful watch-loop adapter that writes once per context-growth cycle."""
+
+    store: TraceStore
+    session_id: str
+    checkpoint_at: float = DEFAULT_CHECKPOINT_AT
+    compaction_threshold: float = DEFAULT_COMPACTION_THRESHOLD
+    events: list[TraceEvent] = field(default_factory=list)
+    _armed: bool = field(default=True, init=False, repr=False)
+    _last_tokens: int | None = field(default=None, init=False, repr=False)
+    _last_tokens_by_stream: dict[str, int] = field(
+        default_factory=dict, init=False, repr=False,
+    )
+    _pending_previous_by_stream: dict[str, int | None] = field(
+        default_factory=dict, init=False, repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        if not 0 < self.checkpoint_at <= 1:
+            raise ValueError("checkpoint threshold must be between 0 and 1")
+        if not 0 < self.compaction_threshold < 1:
+            raise ValueError("compaction threshold must be between 0 and 1")
+        if not self.events:
+            self.events = self.store.load_events(self.session_id)
+        samples = _request_samples(self.events)
+        if samples:
+            self._last_tokens = samples[-1].input_tokens
+            for sample in samples:
+                if not sample.estimated:
+                    self._last_tokens_by_stream[sample.stream_id] = sample.input_tokens
+
+        # Preserve a request/response pairing that was still open when watch
+        # attached.  Subsequent updates stay O(1) instead of reconstructing all
+        # request samples for every tailed LLM event.
+        previous_exact: dict[str, int] = {}
+        for existing in self.events:
+            stream_id = _event_stream(existing)
+            if existing.event_type == EventType.LLM_REQUEST:
+                self._pending_previous_by_stream[stream_id] = previous_exact.get(
+                    stream_id
+                )
+                explicit = _input_token_count(existing.data)
+                if explicit is not None:
+                    previous_exact[stream_id] = explicit
+            elif existing.event_type in {
+                EventType.LLM_RESPONSE, EventType.ASSISTANT_RESPONSE,
+            }:
+                explicit = _input_token_count(existing.data)
+                if explicit is not None:
+                    self._pending_previous_by_stream.pop(stream_id, None)
+                    previous_exact[stream_id] = explicit
+
+    def checkpoint_current(self) -> Path | None:
+        """Checkpoint an already-saturated session when watch starts."""
+        samples = _request_samples(self.events)
+        if not samples or not self._armed:
+            return None
+        latest_exact_by_stream: dict[str, _RequestSample] = {}
+        for sample in samples:
+            if not sample.estimated:
+                latest_exact_by_stream[sample.stream_id] = sample
+        saturated: list[tuple[float, _RequestSample, TraceEvent]] = []
+        for sample in latest_exact_by_stream.values():
+            source_event = self.events[sample.event_index]
+            ratio = sample.input_tokens / _context_limit(source_event.data)
+            if ratio >= self.checkpoint_at:
+                saturated.append((ratio, sample, source_event))
+        if not saturated:
+            return None
+        _ratio, _sample, source_event = max(
+            saturated, key=lambda item: (item[0], item[1].timestamp),
+        )
+        self._armed = False
+        return write_checkpoint(
+            self.store, self.session_id, self.events, source_event.timestamp,
+        )
+
+    def update(self, event: TraceEvent) -> Path | None:
+        """Process a newly tailed event and return a written path, if any."""
+        self.events.append(event)
+        if event.event_type not in {
+            EventType.LLM_REQUEST,
+            EventType.LLM_RESPONSE,
+            EventType.ASSISTANT_RESPONSE,
+        }:
+            return None
+        stream_id = _event_stream(event)
+        explicit = _input_token_count(event.data)
+
+        if event.event_type == EventType.LLM_REQUEST:
+            previous_tokens = self._last_tokens_by_stream.get(stream_id)
+            self._pending_previous_by_stream[stream_id] = previous_tokens
+            # Checkpoints, like compaction reports, require provider-reported
+            # usage.  A paired response can supply it later.
+            if explicit is None:
+                return None
+        else:
+            if explicit is None:
+                return None
+            previous_tokens = self._pending_previous_by_stream.pop(
+                stream_id, self._last_tokens_by_stream.get(stream_id),
+            )
+
+        if explicit is None:
+            return None
+        if (
+            previous_tokens is not None
+            and explicit < previous_tokens
+            and (previous_tokens - explicit) / previous_tokens
+            > self.compaction_threshold
+        ):
+            self._armed = True
+        self._last_tokens = explicit
+        self._last_tokens_by_stream[stream_id] = explicit
+
+        ratio = explicit / _context_limit(event.data)
+        if ratio < self.checkpoint_at or not self._armed:
+            return None
+        self._armed = False
+        return write_checkpoint(
+            self.store, self.session_id, self.events, event.timestamp,
+        )
+
+
+def _rule_post_compaction_regression(events: list[TraceEvent], cfg: dict) -> list[Any]:
+    """Lint rule adapter; imported by ``lint.py`` to avoid a module cycle."""
+    from .lint import LintLevel, LintResult
+
+    level = cfg.get("level", LintLevel.WARN)
+    threshold = float(cfg.get("compaction_threshold", DEFAULT_COMPACTION_THRESHOLD))
+    behavior_window = int(cfg.get("behavior_window", DEFAULT_BEHAVIOR_WINDOW))
+    redundant_threshold = int(cfg.get("redundant_read_threshold", 3))
+    tool_loop_threshold = int(cfg.get("tool_loop_threshold", 5))
+    findings: list[LintResult] = []
+    for compaction in detect_compactions(events, threshold):
+        behavior = behavior_diff_for_compaction(
+            events,
+            compaction,
+            window=behavior_window,
+            redundant_read_threshold=redundant_threshold,
+            tool_loop_threshold=tool_loop_threshold,
+        )
+        if not behavior.regressed:
+            continue
+        findings.append(LintResult(
+            rule="post-compaction-regression",
+            level=level,
+            message=(
+                f"Behavior regressed after compaction #{compaction.sequence} "
+                f"({compaction.drop_ratio * 100:.0f}% context drop): "
+                + "; ".join(behavior.regressions)
+                + "."
+            ),
+            line_start=compaction.event_index + 1,
+        ))
+    return findings
+
+
+def cmd_compaction(args: argparse.Namespace) -> int:
+    """CLI handler registered by :mod:`agent_trace.cli`."""
+    store = TraceStore(args.trace_dir)
+    raw_session_id = getattr(args, "session_id", None) or store.get_latest_session_id()
+    if not raw_session_id:
+        sys.stderr.write("No sessions found.\n")
+        return 1
+    session_id = store.find_session(raw_session_id)
+    if not session_id:
+        sys.stderr.write(f"Session not found: {raw_session_id}\n")
+        return 1
+    threshold = float(
+        getattr(args, "compaction_threshold", DEFAULT_COMPACTION_THRESHOLD)
+    )
+    try:
+        report = analyse_compaction_session(store, session_id, threshold)
+    except ValueError as exc:
+        sys.stderr.write(f"compaction: {exc}\n")
+        return 2
+    format_compaction_report(
+        report,
+        out=sys.stdout,
+        show_diff=bool(getattr(args, "diff", False)),
+        show_behavior_diff=bool(getattr(args, "behavior_diff", False)),
+    )
+    return 0

--- a/src/agent_trace/jsonl_import.py
+++ b/src/agent_trace/jsonl_import.py
@@ -136,6 +136,27 @@ def _extract_text(content: Any) -> str:
     return ""
 
 
+def _explicit_sidechain_id(raw: dict[str, Any]) -> str:
+    """Return a provider-supplied sidechain identity when one is available."""
+    for key in ("agentId", "agent_id", "sidechainId", "sidechain_id"):
+        value = raw.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _is_compaction_summary(raw: dict[str, Any], text: str, pending: bool) -> bool:
+    """Recognise Claude Code's synthetic post-compaction user message."""
+    if raw.get("isCompactSummary") or raw.get("isCompactionSummary"):
+        return True
+    lowered = text.lstrip().lower()
+    if lowered.startswith(
+        "this session is being continued from a previous conversation that ran out of context"
+    ):
+        return True
+    return pending and bool(text)
+
+
 def import_jsonl(
     path: str | Path,
     store: TraceStore | None = None,
@@ -210,18 +231,50 @@ def import_jsonl(
     )
     store.create_session(meta)
 
+    # UUID ancestry keeps separate Claude sidechains separate even when the
+    # source version does not include an explicit agentId on every entry.
+    stream_by_uuid: dict[str, str] = {}
+    pending_compaction: set[str] = set()
+    pending_context: dict[str, str] = {}
+
     # Second pass: convert entries to TraceEvents
     for raw in entries:
         entry_type = raw.get("type", "")
         ts = _parse_iso_timestamp(raw.get("timestamp", ""))
         msg = raw.get("message", {})
         if not isinstance(msg, dict):
-            continue
+            msg = {}
 
         content = msg.get("content", "")
         usage = msg.get("usage", {})
         model = msg.get("model", "")
-        is_sidechain = raw.get("isSidechain", False)
+        is_sidechain = bool(raw.get("isSidechain", False))
+        raw_uuid = str(raw.get("uuid", ""))
+        parent_uuid = str(raw.get("parentUuid", ""))
+        if is_sidechain:
+            explicit_id = _explicit_sidechain_id(raw)
+            inherited = stream_by_uuid.get(parent_uuid, "")
+            if explicit_id:
+                context_stream = f"sidechain:{explicit_id}"
+            elif inherited and inherited != "main":
+                context_stream = inherited
+            else:
+                context_stream = f"sidechain:{raw_uuid or parent_uuid or 'unknown'}"
+        else:
+            context_stream = "main"
+        if raw_uuid:
+            stream_by_uuid[raw_uuid] = context_stream
+
+        provenance: dict[str, Any] = {"context_stream": context_stream}
+        if is_sidechain:
+            provenance["is_sidechain"] = True
+        if raw_uuid:
+            provenance["source_uuid"] = raw_uuid
+        if parent_uuid:
+            provenance["source_parent_uuid"] = parent_uuid
+        explicit_id = _explicit_sidechain_id(raw)
+        if explicit_id:
+            provenance["source_agent_id"] = explicit_id
 
         # User entry
         if entry_type == "user":
@@ -240,6 +293,7 @@ def import_jsonl(
                         data={
                             "tool_use_id": tr["tool_use_id"],
                             "content_preview": preview,
+                            **provenance,
                         },
                     )
                     store.append_event(meta.session_id, event)
@@ -261,16 +315,31 @@ def import_jsonl(
                             data={
                                 "result": result_text,
                                 "content_types": ["text"],
+                                **provenance,
                             },
                         )
                         store.append_event(meta.session_id, event)
 
             if text and not text.startswith("{"):
+                is_summary = _is_compaction_summary(
+                    raw, text, context_stream in pending_compaction,
+                )
+                prompt_data: dict[str, Any] = {
+                    "prompt": text[:2000],
+                    **provenance,
+                }
+                if is_summary:
+                    prompt_data.update({
+                        "is_compaction_summary": True,
+                        "context_summary": text,
+                    })
+                    pending_context[context_stream] = text
+                    pending_compaction.discard(context_stream)
                 event = TraceEvent(
                     event_type=EventType.USER_PROMPT,
                     timestamp=ts,
                     session_id=meta.session_id,
-                    data={"prompt": text[:2000]},
+                    data=prompt_data,
                 )
                 store.append_event(meta.session_id, event)
 
@@ -286,10 +355,8 @@ def import_jsonl(
                         "tool_name": tc["name"],
                         "arguments": tc["input"],
                         "request_id": tc["id"],
+                        **provenance,
                     }
-                    # Tag subagent calls
-                    if is_sidechain:
-                        tool_data["is_sidechain"] = True
                     caller = tc.get("caller", {})
                     if caller.get("type"):
                         tool_data["caller_type"] = caller["type"]
@@ -311,15 +378,23 @@ def import_jsonl(
             # Log assistant text whenever present, including messages that also
             # contain tool calls (Claude Code often emits reasoning text alongside
             # a tool_use block in the same message).
-            if text:
+            if text or usage:
+                response_data: dict[str, Any] = {
+                    "model": model,
+                    **provenance,
+                }
+                if text:
+                    response_data["text"] = text[:2000]
+                if isinstance(usage, dict) and usage:
+                    response_data["usage"] = dict(usage)
+                summary = pending_context.pop(context_stream, "")
+                if summary:
+                    response_data["context_summary"] = summary
                 event = TraceEvent(
                     event_type=EventType.ASSISTANT_RESPONSE,
                     timestamp=ts,
                     session_id=meta.session_id,
-                    data={
-                        "text": text[:2000],
-                        "model": model,
-                    },
+                    data=response_data,
                 )
                 store.append_event(meta.session_id, event)
 
@@ -342,6 +417,15 @@ def import_jsonl(
                 duration_ms = raw.get("durationMs", 0)
                 if duration_ms:
                     meta.total_duration_ms += duration_ms
+            elif subtype in {"compact_boundary", "compaction_boundary"}:
+                summary = _extract_text(raw.get("content", ""))
+                if not summary:
+                    summary = _extract_text(msg.get("content", ""))
+                if summary:
+                    pending_context[context_stream] = summary
+                    pending_compaction.discard(context_stream)
+                else:
+                    pending_compaction.add(context_stream)
 
     # Finalize session
     meta.ended_at = last_ts if last_ts > 0 else meta.started_at

--- a/src/agent_trace/lint.py
+++ b/src/agent_trace/lint.py
@@ -85,6 +85,12 @@ DEFAULT_CONFIG: dict = {
         "level": LintLevel.INFO,
         "threshold": 0.80,     # fraction of context window
     },
+    "post-compaction-regression": {
+        "enabled": True,
+        "level": LintLevel.WARN,
+        "compaction_threshold": 0.50,
+        "behavior_window": 50,
+    },
     "redundant-read": {
         "enabled": True,
         "level": LintLevel.INFO,
@@ -387,6 +393,15 @@ def _rule_no_output(events: list[TraceEvent], cfg: dict) -> list[LintResult]:
     return []
 
 
+def _rule_post_compaction_regression(
+    events: list[TraceEvent], cfg: dict,
+) -> list[LintResult]:
+    """Run the compaction analyzer lazily to keep module imports acyclic."""
+    from .compaction import _rule_post_compaction_regression as compaction_rule
+
+    return compaction_rule(events, cfg)
+
+
 # ---------------------------------------------------------------------------
 # Rule registry
 # ---------------------------------------------------------------------------
@@ -396,6 +411,7 @@ _RULES: dict[str, Callable[[list[TraceEvent], dict], list[LintResult]]] = {
     "reasoning-spiral": _rule_reasoning_spiral,
     "budget-proximity": _rule_budget_proximity,
     "context-saturation": _rule_context_saturation,
+    "post-compaction-regression": _rule_post_compaction_regression,
     "redundant-read": _rule_redundant_read,
     "error-retry-loop": _rule_error_retry_loop,
     "no-output": _rule_no_output,

--- a/src/agent_trace/retention.py
+++ b/src/agent_trace/retention.py
@@ -150,6 +150,17 @@ def _store_size_bytes(store: TraceStore) -> int:
     return total
 
 
+def _retained_session_size_bytes(store: TraceStore, session_id: str) -> int:
+    """Return session storage plus its compaction checkpoint sidecar."""
+    total = _session_size_bytes(store._session_dir(session_id))
+    checkpoint = store.base_dir / "checkpoints" / f"{session_id}.md"
+    try:
+        total += checkpoint.stat().st_size
+    except OSError:
+        pass
+    return total
+
+
 # ---------------------------------------------------------------------------
 # Retention logic
 # ---------------------------------------------------------------------------
@@ -216,7 +227,7 @@ def compute_sessions_to_delete(
             for meta in surviving:
                 if total <= max_bytes:
                     break
-                size = _session_size_bytes(store._session_dir(meta.session_id))
+                size = _retained_session_size_bytes(store, meta.session_id)
                 to_delete.add(meta.session_id)
                 total -= size
 
@@ -241,7 +252,7 @@ def get_retention_status(store: TraceStore, config: RetentionConfig) -> Retentio
     total_bytes = _store_size_bytes(store)
     to_delete = compute_sessions_to_delete(store, config)
     bytes_to_free = sum(
-        _session_size_bytes(store._session_dir(sid)) for sid in to_delete
+        _retained_session_size_bytes(store, sid) for sid in to_delete
     )
 
     return RetentionStatus(
@@ -266,9 +277,11 @@ def delete_sessions(
 
     for sid in session_ids:
         session_dir = store._session_dir(sid)
-        if not session_dir.exists():
-            continue
+        checkpoint_path = store.base_dir / "checkpoints" / f"{sid}.md"
         try:
+            checkpoint_path.unlink(missing_ok=True)
+            if not session_dir.exists():
+                continue
             shutil.rmtree(session_dir)
             deleted += 1
             if config.on_delete == "log":
@@ -335,7 +348,7 @@ def cmd_retention_clean(args: argparse.Namespace, out: TextIO = sys.stdout) -> i
         return 0
 
     bytes_to_free = sum(
-        _session_size_bytes(store._session_dir(sid)) for sid in to_delete
+        _retained_session_size_bytes(store, sid) for sid in to_delete
     )
     mb_to_free = bytes_to_free / (1024 * 1024)
 

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from .cost import _dollars, _event_tokens
+from .compaction import CompactionCheckpointWatcher
 from .models import EventType, TraceEvent
 from .postmortem import clear_heartbeat, write_heartbeat
 from .project_budget import (
@@ -1110,6 +1111,7 @@ def watch_session(
     dry_run: bool = False,
     stream_config: StreamConfig | None = None,
     project_budget_config: ProjectBudgetConfig | None = None,
+    checkpoint_watcher: CompactionCheckpointWatcher | None = None,
 ) -> None:
     """Watch a session's event stream and fire alerts on violations.
 
@@ -1145,6 +1147,13 @@ def watch_session(
         out.write(f"[watch] {len(nanny_rules)} nanny rule(s) active\n")
     if stream_config and stream_config.url:
         out.write(f"[watch] Streaming events to {stream_config.url}\n")
+    if checkpoint_watcher:
+        try:
+            checkpoint_path = checkpoint_watcher.checkpoint_current()
+            if checkpoint_path:
+                out.write(f"[watch] Compaction checkpoint written to {checkpoint_path}\n")
+        except OSError as exc:
+            out.write(f"[watch] Could not write compaction checkpoint: {exc}\n")
     out.flush()
 
     project_budget_base_spend = 0.0
@@ -1192,6 +1201,18 @@ def watch_session(
             event: TraceEvent = item  # type: ignore[assignment]
             event_count += 1
             last_event_time = time.time()
+
+            if checkpoint_watcher:
+                try:
+                    checkpoint_path = checkpoint_watcher.update(event)
+                    if checkpoint_path:
+                        out.write(
+                            f"[watch] Compaction checkpoint written to {checkpoint_path}\n"
+                        )
+                        out.flush()
+                except OSError as exc:
+                    out.write(f"[watch] Could not write compaction checkpoint: {exc}\n")
+                    out.flush()
 
             # Push event to stream if configured
             if streamer:
@@ -1339,6 +1360,18 @@ def cmd_watch(args: argparse.Namespace) -> int:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
 
+    checkpoint_watcher: CompactionCheckpointWatcher | None = None
+    if getattr(args, "compaction_checkpoint", False):
+        try:
+            checkpoint_watcher = CompactionCheckpointWatcher(
+                store,
+                full_id,
+                checkpoint_at=float(getattr(args, "checkpoint_at", 0.80)),
+            )
+        except ValueError as exc:
+            sys.stderr.write(f"[watch] invalid checkpoint threshold: {exc}\n")
+            return 1
+
     # Build StreamConfig if --stream-to was provided
     stream_cfg: StreamConfig | None = None
     stream_url = getattr(args, "stream_to", None)
@@ -1358,6 +1391,7 @@ def cmd_watch(args: argparse.Namespace) -> int:
         dry_run=dry_run,
         stream_config=stream_cfg,
         project_budget_config=project_budget_config,
+        checkpoint_watcher=checkpoint_watcher,
     )
     return 0
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,703 @@
+"""Tests for deterministic context compaction analysis (issue #217)."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.compaction import (
+    CompactionCheckpointWatcher,
+    analyze_compactions,
+    behavior_diff_for_compaction,
+    build_checkpoint_markdown,
+    cmd_compaction,
+    context_diff_for_compaction,
+    context_fill_ratio,
+    detect_compactions,
+    format_compaction_report,
+    write_checkpoint,
+    _rule_post_compaction_regression,
+)
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.jsonl_import import import_jsonl
+from agent_trace.store import TraceStore
+
+
+def _event(event_type: EventType, timestamp: float, **data) -> TraceEvent:
+    return TraceEvent(
+        event_type=event_type,
+        timestamp=timestamp,
+        session_id="session-1",
+        data=data,
+    )
+
+
+def _request(timestamp: float, tokens: int, **data) -> TraceEvent:
+    return _event(
+        EventType.LLM_REQUEST,
+        timestamp,
+        model="claude-sonnet-4",
+        input_tokens=tokens,
+        **data,
+    )
+
+
+def _read(timestamp: float, path: str) -> TraceEvent:
+    return _event(
+        EventType.TOOL_CALL,
+        timestamp,
+        tool_name="Read",
+        arguments={"file_path": path},
+    )
+
+
+def _store(events: list[TraceEvent]) -> tuple[tempfile.TemporaryDirectory, TraceStore, str]:
+    temporary = tempfile.TemporaryDirectory()
+    store = TraceStore(temporary.name, redact=False)
+    meta = SessionMeta(session_id="session-1", started_at=events[0].timestamp if events else 0)
+    store.create_session(meta)
+    for event in events:
+        store.append_event(meta.session_id, event)
+    return temporary, store, meta.session_id
+
+
+class CompactionDetectionTests(unittest.TestCase):
+    def test_detects_drop_greater_than_threshold_and_estimates_cost(self):
+        events = [_request(100.0, 180_000), _request(142.0, 12_000)]
+
+        compactions = detect_compactions(events)
+
+        self.assertEqual(len(compactions), 1)
+        event = compactions[0]
+        self.assertEqual(event.before_request_index, 1)
+        self.assertEqual(event.after_request_index, 2)
+        self.assertEqual(event.tokens_dropped, 168_000)
+        self.assertAlmostEqual(event.drop_ratio, 168_000 / 180_000)
+        self.assertAlmostEqual(event.estimated_cost_usd, 0.504)
+        self.assertEqual(event.offset_seconds, 42.0)
+
+    def test_exactly_fifty_percent_is_not_more_than_threshold(self):
+        self.assertEqual(
+            detect_compactions([_request(1, 1000), _request(2, 500)]),
+            [],
+        )
+        self.assertEqual(
+            len(detect_compactions(
+                [_request(1, 1000), _request(2, 500)], threshold=0.49,
+            )),
+            1,
+        )
+
+    def test_rejects_invalid_threshold(self):
+        with self.assertRaisesRegex(ValueError, "between 0 and 1"):
+            detect_compactions([], threshold=1.0)
+
+    def test_uses_response_usage_for_request_context(self):
+        events = [
+            _event(EventType.LLM_REQUEST, 1, model="gpt-4o", messages=[]),
+            _event(
+                EventType.LLM_RESPONSE,
+                2,
+                model="gpt-4o",
+                usage={"prompt_tokens": 120_000, "completion_tokens": 10},
+            ),
+            _event(EventType.LLM_REQUEST, 3, model="gpt-4o", messages=[]),
+            _event(
+                EventType.LLM_RESPONSE,
+                4,
+                model="gpt-4o",
+                usage={"prompt_tokens": 10_000, "completion_tokens": 10},
+            ),
+        ]
+
+        compactions = detect_compactions(events)
+
+        self.assertEqual(len(compactions), 1)
+        self.assertEqual(compactions[0].tokens_before, 120_000)
+        self.assertEqual(compactions[0].tokens_after, 10_000)
+
+    def test_includes_cache_tokens_and_response_only_imported_turns(self):
+        # Claude Code imports can retain one usage-bearing assistant event per turn.
+        events = [
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                1,
+                model="claude-sonnet-4",
+                usage={
+                    "input_tokens": 1_000,
+                    "cache_creation_input_tokens": 20_000,
+                    "cache_read_input_tokens": 160_000,
+                },
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                2,
+                model="claude-sonnet-4",
+                usage={"input_tokens": 12_000},
+            ),
+        ]
+
+        compactions = detect_compactions(events)
+
+        self.assertEqual(len(compactions), 1)
+        self.assertEqual(compactions[0].tokens_before, 181_000)
+        self.assertEqual(compactions[0].tokens_after, 12_000)
+
+    def test_does_not_report_or_price_estimated_only_context_drops(self):
+        events = [
+            _event(EventType.LLM_REQUEST, 1, prompt="x" * 40_000),
+            _event(EventType.LLM_REQUEST, 2, prompt="short"),
+        ]
+
+        self.assertEqual(detect_compactions(events), [])
+
+    def test_compares_only_requests_from_the_same_context_stream(self):
+        events = [
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                1,
+                context_stream="main",
+                usage={"input_tokens": 180_000},
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                2,
+                context_stream="sidechain:research",
+                usage={"input_tokens": 10_000},
+            ),
+        ]
+
+        self.assertEqual(detect_compactions(events), [])
+
+        events.extend([
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                3,
+                context_stream="sidechain:review",
+                usage={"input_tokens": 180_000},
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                4,
+                context_stream="main",
+                usage={"input_tokens": 185_000},
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                5,
+                context_stream="sidechain:review",
+                context_summary="Review the compaction implementation.",
+                usage={"input_tokens": 12_000},
+            ),
+        ])
+
+        compactions = detect_compactions(events)
+        self.assertEqual(len(compactions), 1)
+        self.assertEqual(compactions[0].stream_id, "sidechain:review")
+
+
+class ImportedCompactionTests(unittest.TestCase):
+    def test_imported_usage_and_compaction_summary_drive_the_report(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        source = Path(temporary.name) / "claude.jsonl"
+        entries = [
+            {
+                "type": "user",
+                "sessionId": "imported-session",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "uuid": "u1",
+                "message": {
+                    "role": "user",
+                    "content": (
+                        "Implement rate limiting middleware.\n"
+                        "Do not modify src/auth.py."
+                    ),
+                },
+            },
+            {
+                "type": "assistant",
+                "sessionId": "imported-session",
+                "timestamp": "2025-01-01T00:00:01Z",
+                "uuid": "a1",
+                "parentUuid": "u1",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [{"type": "text", "text": "Working on it."}],
+                    "usage": {"input_tokens": 180_000, "output_tokens": 10},
+                },
+            },
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "sessionId": "imported-session",
+                "timestamp": "2025-01-01T00:00:02Z",
+                "uuid": "c1",
+            },
+            {
+                "type": "user",
+                "sessionId": "imported-session",
+                "timestamp": "2025-01-01T00:00:03Z",
+                "uuid": "u2",
+                "parentUuid": "c1",
+                "message": {
+                    "role": "user",
+                    "content": (
+                        "This session is being continued from a previous conversation "
+                        "that ran out of context. Implement rate limiting middleware."
+                    ),
+                },
+            },
+            {
+                "type": "assistant",
+                "sessionId": "imported-session",
+                "timestamp": "2025-01-01T00:00:04Z",
+                "uuid": "a2",
+                "parentUuid": "u2",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [{"type": "text", "text": "Continuing."}],
+                    "usage": {"input_tokens": 12_000, "output_tokens": 10},
+                },
+            },
+        ]
+        source.write_text(
+            "".join(json.dumps(entry) + "\n" for entry in entries),
+            encoding="utf-8",
+        )
+        store = TraceStore(Path(temporary.name) / "traces", redact=False)
+
+        session_id = import_jsonl(source, store=store)
+        events = store.load_events(session_id)
+        report = analyze_compactions(events, session_id)
+
+        self.assertEqual(len(report.events), 1)
+        compaction = report.events[0]
+        self.assertEqual(compaction.tokens_before, 180_000)
+        self.assertEqual(compaction.tokens_after, 12_000)
+        self.assertTrue(compaction.context_diff.context_available)
+        survived = {item.text for item in compaction.context_diff.survived}
+        dropped = {item.text for item in compaction.context_diff.likely_dropped}
+        self.assertIn("Implement rate limiting middleware.", survived)
+        self.assertIn("Do not modify src/auth.py.", dropped)
+
+    def test_response_text_is_not_treated_as_the_compaction_summary(self):
+        events = [
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                1,
+                text="Original response",
+                usage={"input_tokens": 180_000},
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                2,
+                text="A short answer, not the retained context",
+                usage={"input_tokens": 12_000},
+            ),
+        ]
+
+        compaction = detect_compactions(events)[0]
+        diff = context_diff_for_compaction(events, compaction)
+
+        self.assertFalse(diff.context_available)
+        self.assertEqual(diff.survived, [])
+        self.assertEqual(diff.likely_dropped, [])
+
+
+class ContextAndBehaviorDiffTests(unittest.TestCase):
+    def setUp(self):
+        self.events = [
+            _event(
+                EventType.USER_PROMPT,
+                1,
+                prompt=(
+                    "Implement rate limiting middleware.\n"
+                    "It must be Redis-compatible.\n"
+                    "Do not modify src/auth.py."
+                ),
+            ),
+            _read(2, "src/middleware.py"),
+            _read(3, "src/config.py"),
+            _event(
+                EventType.DECISION,
+                4,
+                decision="Token bucket chosen over fixed window",
+                reason="memory cost",
+            ),
+            _request(5, 190_000, messages=[{"role": "user", "content": "work"}]),
+            _request(
+                6,
+                12_000,
+                messages=[{
+                    "role": "system",
+                    "content": (
+                        "Continue implementing rate limiting middleware with a token bucket. "
+                        "Previously read src/middleware.py."
+                    ),
+                }],
+            ),
+            _read(7, "src/middleware.py"),
+            _read(8, "src/middleware.py"),
+            _read(9, "src/middleware.py"),
+            _event(
+                EventType.TOOL_CALL,
+                10,
+                tool_name="Bash",
+                arguments={"command": "ls src"},
+            ),
+        ]
+        self.compaction = detect_compactions(self.events)[0]
+
+    def test_context_diff_identifies_survived_and_high_risk_dropped_items(self):
+        diff = context_diff_for_compaction(self.events, self.compaction)
+
+        survived = {(item.kind, item.text) for item in diff.survived}
+        dropped = {(item.kind, item.text) for item in diff.likely_dropped}
+        self.assertIn(("Task goal", "Implement rate limiting middleware."), survived)
+        self.assertIn(("File read", "src/middleware.py"), survived)
+        self.assertIn(("Constraint", "It must be Redis-compatible."), dropped)
+        self.assertIn(("Constraint", "Do not modify src/auth.py."), dropped)
+        self.assertEqual(len(diff.high_risk_drops), 2)
+
+    def test_context_diff_inventories_modified_files(self):
+        events = [
+            _event(EventType.USER_PROMPT, 1, prompt="Implement middleware."),
+            _event(EventType.FILE_WRITE, 2, path="src/middleware.py"),
+            _request(3, 180_000),
+            _request(4, 10_000, context_summary="Implement middleware."),
+        ]
+
+        diff = context_diff_for_compaction(events, detect_compactions(events)[0])
+
+        self.assertIn(
+            ("File modified", "src/middleware.py"),
+            {(item.kind, item.text) for item in diff.likely_dropped},
+        )
+
+    def test_behavior_diff_flags_rereads_redundancy_and_reexploration(self):
+        behavior = behavior_diff_for_compaction(
+            self.events,
+            self.compaction,
+            redundant_read_threshold=3,
+        )
+
+        self.assertTrue(behavior.regressed)
+        self.assertEqual(behavior.reread_files, ("src/middleware.py",))
+        self.assertEqual(behavior.before.redundant_read_violations, 0)
+        self.assertEqual(behavior.after.redundant_read_violations, 1)
+        self.assertEqual(behavior.after.reexploration_calls, 1)
+        self.assertTrue(any("re-read" in reason for reason in behavior.regressions))
+
+    def test_behavior_diff_includes_saturation_and_registered_lint_rules(self):
+        events = [
+            _request(1, 100_000),
+            _request(2, 10_000),
+            _request(3, 180_000),
+            _event(EventType.TOOL_CALL, 4, tool_name="Bash", arguments={}),
+            _event(EventType.ERROR, 5, message="failed"),
+            _event(EventType.TOOL_CALL, 6, tool_name="Bash", arguments={}),
+            _event(EventType.ERROR, 7, message="failed"),
+            _event(EventType.TOOL_CALL, 8, tool_name="Bash", arguments={}),
+            _event(EventType.ERROR, 9, message="failed"),
+        ]
+        compaction = detect_compactions(events)[0]
+
+        behavior = behavior_diff_for_compaction(events, compaction)
+
+        self.assertEqual(behavior.before.context_saturation_violations, 0)
+        self.assertEqual(behavior.after.context_saturation_violations, 1)
+        self.assertIn(("context-saturation", 0, 1), behavior.lint_deltas)
+        self.assertIn(("error-retry-loop", 0, 1), behavior.lint_deltas)
+        self.assertTrue(any(
+            "context-saturation" in reason for reason in behavior.regressions
+        ))
+
+    def test_behavior_window_counts_events_from_only_the_compacted_stream(self):
+        events = [
+            _read(1, "src/a.py"),
+            _request(2, 180_000),
+            _request(3, 10_000),
+            _event(
+                EventType.TOOL_CALL,
+                4,
+                context_stream="sidechain:review",
+                tool_name="Read",
+                arguments={"file_path": "review-1.py"},
+            ),
+            _read(5, "src/a.py"),
+            _event(
+                EventType.TOOL_CALL,
+                6,
+                context_stream="sidechain:review",
+                tool_name="Read",
+                arguments={"file_path": "review-2.py"},
+            ),
+            _read(7, "src/a.py"),
+            _event(
+                EventType.TOOL_CALL,
+                8,
+                context_stream="sidechain:review",
+                tool_name="Read",
+                arguments={"file_path": "review-3.py"},
+            ),
+            _read(9, "src/a.py"),
+        ]
+
+        behavior = behavior_diff_for_compaction(
+            events, detect_compactions(events)[0], window=4,
+        )
+
+        self.assertEqual(behavior.after.redundant_read_violations, 1)
+
+    def test_report_and_formatter_include_requested_sections(self):
+        report = analyze_compactions(self.events, "session-1")
+        output = io.StringIO()
+
+        format_compaction_report(
+            report, output, show_diff=True, show_behavior_diff=True,
+        )
+
+        text = output.getvalue()
+        self.assertIn("1 compaction event(s)", text)
+        self.assertIn("Estimated cost of dropped context", text)
+        self.assertIn("Likely dropped", text)
+        self.assertIn("High-risk drop", text)
+        self.assertIn("Behavior change after compaction #1", text)
+        self.assertIn("Verdict: behavior regressed", text)
+
+    def test_no_event_report_is_explicit(self):
+        output = io.StringIO()
+        format_compaction_report(analyze_compactions([], "empty"), output)
+        self.assertIn("No compaction events detected", output.getvalue())
+
+
+class CheckpointTests(unittest.TestCase):
+    def setUp(self):
+        self.events = [
+            _event(
+                EventType.USER_PROMPT,
+                100,
+                prompt="Implement rate limiting. Must use Redis. Do not modify auth.py.",
+            ),
+            _read(112, "src/middleware.py"),
+            _event(
+                EventType.DECISION,
+                118,
+                decision="Chose token bucket instead of fixed window",
+            ),
+            _event(
+                EventType.FILE_WRITE,
+                124,
+                path="src/middleware.py",
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                130,
+                text="Middleware implemented; tests are not yet passing.",
+            ),
+            _request(138, 170_000, context_window=200_000),
+        ]
+
+    def test_build_checkpoint_contains_recoverable_state(self):
+        markdown = build_checkpoint_markdown(self.events, "session-1", timestamp=138)
+
+        self.assertIn("# Session checkpoint - session-1 - 0m 38s", markdown)
+        self.assertIn("## Task\nImplement rate limiting.", markdown)
+        self.assertIn("- Must use Redis.", markdown)
+        self.assertIn("- Do not modify auth.py.", markdown)
+        self.assertIn("src/middleware.py (read at 0m 12s)", markdown)
+        self.assertIn("Chose token bucket instead of fixed window", markdown)
+        self.assertIn("Modified files: src/middleware.py", markdown)
+
+    def test_write_checkpoint_is_additive_sidecar(self):
+        temporary, store, session_id = _store(self.events)
+        self.addCleanup(temporary.cleanup)
+        events_path = store._session_dir(session_id) / "events.ndjson"
+        original_events = events_path.read_text()
+
+        path = write_checkpoint(store, session_id)
+
+        self.assertEqual(path, Path(temporary.name) / "checkpoints" / "session-1.md")
+        self.assertTrue(path.exists())
+        self.assertEqual(events_path.read_text(), original_events)
+
+    def test_context_fill_ratio_reads_nested_usage(self):
+        event = _event(
+            EventType.LLM_RESPONSE,
+            1,
+            model="claude-sonnet-4",
+            usage={"input_tokens": 160_000},
+        )
+        self.assertEqual(context_fill_ratio(event), 0.8)
+
+    def test_watcher_writes_once_then_rearms_after_compaction(self):
+        temporary, store, session_id = _store(self.events[:-1])
+        self.addCleanup(temporary.cleanup)
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        first = watcher.update(_request(138, 170_000, context_window=200_000))
+        duplicate = watcher.update(_request(140, 175_000, context_window=200_000))
+        compacted = watcher.update(_request(142, 10_000, context_window=200_000))
+        second = watcher.update(_request(150, 165_000, context_window=200_000))
+
+        self.assertIsNotNone(first)
+        self.assertIsNone(duplicate)
+        self.assertIsNone(compacted)
+        self.assertEqual(second, first)
+
+    def test_watcher_can_checkpoint_existing_saturated_context(self):
+        temporary, store, session_id = _store(self.events)
+        self.addCleanup(temporary.cleanup)
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        self.assertIsNotNone(watcher.checkpoint_current())
+        self.assertIsNone(watcher.checkpoint_current())
+
+    def test_existing_checkpoint_uses_latest_exact_sample_from_each_stream(self):
+        events = [
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                1,
+                context_stream="main",
+                model="claude-sonnet-4",
+                usage={"input_tokens": 180_000},
+            ),
+            _event(
+                EventType.ASSISTANT_RESPONSE,
+                2,
+                context_stream="sidechain:review",
+                model="claude-sonnet-4",
+                usage={"input_tokens": 10_000},
+            ),
+        ]
+        temporary, store, session_id = _store(events)
+        self.addCleanup(temporary.cleanup)
+
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        self.assertIsNotNone(watcher.checkpoint_current())
+
+    def test_existing_checkpoint_ignores_estimated_request_payloads(self):
+        events = [_event(
+            EventType.LLM_REQUEST,
+            1,
+            model="claude-sonnet-4",
+            prompt="x" * 800_000,
+        )]
+        temporary, store, session_id = _store(events)
+        self.addCleanup(temporary.cleanup)
+
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        self.assertIsNone(watcher.checkpoint_current())
+
+    def test_watcher_processes_updates_without_rescanning_history(self):
+        temporary, store, session_id = _store(self.events[:-1])
+        self.addCleanup(temporary.cleanup)
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        with patch(
+            "agent_trace.compaction._request_samples",
+            side_effect=AssertionError("watch update rescanned the session"),
+        ):
+            path = watcher.update(
+                _request(138, 170_000, context_window=200_000)
+            )
+
+        self.assertIsNotNone(path)
+
+    def test_watcher_uses_paired_response_usage_without_false_rearming(self):
+        temporary, store, session_id = _store(self.events[:-1])
+        self.addCleanup(temporary.cleanup)
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        request = _event(
+            EventType.LLM_REQUEST, 138, model="claude-sonnet-4", messages=[]
+        )
+        response = _event(
+            EventType.LLM_RESPONSE,
+            139,
+            model="claude-sonnet-4",
+            usage={"input_tokens": 170_000},
+        )
+
+        self.assertIsNone(watcher.update(request))
+        self.assertIsNotNone(watcher.update(response))
+
+    def test_watcher_pairs_interleaved_responses_with_their_stream(self):
+        temporary, store, session_id = _store(self.events[:-1])
+        self.addCleanup(temporary.cleanup)
+        watcher = CompactionCheckpointWatcher(store, session_id, checkpoint_at=0.8)
+
+        self.assertIsNone(watcher.update(_event(
+            EventType.LLM_REQUEST, 138, context_stream="main", messages=[],
+        )))
+        self.assertIsNone(watcher.update(_event(
+            EventType.LLM_REQUEST,
+            139,
+            context_stream="sidechain:review",
+            messages=[],
+        )))
+        checkpoint = watcher.update(_event(
+            EventType.LLM_RESPONSE,
+            140,
+            context_stream="main",
+            model="claude-sonnet-4",
+            usage={"input_tokens": 180_000},
+        ))
+
+        self.assertIsNotNone(checkpoint)
+        self.assertEqual(watcher._last_tokens_by_stream["main"], 180_000)
+
+
+class CompactionLintAndCommandTests(unittest.TestCase):
+    def test_post_compaction_regression_lint_rule(self):
+        events = [
+            _read(1, "src/a.py"),
+            _request(2, 180_000),
+            _request(3, 10_000),
+            _read(4, "src/a.py"),
+        ]
+
+        findings = _rule_post_compaction_regression(events, {})
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].rule, "post-compaction-regression")
+        self.assertEqual(findings[0].line_start, 3)
+        self.assertIn("re-read 1", findings[0].message)
+
+    def test_lint_rule_does_not_flag_compaction_without_regression(self):
+        events = [_request(1, 180_000), _request(2, 10_000)]
+        self.assertEqual(_rule_post_compaction_regression(events, {}), [])
+
+    def test_cmd_compaction_resolves_prefix_and_prints_report(self):
+        temporary, _store_instance, _session_id = _store([
+            _request(1, 180_000), _request(2, 10_000),
+        ])
+        self.addCleanup(temporary.cleanup)
+        args = argparse.Namespace(
+            trace_dir=temporary.name,
+            session_id="session",
+            compaction_threshold=0.5,
+            diff=False,
+            behavior_diff=False,
+        )
+        output = io.StringIO()
+
+        with patch("sys.stdout", output):
+            result = cmd_compaction(args)
+
+        self.assertEqual(result, 0)
+        self.assertIn("Compaction events - session session-1", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_jsonl_import.py
+++ b/tests/test_jsonl_import.py
@@ -70,6 +70,12 @@ class TestJSONLImport(unittest.TestCase):
         self.assertIn(EventType.USER_PROMPT, types)
         self.assertIn(EventType.ASSISTANT_RESPONSE, types)
         self.assertIn(EventType.SESSION_END, types)
+        response = next(
+            event for event in events
+            if event.event_type == EventType.ASSISTANT_RESPONSE
+        )
+        self.assertEqual(response.data["usage"]["input_tokens"], 100)
+        self.assertEqual(response.data["context_stream"], "main")
 
     def test_import_tool_calls(self):
         path = self._write_jsonl([
@@ -140,6 +146,109 @@ class TestJSONLImport(unittest.TestCase):
         self.assertEqual(len(tool_calls), 1)
         self.assertEqual(tool_calls[0].data["tool_name"], "Agent")
         self.assertEqual(tool_calls[0].data["subagent_type"], "Explore")
+
+    def test_import_preserves_stable_sidechain_identity(self):
+        path = self._write_jsonl([
+            {
+                "type": "assistant",
+                "sessionId": "sidechains",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "isSidechain": True,
+                "agentId": "research",
+                "uuid": "a1",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [],
+                    "usage": {"input_tokens": 100, "output_tokens": 1},
+                },
+            },
+            {
+                "type": "assistant",
+                "sessionId": "sidechains",
+                "timestamp": "2025-01-01T00:00:01Z",
+                "isSidechain": True,
+                "agentId": "research",
+                "uuid": "a2",
+                "parentUuid": "a1",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [],
+                    "usage": {"input_tokens": 90, "output_tokens": 1},
+                },
+            },
+            {
+                "type": "assistant",
+                "sessionId": "sidechains",
+                "timestamp": "2025-01-01T00:00:02Z",
+                "isSidechain": True,
+                "agentId": "review",
+                "uuid": "b1",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [],
+                    "usage": {"input_tokens": 80, "output_tokens": 1},
+                },
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        responses = [
+            event for event in self.store.load_events(session_id)
+            if event.event_type == EventType.ASSISTANT_RESPONSE
+        ]
+
+        self.assertEqual(responses[0].data["context_stream"], "sidechain:research")
+        self.assertEqual(responses[1].data["context_stream"], "sidechain:research")
+        self.assertEqual(responses[2].data["context_stream"], "sidechain:review")
+
+    def test_boundary_embedded_summary_is_not_overwritten_by_next_user(self):
+        path = self._write_jsonl([
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "sessionId": "embedded-summary",
+                "timestamp": "2025-01-01T00:00:00Z",
+                "uuid": "boundary",
+                "content": "Retain the Redis compatibility constraint.",
+            },
+            {
+                "type": "user",
+                "sessionId": "embedded-summary",
+                "timestamp": "2025-01-01T00:00:01Z",
+                "uuid": "user",
+                "parentUuid": "boundary",
+                "message": {"role": "user", "content": "Please continue."},
+            },
+            {
+                "type": "assistant",
+                "sessionId": "embedded-summary",
+                "timestamp": "2025-01-01T00:00:02Z",
+                "uuid": "assistant",
+                "parentUuid": "user",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-sonnet-4",
+                    "content": [],
+                    "usage": {"input_tokens": 10_000},
+                },
+            },
+        ])
+
+        session_id = import_jsonl(path, store=self.store)
+        events = self.store.load_events(session_id)
+        prompt = next(e for e in events if e.event_type == EventType.USER_PROMPT)
+        response = next(
+            e for e in events if e.event_type == EventType.ASSISTANT_RESPONSE
+        )
+
+        self.assertNotIn("is_compaction_summary", prompt.data)
+        self.assertEqual(
+            response.data["context_summary"],
+            "Retain the Redis compatibility constraint.",
+        )
 
     def test_import_queue_operations_skipped(self):
         path = self._write_jsonl([

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -373,6 +373,16 @@ class TestRuleNoOutput(unittest.TestCase):
 # Config loading
 # ---------------------------------------------------------------------------
 
+class TestCompactionRuleRegistration(unittest.TestCase):
+    def test_post_compaction_regression_is_enabled_and_registered(self):
+        from agent_trace import lint as lint_module
+
+        config = DEFAULT_CONFIG["post-compaction-regression"]
+        self.assertTrue(config["enabled"])
+        self.assertEqual(config["level"], LintLevel.WARN)
+        self.assertIn("post-compaction-regression", lint_module._RULES)
+
+
 class TestLoadConfig(unittest.TestCase):
     def test_defaults_returned_when_no_file(self):
         config = _load_config(None)

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -210,6 +210,33 @@ class TestDeleteSessions(unittest.TestCase):
         self.assertEqual(deleted, 1)
         self.assertFalse(session_dir.exists())
 
+    def test_deletes_compaction_checkpoint_with_session(self):
+        store, _ = _make_store()
+        meta = _add_session(store, age_days=40)
+        checkpoint = store.base_dir / "checkpoints" / f"{meta.session_id}.md"
+        checkpoint.parent.mkdir(parents=True)
+        checkpoint.write_text("sensitive recovery context")
+
+        deleted = delete_sessions(
+            store, [meta.session_id], RetentionConfig(on_delete="silent")
+        )
+
+        self.assertEqual(deleted, 1)
+        self.assertFalse(checkpoint.exists())
+
+    def test_deletes_orphaned_compaction_checkpoint(self):
+        store, _ = _make_store()
+        checkpoint = store.base_dir / "checkpoints" / "missing-session.md"
+        checkpoint.parent.mkdir(parents=True)
+        checkpoint.write_text("orphaned recovery context")
+
+        deleted = delete_sessions(
+            store, ["missing-session"], RetentionConfig(on_delete="silent")
+        )
+
+        self.assertEqual(deleted, 0)
+        self.assertFalse(checkpoint.exists())
+
     def test_logs_deletion_when_on_delete_log(self):
         store, tmpdir = _make_store()
         meta = _add_session(store, age_days=40)

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -23,6 +23,8 @@ from agent_trace.watch import (
     _detect_loop,
     _detect_spin_loop,
     _event_key,
+    cmd_watch,
+    watch_session,
 )
 
 
@@ -300,6 +302,76 @@ class TestBuiltInRules(unittest.TestCase):
         self.assertEqual(args.command, "watch")
         self.assertEqual(args.loop_threshold, 4)
         self.assertEqual(args.loop_window, 12)
+
+    def test_compaction_cli_and_watch_flags_are_registered(self):
+        parser = build_parser()
+        compaction = parser.parse_args([
+            "compaction", "abc123", "--diff", "--behavior-diff",
+            "--compaction-threshold", "0.65",
+        ])
+        self.assertEqual(compaction.command, "compaction")
+        self.assertEqual(compaction.session_id, "abc123")
+        self.assertTrue(compaction.diff)
+        self.assertTrue(compaction.behavior_diff)
+        self.assertEqual(compaction.compaction_threshold, 0.65)
+
+        watch = parser.parse_args([
+            "watch", "abc123", "--compaction-checkpoint", "--checkpoint-at", "0.75",
+        ])
+        self.assertTrue(watch.compaction_checkpoint)
+        self.assertEqual(watch.checkpoint_at, 0.75)
+
+    def test_cmd_watch_wires_compaction_checkpoint_watcher(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(tmp, redact=False)
+            meta = SessionMeta(session_id="checkpoint-session", started_at=1.0)
+            store.create_session(meta)
+            args = build_parser().parse_args([
+                "--trace-dir", tmp, "watch", meta.session_id,
+                "--compaction-checkpoint", "--checkpoint-at", "0.75",
+            ])
+
+            with patch("agent_trace.watch.watch_session") as watch_session_mock:
+                result = cmd_watch(args)
+
+            self.assertEqual(result, 0)
+            watcher = watch_session_mock.call_args.kwargs["checkpoint_watcher"]
+            self.assertIsNotNone(watcher)
+            self.assertEqual(watcher.checkpoint_at, 0.75)
+
+    def test_watch_loop_checks_existing_and_new_checkpoint_state(self):
+        class FakeCheckpointWatcher:
+            def __init__(self):
+                self.updated = []
+
+            def checkpoint_current(self):
+                return Path("initial-checkpoint.md")
+
+            def update(self, event):
+                self.updated.append(event)
+                return Path("updated-checkpoint.md") if len(self.updated) == 1 else None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = TraceStore(tmp, redact=False)
+            meta = SessionMeta(session_id="checkpoint-loop", started_at=1.0)
+            store.create_session(meta)
+            event = _make_event(EventType.LLM_REQUEST, 2.0, input_tokens=160_000)
+            end = _make_event(EventType.SESSION_END, 3.0, exit_code=0)
+            watcher = FakeCheckpointWatcher()
+            output = io.StringIO()
+
+            with patch("agent_trace.watch._tail_events", return_value=iter([event, end])):
+                watch_session(
+                    store,
+                    meta.session_id,
+                    _default_config(),
+                    out=output,
+                    checkpoint_watcher=watcher,
+                )
+
+            self.assertEqual(watcher.updated, [event, end])
+            self.assertIn("initial-checkpoint.md", output.getvalue())
+            self.assertIn("updated-checkpoint.md", output.getvalue())
 
     def test_mcp_poisoning_rule_alerts_on_exfil_sequence(self):
         config = WatcherConfig(built_in_rules={"mcp-poisoning"})


### PR DESCRIPTION
## Summary

- add `agent-strace compaction` to detect provider-reported context drops and estimate discarded-context cost
- diff retained versus likely-dropped goals, constraints, decisions, reads, and modified files per conversation sidechain
- compare pre/post-compaction lint and tool behavior, including re-reads, loops, exploration, and context saturation
- add `post-compaction-regression` to `agent-strace lint`
- add live pre-compaction Markdown checkpoints with per-stream, O(1) watcher state and retention cleanup
- preserve Claude JSONL usage, compaction summaries, and stable sidechain identity during import
- document analysis, checkpoint privacy, flags, and interpretation; bump the package to 0.89.0

Closes #217

## Verification

- `python -m unittest tests.test_compaction tests.test_jsonl_import -v` (36 passed)
- Ona `test` task (1,765 Python tests passed; 3 VS Code tests passed)
- `python -m py_compile src/agent_trace/compaction.py src/agent_trace/jsonl_import.py`
- `git diff --check`