### PR TITLE
feat: add multi-tenant session isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace budget-report`](docs/commands.md#budget-report) | Weekly spend digest |
 | [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
 | [`agent-strace cost --breakdown provider`](docs/commands.md#cost) | Offline spend by provider and model |
+| [`agent-strace tenant report`](docs/tenancy.md) | Per-customer cost, export, and erasure workflows |
 | [`agent-strace cognitive-debt`](docs/commands.md#cognitive-debt) | Unreviewed agent-written code by session |
 | [`agent-strace context-score`](docs/commands.md#context-score) | Score AGENTS.md and CLAUDE.md from session outcomes |
 | [`agent-strace lint <id>`](docs/commands.md#lint) | Flag bad behaviour patterns (loops, spirals, waste) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,9 +80,10 @@ Show the parent/child session hierarchy for a root session, including per-node c
 
 ### `list`
 ```
-agent-strace list
+agent-strace list [--tenant ID]
 ```
 List all captured sessions with ID, timestamp, duration, tool calls, and errors.
+`--tenant ID` performs an exact tenant match before listing metadata.
 
 ### `inspect`
 ```
@@ -127,6 +128,7 @@ Trace the causal chain backwards from event `#N`. Run `replay` first to see even
 ```
 agent-strace cost [session-id] [--model MODEL] [--input-price N] [--output-price N]
 agent-strace cost --breakdown provider [--since DATE_OR_DURATION] [--csv] [--live-pricing]
+agent-strace cost --tenant ID [--since DATE_OR_DURATION]
 ```
 Token and dollar cost by phase. Flags wasted spend on failed phases.
 
@@ -145,6 +147,7 @@ the stable columns `provider`, `model`, `session_id`, `input_tokens`,
 | `--since DATE_OR_DURATION` | `30d` | ISO date or duration such as `7d`, `24h`, or `2w` |
 | `--csv` | off | Emit raw per-session/model rows instead of the dashboard |
 | `--live-pricing` | off | Request authoritative live rates; error when compatible provider APIs are unavailable rather than scrape or guess |
+| `--tenant ID` | — | Scope an explicit session or aggregate the selected time window to one tenant |
 
 Pricing estimates exclude caching, batch discounts, regional or service-tier
 differences, long-context premiums, and non-token charges. To update the bundled
@@ -204,6 +207,7 @@ agent-strace watch [session-id] [--timeout DURATION] [--budget $N] [--on-violati
                    [--stream-batch-size N] [--stream-flush-interval S]
                    [--loop-threshold N] [--loop-window N] [--max-context-pct N]
                    [--compaction-checkpoint] [--checkpoint-at RATIO] [--dry-run]
+                   [--tenant-id ID]
 ```
 Live session monitor with kill-switch rules.
 
@@ -221,6 +225,7 @@ Live session monitor with kill-switch rules.
 | `--rules FILE_OR_BUILTINS` | JSON/YAML rules file, or comma-separated built-ins such as `mcp-poisoning,loop:3/10,budget:$5,timeout:30m,cognitive-debt:0.8` |
 | `--stream-to URL` | Stream events to HTTP endpoint in real-time |
 | `--dry-run` | Evaluate rules without acting |
+| `--tenant-id ID` | Tag the session and all events; defaults to `AGENT_STRACE_TENANT_ID` |
 
 **Project budget config** (`.agent-strace.yaml`):
 ```yaml
@@ -772,6 +777,17 @@ retention:
   max_size_mb: 500
   on_delete: log
 ```
+
+### `tenant`
+```
+agent-strace tenant report [--month YYYY-MM] [--model MODEL] [--format text|json]
+agent-strace tenant export ID [--format json] [--output FILE]
+agent-strace tenant delete ID --confirm
+```
+Report monthly cost allocation, produce a tenant-scoped subject access export,
+or irreversibly erase all local trace data for one tenant. Deletion requires
+`--confirm` and appends a minimal audit record. See the
+[multi-tenant deployment guide](tenancy.md) for isolation and GDPR notes.
 
 ---
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -66,10 +66,15 @@ docker run -p 4317:4317 -v $(pwd)/traces:/data agent-strace-server
 | `POST` | `/events` | Receive a batch of NDJSON events |
 | `POST` | `/sessions` | Create or update session metadata |
 | `GET` | `/sessions` | List all sessions |
+| `GET` | `/sessions/<id>` | Read metadata for a session |
 | `GET` | `/sessions/<id>/events` | Stream events for a session |
 | `GET` | `/health` | Liveness check |
 
 Events are accepted as NDJSON (`application/x-ndjson`), one event per line.
+GET session IDs are URL-decoded as one containment-safe path component, so
+legacy IDs containing spaces, Unicode, or more than 128 characters remain
+readable. POST routes retain the strict 1–128 character ASCII policy for new
+session IDs.
 
 ---
 
@@ -96,6 +101,13 @@ AGENT_STRACE_AUTH_KEY=ast_a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5 agent-strace server
 ```
 
 Requests without a matching `Authorization: Bearer <key>` header receive `401 Unauthorized`.
+
+The key authorizes the entire collector instance; it is not scoped to a
+`tenant_id`. Treat one collector and storage root as one organization boundary,
+and run separate authenticated instances for organizations that must not access
+one another. Tenant filters are customer-level scoping inside that boundary,
+not an authorization mechanism. Managed multi-organization hosting is tracked
+separately in [issue #129](https://github.com/Siddhant-K-code/agent-trace/issues/129).
 
 **Client side** — set `AGENT_STRACE_AUTH_KEY` alongside `AGENT_STRACE_ENDPOINT` and all outbound requests include the header automatically:
 

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -1,0 +1,159 @@
+# Multi-tenant agent deployments
+
+`agent-strace` can tag sessions and events with an application customer ID,
+scope queries and costs to that ID, and perform customer export and erasure
+workflows. Tenant tags are additive: sessions recorded before v0.90.0 remain
+readable and appear as `(untagged)`.
+
+## Tag every customer session
+
+Assign the tenant when monitoring an active session:
+
+```bash
+agent-strace watch --tenant-id customer-acme
+```
+
+For hooks, CI, auto-instrumentation, or other non-interactive capture paths,
+set the environment variable before the agent starts:
+
+```bash
+export AGENT_STRACE_TENANT_ID=customer-acme
+python my_agent.py
+```
+
+`tenant_id` is stored at the top level of `meta.json` and every event in
+`events.ndjson`. The session value is authoritative: agent-strace rejects an
+event with a different tenant and refuses to move an already-tagged session to
+another tenant. When `watch` tags events already written to the active session,
+it atomically rewrites the file and rebuilds the SHA-256 event chain. The
+pre-change and post-change terminal hashes are recorded in
+`.agent-traces/tenant-audit.ndjson`. A small durable intent journal is used so
+an interrupted metadata/event transition can roll forward on restart.
+
+New session and workspace IDs accepted by capture and collector entry points
+use a strict 1–128 character ASCII format (`A-Z`, `a-z`, digits, `.`, `_`, and
+`-`). Existing safe directory basenames remain readable, reportable,
+exportable, and deletable even when they contain spaces, Unicode, or exceed
+128 characters. Legacy names must still be a single path component: path
+separators, dot segments, NUL/control characters, and symlink escapes are
+rejected.
+
+Parent and child sessions must resolve inside the same flat/workspace store
+and have the same tenant. A newly created untagged child inherits a tagged
+parent's tenant. Legacy untagged parent/child pairs remain readable, but
+tagging either side is rejected if it would leave the relationship split
+between tagged and untagged (or differently tagged) sessions. For a legacy
+untagged tree, unlink the relationship, tag both sessions, and then relink it
+as one coordinated migration.
+
+Use stable opaque customer identifiers rather than names, emails, or other
+personal data. Tenant IDs must be 256 characters or fewer and cannot contain
+control characters.
+
+## Scoped queries and cost attribution
+
+```bash
+# Only this customer's sessions
+agent-strace list --tenant customer-acme
+
+# Estimated cost over the last 30 days
+agent-strace cost --tenant customer-acme --since 30d
+
+# Actual recorded provider/model counters for the same tenant
+agent-strace cost --tenant customer-acme --breakdown provider --since 30d
+
+# Cost allocation across every tenant for one UTC month
+agent-strace tenant report --month 2026-06
+agent-strace tenant report --month 2026-06 --format json
+```
+
+The standard estimate uses the selected offline pricing model. Provider
+breakdowns use recorded model/token counters and the dated bundled pricing
+snapshot. Both perform exact tenant matching before event data is loaded.
+
+Tenant administration uses fail-closed store discovery. Unlike the ordinary
+interactive session list, report, export, and deletion abort when a plausible
+session directory has malformed metadata/events, missing core files, unsafe
+symlinks, or a directory/metadata ID mismatch. Workspace discovery likewise
+aborts on symlinked or unsafe workspace roots and children, so an omitted store
+cannot produce a false zero report or false successful erasure.
+
+## Subject access export
+
+Export all metadata and events for one customer as a single JSON document:
+
+```bash
+agent-strace tenant export customer-acme > customer-acme.json
+# or
+agent-strace tenant export customer-acme --output customer-acme.json
+```
+
+The versioned export contains `tenant_id`, `exported_at`, `session_count`, and
+a `sessions` array with complete metadata, event history, session sidecars, and
+compaction checkpoints. Its versioned `external_records` section also contains
+matching human-approval requests (including tool input), eval-dataset entries,
+and retention-log records. It searches the flat store and every workspace
+store, regardless of `AGENT_STRACE_WORKSPACE`, and includes relevant hash-only
+tenant audit evidence. Review the output's storage location and access controls
+before sending it to a data subject.
+
+## Right to erasure
+
+Preview the customer ID carefully, create an access export if required by your
+policy, and then run the explicitly confirmed deletion:
+
+```bash
+agent-strace tenant delete customer-acme --confirm
+```
+
+This is irreversible. It removes every matching session directory, including
+annotations, evals, identities, postmortems, and other files stored within it,
+matching compaction checkpoints, approval requests, dataset entries, and
+retention-log records. Shared JSONL files are atomically filtered so malformed
+and unrelated records remain unchanged. Other tenants and untagged sessions
+are untouched.
+
+Before removing data, the command fsyncs a hash-only `pending` record to
+`.agent-traces/tenant-deletions.ndjson`; it appends `completed` or `partial`
+afterward. Tenant IDs and session IDs are never stored there in plaintext.
+Hashed session IDs act as tombstones so late hook events cannot recreate erased
+trace data. A recoverable intent journal finishes interrupted deletions during
+ordinary `TraceStore` startup as well as tenant administration commands. The
+operation covers the flat store and every workspace store and clears matching
+workspace hook state. Hook markers and pending-call files live beneath their
+workspace store. Provider IDs are represented by a path-safe local-session
+component and SHA-256 digest rather than being copied into filenames. Legacy
+root markers are removed only when no surviving flat or workspace session
+makes their ownership ambiguous; markerless pending state is removed only when
+its safe suffix identifies an erased session.
+
+Export and deletion reject symlinked session metadata, event streams,
+checkpoint directories/files, audit files, and external-record sources. This
+fail-closed behavior prevents a trace store from reading or deleting a target
+outside its configured root.
+
+Tenant audit files and completed journal directories are outside normal session
+retention. Set an explicit operational retention/rotation schedule for
+`tenant-audit.ndjson` and `tenant-deletions.ndjson` based on legal advice and
+backup policy. Incomplete files under `.tenant-journal/` must not be deleted
+until recovery succeeds or an operator has reconciled the recorded intent.
+
+## Isolation and hosted collectors
+
+Tenant tags scope agent-strace queries; they do not replace operating-system
+permissions or collector authorization. Anyone who can read the trace directory
+can read its NDJSON files, and anyone who can run local commands against it can
+select another tenant ID.
+
+The built-in collector's bearer key protects a collector instance, which must
+be treated as the organization boundary; it is not an individual-tenant key.
+For a hard hosted multi-organization boundary, deploy a separate storage
+directory/collector per organization or place each collector behind an
+authenticated gateway that derives organization scope from server-side key
+metadata. Never accept an organization ID supplied by the client as the
+authorization decision. Within an authorized organization, `tenant_id` can be
+used as the customer-level tag.
+
+OTLP and live `--stream-otlp` exports attach `tenant_id` to every generated
+span and the OTLP resource. Configure equivalent access controls and retention
+at the observability backend.

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.89.0"
+__version__ = "0.90.0"

--- a/src/agent_trace/audit.py
+++ b/src/agent_trace/audit.py
@@ -450,7 +450,7 @@ def verify_chain(store: TraceStore, session_id: str) -> ChainVerifyResult:
     """
     import hashlib
 
-    events_path = store._session_dir(session_id) / "events.ndjson"
+    events_path = store._session_file(session_id, "events.ndjson", "event stream")
     if not events_path.exists():
         return ChainVerifyResult(session_id=session_id, ok=False,
                                  total_events=0, broken_at=0)

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -69,6 +69,7 @@ from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
 from .team_report import cmd_team_report
+from .tenancy import cmd_tenant
 from .compare import cmd_compare
 from .compaction import cmd_compaction
 from .freeze import cmd_freeze, cmd_regression
@@ -303,7 +304,15 @@ def cmd_replay(args: argparse.Namespace) -> int:
 def cmd_list(args: argparse.Namespace) -> int:
     """List all recorded sessions."""
     store = TraceStore(args.trace_dir)
-    list_sessions(store)
+    tenant_id = getattr(args, "tenant", None)
+    if tenant_id is not None:
+        from .store import validate_tenant_id
+        try:
+            tenant_id = validate_tenant_id(tenant_id)
+        except ValueError as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return 1
+    list_sessions(store, tenant_id=tenant_id)
     return 0
 
 
@@ -1000,7 +1009,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="output format (default: text)")
 
     # list
-    sub.add_parser("list", help="list all recorded sessions")
+    p_list = sub.add_parser("list", help="list all recorded sessions")
+    p_list.add_argument("--tenant", metavar="ID", help="show only sessions for this tenant")
 
     # inspect
     p_inspect = sub.add_parser("inspect", help="inspect a session as raw JSON")
@@ -1135,6 +1145,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="export raw provider cost rows as CSV")
     p_cost.add_argument("--live-pricing", dest="live_pricing", action="store_true",
                         help="request live prices; fail safely when authoritative APIs are unavailable")
+    p_cost.add_argument("--tenant", metavar="ID",
+                        help="scope session lookup or aggregate cost to one tenant")
 
     # audit
     p_audit = sub.add_parser("audit", help="check session tool calls against a policy file")
@@ -1263,6 +1275,9 @@ def build_parser() -> argparse.ArgumentParser:
     # watch
     p_watch = sub.add_parser("watch", help="monitor a live session with circuit breakers")
     p_watch.add_argument("session_id", nargs="?", help="session ID to watch (default: latest active)")
+    p_watch.add_argument("--tenant-id", dest="tenant_id", metavar="ID",
+                         help="tag this session and its events with a tenant ID; "
+                              "defaults to AGENT_STRACE_TENANT_ID")
     p_watch.add_argument("--max-retries", type=int, default=5, help="max retries before alert (default: 5)")
     p_watch.add_argument("--max-cost", type=float, default=10.0, help="max cost in dollars (default: 10)")
     p_watch.add_argument("--max-duration", type=int, default=1800, help="max duration in seconds (default: 1800)")
@@ -1943,6 +1958,29 @@ def build_parser() -> argparse.ArgumentParser:
     p_ret_clean.add_argument("--config", metavar="FILE",
                              help="path to .agent-strace.yaml config file")
 
+    # tenant isolation, reporting, and GDPR workflows
+    p_tenant = sub.add_parser("tenant", help="report, export, or delete tenant trace data")
+    tenant_sub = p_tenant.add_subparsers(dest="tenant_command")
+
+    p_tenant_report = tenant_sub.add_parser("report", help="cost rollup across all tenants")
+    p_tenant_report.add_argument("--month", metavar="YYYY-MM",
+                                 help="UTC report month (default: current month)")
+    p_tenant_report.add_argument("--model", default="sonnet",
+                                 choices=["sonnet", "opus", "haiku", "gpt4", "gpt4o"],
+                                 help="pricing model for estimates (default: sonnet)")
+    p_tenant_report.add_argument("--format", choices=["text", "json"], default="text")
+
+    p_tenant_export = tenant_sub.add_parser("export", help="export all sessions for one tenant")
+    p_tenant_export.add_argument("tenant_id", metavar="ID")
+    p_tenant_export.add_argument("--format", choices=["json"], default="json")
+    p_tenant_export.add_argument("--output", "-o", metavar="FILE",
+                                 help="write JSON to a file instead of stdout")
+
+    p_tenant_delete = tenant_sub.add_parser("delete", help="hard-delete all data for one tenant")
+    p_tenant_delete.add_argument("tenant_id", metavar="ID")
+    p_tenant_delete.add_argument("--confirm", action="store_true",
+                                 help="confirm the irreversible deletion")
+
     # diff --semantic and --eval-config flags (extend existing diff parser)
     p_diff.add_argument("--semantic", action="store_true",
                         help="semantic outcome-level diff (files, cost, errors)")
@@ -2014,6 +2052,7 @@ _TELEMETRY_SUBCOMMAND_ATTRS = (
     "server_subcommand",
     "config_watch_command",
     "retention_command",
+    "tenant_command",
 )
 
 
@@ -2248,6 +2287,7 @@ def main() -> None:
         "config-watch": cmd_config_watch,
         "lint": cmd_lint,
         "retention": cmd_retention,
+        "tenant": cmd_tenant,
         "sample": cmd_sample,
         "server": cmd_server,
     }

--- a/src/agent_trace/compaction.py
+++ b/src/agent_trace/compaction.py
@@ -928,9 +928,9 @@ def write_checkpoint(
     """Write ``checkpoints/<session>.md`` without touching trace storage."""
     if events is None:
         events = store.load_events(session_id)
-    checkpoint_dir = store.base_dir / "checkpoints"
+    path = store.checkpoint_path(session_id)
+    checkpoint_dir = path.parent
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
-    path = checkpoint_dir / f"{session_id}.md"
     path.write_text(
         build_checkpoint_markdown(events, session_id, timestamp), encoding="utf-8",
     )

--- a/src/agent_trace/compliance.py
+++ b/src/agent_trace/compliance.py
@@ -72,7 +72,7 @@ def _parse_time_bound(value: str | None, default: float | None = None) -> float 
 
 
 def _load_event_lines(store: TraceStore, session_id: str) -> list[str]:
-    path = store._session_dir(session_id) / "events.ndjson"
+    path = store._session_file(session_id, "events.ndjson", "event stream")
     if not path.exists():
         return []
     return [line for line in path.read_text().splitlines() if line.strip()]

--- a/src/agent_trace/cost.py
+++ b/src/agent_trace/cost.py
@@ -144,6 +144,16 @@ class CostResult:
 
 
 @dataclass(frozen=True)
+class TenantCostResult:
+    tenant_id: str
+    since: str
+    sessions: int
+    total_cost: float
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass(frozen=True)
 class ModelPrice:
     """One model's bundled, offline token rates."""
 
@@ -512,6 +522,7 @@ def build_provider_cost_report(
     now: float | None = None,
     live_pricing: bool = False,
     pricing_table: Mapping[str, Mapping[str, float]] = PRICING,
+    tenant_id: str | None = None,
 ) -> ProviderCostReport:
     """Aggregate stored session usage by inferred provider and model.
 
@@ -531,7 +542,7 @@ def build_provider_cost_report(
     cutoff = parse_since(since_value, now=generated_at)
     records: list[ProviderCostRecord] = []
 
-    for meta in store.list_sessions():
+    for meta in store.list_sessions(tenant_id=tenant_id):
         if meta.started_at < cutoff or meta.started_at > generated_at:
             continue
         try:
@@ -617,6 +628,47 @@ def estimate_cost(
     )
 
 
+def build_tenant_cost_report(
+    store: TraceStore,
+    tenant_id: str,
+    since: str = "30d",
+    model: str = DEFAULT_MODEL,
+    input_price: float | None = None,
+    output_price: float | None = None,
+    now: float | None = None,
+) -> TenantCostResult:
+    """Aggregate legacy per-session estimates for one exact tenant tag."""
+    generated_at = _time.time() if now is None else float(now)
+    cutoff = parse_since(since, now=generated_at)
+    sessions = total_input = total_output = 0
+    total_cost = 0.0
+    for meta in store.list_sessions(tenant_id=tenant_id):
+        if meta.started_at < cutoff or meta.started_at > generated_at:
+            continue
+        try:
+            result = estimate_cost(
+                store,
+                meta.session_id,
+                model=model,
+                input_price=input_price,
+                output_price=output_price,
+            )
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        sessions += 1
+        total_input += result.input_tokens
+        total_output += result.output_tokens
+        total_cost += result.total_cost
+    return TenantCostResult(
+        tenant_id=tenant_id,
+        since=since,
+        sessions=sessions,
+        total_cost=total_cost,
+        input_tokens=total_input,
+        output_tokens=total_output,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------
@@ -642,6 +694,16 @@ def format_cost(result: CostResult, out: TextIO = sys.stdout) -> None:
     if result.wasted_cost > 0:
         wasted_pct = result.wasted_cost / (result.total_cost or 1e-9) * 100
         w(f"Wasted on failed phases: ${result.wasted_cost:.4f} ({wasted_pct:.0f}%)\n\n")
+
+
+def format_tenant_cost(result: TenantCostResult, out: TextIO = sys.stdout) -> None:
+    out.write(
+        f"Tenant: {result.tenant_id}\n"
+        f"Window: {_since_description(result.since)}\n"
+        f"Sessions: {result.sessions}\n"
+        f"Estimated cost: ${result.total_cost:.4f}\n"
+        f"Tokens: {result.input_tokens:,} input, {result.output_tokens:,} output\n"
+    )
 
 
 def _since_description(value: str) -> str:
@@ -716,6 +778,14 @@ def format_provider_cost_csv(
 
 def cmd_cost(args: argparse.Namespace) -> int:
     store = TraceStore(args.trace_dir)
+    tenant_id = getattr(args, "tenant", None)
+    if tenant_id is not None:
+        from .store import validate_tenant_id
+        try:
+            tenant_id = validate_tenant_id(tenant_id)
+        except ValueError as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return 1
 
     breakdown = getattr(args, "breakdown", None)
     if breakdown:
@@ -727,6 +797,7 @@ def cmd_cost(args: argparse.Namespace) -> int:
                 store,
                 since=getattr(args, "since", None) or "30d",
                 live_pricing=bool(getattr(args, "live_pricing", False)),
+                tenant_id=tenant_id,
             )
         except (ValueError, LivePricingUnavailable) as exc:
             sys.stderr.write(f"Error: {exc}\n")
@@ -738,19 +809,43 @@ def cmd_cost(args: argparse.Namespace) -> int:
         return 0
 
     session_id = getattr(args, "session_id", None)
+    model = getattr(args, "model", DEFAULT_MODEL) or DEFAULT_MODEL
+    input_price = getattr(args, "input_price", None)
+    output_price = getattr(args, "output_price", None)
+
+    if tenant_id is not None and not session_id:
+        if (input_price is None) != (output_price is None):
+            sys.stderr.write(
+                "Error: --input-price and --output-price must be provided together.\n"
+            )
+            return 1
+        try:
+            report = build_tenant_cost_report(
+                store,
+                tenant_id,
+                since=getattr(args, "since", None) or "30d",
+                model=model,
+                input_price=input_price,
+                output_price=output_price,
+            )
+        except ValueError as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return 1
+        format_tenant_cost(report)
+        return 0
+
     if not session_id:
         session_id = store.get_latest_session_id()
     if not session_id:
         sys.stderr.write("No sessions found.\n")
         return 1
-    full_id = store.find_session(session_id)
+    full_id = store.find_session(session_id, tenant_id=tenant_id)
     if not full_id:
-        sys.stderr.write(f"Session not found: {session_id}\n")
+        if tenant_id:
+            sys.stderr.write(f"Session not found for tenant {tenant_id}: {session_id}\n")
+        else:
+            sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
-
-    model = getattr(args, "model", DEFAULT_MODEL) or DEFAULT_MODEL
-    input_price = getattr(args, "input_price", None)
-    output_price = getattr(args, "output_price", None)
 
     if (input_price is None) != (output_price is None):
         sys.stderr.write(

--- a/src/agent_trace/hooks.py
+++ b/src/agent_trace/hooks.py
@@ -32,13 +32,14 @@ Usage:
 The hook script reads JSON from stdin (provided by Claude Code), converts
 it to a TraceEvent, and appends it to the active session's trace store.
 
-Session state is tracked via a file at .agent-traces/.active-session so
-that PreToolUse and PostToolUse hooks (which run as separate processes)
-can find the current session.
+Session state is tracked via an .active-session file in the flat trace store
+or active workspace store so hooks running as separate processes can find the
+current session without colliding with another workspace.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
@@ -91,6 +92,11 @@ def _get_store() -> TraceStore:
     return TraceStore(_get_store_dir())
 
 
+def _get_state_dir() -> Path:
+    """Keep hook coordination state inside the active workspace scope."""
+    return _get_store().base_dir
+
+
 def _get_remote_endpoint() -> str:
     """Return AGENT_STRACE_ENDPOINT if set, else empty string."""
     return os.environ.get("AGENT_STRACE_ENDPOINT", "").rstrip("/")
@@ -112,6 +118,15 @@ def _write_event(store: TraceStore, session_id: str, event: TraceEvent) -> None:
         store.append_event(session_id, event)
 
 
+def _write_session_meta(meta: SessionMeta) -> None:
+    """Best-effort metadata propagation to a configured remote collector."""
+    endpoint = _get_remote_endpoint()
+    if not endpoint:
+        return
+    from .server import send_session_meta_to_endpoint
+    send_session_meta_to_endpoint(meta, endpoint)
+
+
 def _provider_env(provider: str = "claude") -> str:
     return _PROVIDER_ENV.get(provider, _CLAUDE_SESSION_ID_ENV)
 
@@ -123,22 +138,27 @@ def _state_suffix(provider: str = "claude") -> str:
     sets a provider-specific env var for same-process tests and manual use.
     """
     sid = os.environ.get(_provider_env(provider), "")
-    return f".{sid}" if sid else ""
+    if not sid:
+        return ""
+    provider_key = provider if provider in _PROVIDER_ENV else "claude"
+    local_session_hex = sid[:16].encode("utf-8").hex()
+    digest = hashlib.sha256(f"{provider_key}\0{sid}".encode()).hexdigest()
+    return f".v2.{provider_key}.{local_session_hex}.{digest}"
 
 
 def _active_session_path(provider: str = "claude") -> Path:
-    return Path(_get_store_dir()) / f".active-session{_state_suffix(provider)}"
+    return _get_state_dir() / f".active-session{_state_suffix(provider)}"
 
 
 def _canonical_active_session_path() -> Path:
     """Return the active-session marker consumed by editor integrations."""
-    return Path(_get_store_dir()) / ".active-session"
+    return _get_state_dir() / ".active-session"
 
 
 def _pending_calls_path(provider: str = "claude") -> Path:
     suffix = _state_suffix(provider)
     name = _PENDING_FILE.replace(".json", f"{suffix}.json")
-    return Path(_get_store_dir()) / name
+    return _get_state_dir() / name
 
 
 def _read_active_session(provider: str = "claude") -> str | None:
@@ -322,6 +342,7 @@ def handle_session_start(input_data: dict, provider: str = "claude") -> None:
         meta.session_id = session_id[:16]
 
     store.create_session(meta)
+    _write_session_meta(meta)
 
     if session_id:
         os.environ[_provider_env(provider)] = session_id
@@ -377,6 +398,7 @@ def handle_session_end(input_data: dict, provider: str = "claude") -> None:
             ),
         )
         store.update_meta(meta)
+        _write_session_meta(meta)
         _product_telemetry.capture(
             _product_telemetry.SESSION_COMPLETED,
             {

--- a/src/agent_trace/mcp_scan.py
+++ b/src/agent_trace/mcp_scan.py
@@ -541,7 +541,7 @@ def _watch_session(
     patterns: list[tuple[str, re.Pattern[str]]] | None = None,
     project_root: str = "",
 ) -> int:
-    events_file = store._session_dir(session_id) / "events.ndjson"
+    events_file = store._session_file(session_id, "events.ndjson", "event stream")
     if not events_file.exists():
         out.write(f"events file not found: {events_file}\n")
         return 1

--- a/src/agent_trace/models.py
+++ b/src/agent_trace/models.py
@@ -22,6 +22,7 @@ Event types:
 from __future__ import annotations
 
 import json
+import os
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -57,6 +58,10 @@ class TraceEvent:
     prev_hash: str = ""
     # True when secret redaction changed or protected this event before write
     redacted: bool = False
+    # Appended after all pre-v0.90 fields to preserve positional construction.
+    tenant_id: str = field(
+        default_factory=lambda: os.environ.get("AGENT_STRACE_TENANT_ID", "").strip()
+    )
 
     def to_json(self) -> str:
         d = asdict(self)
@@ -71,6 +76,9 @@ class TraceEvent:
     def from_json(cls, line: str) -> TraceEvent:
         d = json.loads(line)
         d["event_type"] = EventType(d["event_type"])
+        # Deserialising a legacy event must not accidentally assign the
+        # current process tenant to historical data.
+        d.setdefault("tenant_id", "")
         return cls(**d)
 
 
@@ -105,6 +113,10 @@ class SessionMeta:
     trace_flags: str = ""
     # True when secret redaction changed or protected session metadata
     redacted: bool = False
+    # Appended after all pre-v0.90 fields to preserve positional construction.
+    tenant_id: str = field(
+        default_factory=lambda: os.environ.get("AGENT_STRACE_TENANT_ID", "").strip()
+    )
 
     def to_json(self) -> str:
         d = asdict(self)
@@ -113,4 +125,8 @@ class SessionMeta:
 
     @classmethod
     def from_json(cls, text: str) -> SessionMeta:
-        return cls(**json.loads(text))
+        data = json.loads(text)
+        # Keep pre-tenancy metadata untagged even when the reader itself is
+        # running with AGENT_STRACE_TENANT_ID set.
+        data.setdefault("tenant_id", "")
+        return cls(**data)

--- a/src/agent_trace/otlp.py
+++ b/src/agent_trace/otlp.py
@@ -312,6 +312,11 @@ def session_to_otlp(
     if parent_span_id:
         root_span["parentSpanId"] = parent_span_id
 
+    if meta.tenant_id:
+        tenant_attributes = _make_attributes({"tenant_id": meta.tenant_id})
+        for span in [root_span] + child_spans:
+            span.setdefault("attributes", []).extend(tenant_attributes)
+
     all_spans = [root_span] + child_spans
 
     return {
@@ -321,6 +326,7 @@ def session_to_otlp(
                     "service.name": service_name,
                     "service.version": "agent-trace",
                     "agent.session_id": meta.session_id,
+                    **({"tenant_id": meta.tenant_id} if meta.tenant_id else {}),
                 }),
             },
             "scopeSpans": [{
@@ -382,6 +388,7 @@ def tree_to_otlp(
                     "service.name": service_name,
                     "service.version": "agent-trace",
                     "agent.session_id": root_session_id,
+                    **({"tenant_id": root_meta.tenant_id} if root_meta.tenant_id else {}),
                 }),
             },
             "scopeSpans": [{
@@ -661,6 +668,11 @@ def session_to_otlp_genai(
     if parent_span_id:
         root_span["parentSpanId"] = parent_span_id
 
+    if meta.tenant_id:
+        tenant_attributes = _make_attributes({"tenant_id": meta.tenant_id})
+        for span in [root_span] + child_spans:
+            span.setdefault("attributes", []).extend(tenant_attributes)
+
     return {
         "resourceSpans": [{
             "resource": {
@@ -668,6 +680,7 @@ def session_to_otlp_genai(
                     "service.name": service_name,
                     "service.version": "agent-trace",
                     "agent.session_id": meta.session_id,
+                    **({"tenant_id": meta.tenant_id} if meta.tenant_id else {}),
                 }),
             },
             "scopeSpans": [{

--- a/src/agent_trace/replay.py
+++ b/src/agent_trace/replay.py
@@ -404,9 +404,13 @@ def replay_session(
     out.write("\n")
 
 
-def list_sessions(store: TraceStore, out: TextIO = sys.stdout) -> None:
+def list_sessions(
+    store: TraceStore,
+    out: TextIO = sys.stdout,
+    tenant_id: str | None = None,
+) -> None:
     """List all captured sessions."""
-    sessions = store.list_sessions()
+    sessions = store.list_sessions(tenant_id=tenant_id)
 
     if not sessions:
         out.write("No traces found.\n")
@@ -446,6 +450,8 @@ def list_sessions(store: TraceStore, out: TextIO = sys.stdout) -> None:
 
     out.write(f"{C.GRAY}{'─' * 70}{C.RESET}\n")
     out.write(f"  {len(sessions)} session(s)\n")
+    if tenant_id is not None:
+        out.write(f"  {C.DIM}Tenant: {tenant_id}{C.RESET}\n")
     out.write(
         f"  {C.DIM}Tools = MCP tool calls  "
         f"LLM = sampling/createMessage or @trace_llm_call  "

--- a/src/agent_trace/retention.py
+++ b/src/agent_trace/retention.py
@@ -153,7 +153,7 @@ def _store_size_bytes(store: TraceStore) -> int:
 def _retained_session_size_bytes(store: TraceStore, session_id: str) -> int:
     """Return session storage plus its compaction checkpoint sidecar."""
     total = _session_size_bytes(store._session_dir(session_id))
-    checkpoint = store.base_dir / "checkpoints" / f"{session_id}.md"
+    checkpoint = store.checkpoint_path(session_id)
     try:
         total += checkpoint.stat().st_size
     except OSError:
@@ -277,7 +277,7 @@ def delete_sessions(
 
     for sid in session_ids:
         session_dir = store._session_dir(sid)
-        checkpoint_path = store.base_dir / "checkpoints" / f"{sid}.md"
+        checkpoint_path = store.checkpoint_path(sid)
         try:
             checkpoint_path.unlink(missing_ok=True)
             if not session_dir.exists():

--- a/src/agent_trace/server.py
+++ b/src/agent_trace/server.py
@@ -44,10 +44,15 @@ import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from .models import SessionMeta, TraceEvent
-from .store import TraceStore, DEFAULT_TRACE_DIR
+from .store import (
+    TraceStore,
+    DEFAULT_TRACE_DIR,
+    validate_session_id,
+    validate_stored_id,
+)
 from . import web_dashboard as _wd
 
 
@@ -56,6 +61,13 @@ from . import web_dashboard as _wd
 # ---------------------------------------------------------------------------
 
 KEY_PREFIX = "ast_"
+
+
+def _decode_read_session_id(segment: str) -> str:
+    """Decode one URL segment and permit containment-safe legacy IDs."""
+    return validate_stored_id(
+        unquote(segment, encoding="utf-8", errors="strict"), "stored session ID"
+    )
 
 
 def generate_api_key() -> str:
@@ -202,7 +214,12 @@ class CollectorHandler(BaseHTTPRequestHandler):
                 return
             parts = path.split("/")
             if len(parts) == 3 and parts[1] == "session":
-                self._send_html(200, _wd.render_detail_page(parts[2]))
+                try:
+                    session_id = _decode_read_session_id(parts[2])
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self._send_json(400, {"error": str(exc)})
+                    return
+                self._send_html(200, _wd.render_detail_page(session_id))
                 return
             # Dashboard API endpoints
             if path == "/api/sessions":
@@ -214,7 +231,12 @@ class CollectorHandler(BaseHTTPRequestHandler):
                 self.wfile.write(body)
                 return
             if len(parts) == 5 and parts[1] == "api" and parts[2] == "sessions" and parts[4] == "events":
-                result = _wd.api_session_events(self.store, parts[3])
+                try:
+                    session_id = _decode_read_session_id(parts[3])
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self._send_json(400, {"error": str(exc)})
+                    return
+                result = _wd.api_session_events(self.store, session_id)
                 if result is None:
                     self._send_json(404, {"error": f"session not found: {parts[3]}"})
                     return
@@ -239,7 +261,11 @@ class CollectorHandler(BaseHTTPRequestHandler):
         # /sessions/<id>/events
         parts = path.split("/")
         if len(parts) == 4 and parts[1] == "sessions" and parts[3] == "events":
-            session_id = parts[2]
+            try:
+                session_id = _decode_read_session_id(parts[2])
+            except (UnicodeDecodeError, ValueError) as exc:
+                self._send_json(400, {"error": str(exc)})
+                return
             if not self.store.session_exists(session_id):
                 found = self.store.find_session(session_id)
                 if found:
@@ -253,7 +279,11 @@ class CollectorHandler(BaseHTTPRequestHandler):
 
         # /sessions/<id>
         if len(parts) == 3 and parts[1] == "sessions":
-            session_id = parts[2]
+            try:
+                session_id = _decode_read_session_id(parts[2])
+            except (UnicodeDecodeError, ValueError) as exc:
+                self._send_json(400, {"error": str(exc)})
+                return
             if not self.store.session_exists(session_id):
                 found = self.store.find_session(session_id)
                 if found:
@@ -298,14 +328,14 @@ class CollectorHandler(BaseHTTPRequestHandler):
                 continue
             try:
                 event = TraceEvent.from_json(line)
-                session_id = event.session_id
+                session_id = validate_session_id(event.session_id)
                 if not session_id:
                     errors += 1
                     continue
                 with self._lock:
                     # Auto-create session if it doesn't exist
                     if not self.store.session_exists(session_id):
-                        meta = SessionMeta()
+                        meta = SessionMeta(tenant_id=event.tenant_id)
                         meta.session_id = session_id
                         self.store.create_session(meta)
                     self.store.append_event(session_id, event)
@@ -325,13 +355,22 @@ class CollectorHandler(BaseHTTPRequestHandler):
             if not session_id:
                 self._send_json(400, {"error": "session_id required"})
                 return
+            session_id = validate_session_id(session_id)
 
             with self._lock:
                 if self.store.session_exists(session_id):
                     # Update existing meta
                     meta = self.store.load_meta(session_id)
+                    incoming_tenant = str(data.get("tenant_id", "") or "").strip()
+                    if "tenant_id" in data:
+                        if meta.tenant_id and incoming_tenant != meta.tenant_id:
+                            self._send_json(409, {"error": "session tenant cannot be cleared or changed"})
+                            return
+                        if not meta.tenant_id and incoming_tenant:
+                            self.store.tag_session(session_id, incoming_tenant)
+                            meta = self.store.load_meta(session_id)
                     for k, v in data.items():
-                        if hasattr(meta, k):
+                        if k not in {"session_id", "tenant_id"} and hasattr(meta, k):
                             setattr(meta, k, v)
                     self.store.update_meta(meta)
                 else:

--- a/src/agent_trace/store.py
+++ b/src/agent_trace/store.py
@@ -14,14 +14,24 @@ Traces are stored as directories:
           meta.json
           events.ndjson
 
-NDJSON is append-only. No database. No dependencies. Just files.
+NDJSON is append-only during capture. Assigning a tenant to an already-active
+session performs one atomic rewrite and rebuilds its hash chain. No database.
+No dependencies. Just files.
 """
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import json
 import os
+import re
+import shutil
 import sys
+import tempfile
+import time
+import unicodedata
+import uuid
 from pathlib import Path
 
 from .models import EventType, SessionMeta, TraceEvent
@@ -32,11 +42,168 @@ DEFAULT_TRACE_DIR = ".agent-traces"
 # Env var for workspace isolation — sessions are stored under
 # .agent-traces/workspaces/<workspace-id>/ when this is set.
 _WORKSPACE_ENV = "AGENT_STRACE_WORKSPACE"
+_TENANT_ENV = "AGENT_STRACE_TENANT_ID"
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_TENANT_ADMIN_AUXILIARY_DIRS = {
+    ".approvals",
+    ".tenant-journal",
+    "checkpoints",
+    "datasets",
+}
+
+
+def _has_control_character(value: str) -> bool:
+    return any(unicodedata.category(char) == "Cc" for char in value)
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Return a normalised tenant ID or raise ``ValueError``.
+
+    Tenant IDs are data tags rather than paths, but rejecting control
+    characters prevents terminal/log injection and a modest length limit
+    keeps exported attributes bounded.
+    """
+    value = str(tenant_id).strip()
+    if not value:
+        raise ValueError("tenant ID cannot be empty")
+    if len(value) > 256:
+        raise ValueError("tenant ID cannot exceed 256 characters")
+    if _has_control_character(value):
+        raise ValueError("tenant ID cannot contain control characters")
+    return value
+
+
+def validate_session_id(session_id: str) -> str:
+    """Validate an opaque session identifier before any path construction."""
+    value = str(session_id)
+    if not _SAFE_ID_RE.fullmatch(value) or value in {".", ".."}:
+        raise ValueError(
+            "session ID must be 1-128 ASCII letters, digits, dots, underscores, or hyphens"
+        )
+    return value
+
+
+def validate_stored_id(value: str, kind: str = "stored identifier") -> str:
+    """Validate a containment-safe legacy directory basename.
+
+    Historical stores may contain spaces, Unicode, or identifiers longer than
+    the current external-ingress limit. Those names remain readable as long as
+    they are one safe path component and contain no control characters.
+    """
+    value = str(value)
+    if (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or _has_control_character(value)
+    ):
+        raise ValueError(f"invalid {kind}")
+    return value
+
+
+def validate_workspace_id(workspace_id: str) -> str:
+    """Validate a workspace directory identifier."""
+    value = str(workspace_id)
+    if not _SAFE_ID_RE.fullmatch(value) or value in {".", ".."}:
+        raise ValueError(
+            "workspace ID must be 1-128 ASCII letters, digits, dots, underscores, or hyphens"
+        )
+    return value
+
+
+def _validate_meta_ids(meta: SessionMeta, *, strict_session: bool = False) -> None:
+    validator = validate_session_id if strict_session else validate_stored_id
+    meta.session_id = validator(meta.session_id)
+    if meta.parent_session_id:
+        meta.parent_session_id = validate_stored_id(
+            meta.parent_session_id, "stored parent session ID"
+        )
+
+
+def _lock_file(file_obj) -> None:
+    """Best-effort exclusive lock shared by event append and tenant tagging."""
+    try:
+        import fcntl
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_EX)
+    except (ImportError, OSError):
+        pass
+
+
+def _unlock_file(file_obj) -> None:
+    try:
+        import fcntl
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_UN)
+    except (ImportError, OSError):
+        pass
+
+
+@contextlib.contextmanager
+def _store_write_lock(base_dir: Path):
+    """Serialise event append and atomic session retag operations."""
+    base_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = base_dir / ".store.lock"
+    if lock_path.is_symlink() or (lock_path.exists() and not lock_path.is_file()):
+        raise ValueError("unsafe trace store lock path")
+    if lock_path.resolve(strict=False).parent != base_dir.resolve():
+        raise ValueError("trace store lock path escapes the store")
+    with open(lock_path, "a+", encoding="utf-8") as lock_file:
+        _lock_file(lock_file)
+        try:
+            yield
+        finally:
+            _unlock_file(lock_file)
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    """Write text to a sibling temporary file and atomically replace path."""
+    if path.is_symlink() or path.parent.is_symlink():
+        raise ValueError(f"refusing symlinked atomic write path: {path.name}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(text)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        if path.exists():
+            os.chmod(temporary_name, path.stat().st_mode)
+        os.replace(temporary_name, path)
+        temporary_name = ""
+        _fsync_directory(path.parent)
+    finally:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort directory fsync for durable rename/unlink operations."""
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
 
 
 def _workspace_base(base_dir: str | Path, workspace_id: str) -> Path:
     """Return the workspace-scoped subdirectory path."""
-    return Path(base_dir) / "workspaces" / workspace_id
+    return Path(base_dir) / "workspaces" / validate_workspace_id(workspace_id)
 
 
 class TraceStore:
@@ -45,6 +212,8 @@ class TraceStore:
         base_dir: str | Path = DEFAULT_TRACE_DIR,
         workspace_id: str = "",
         redact: bool | None = None,
+        use_workspace_env: bool = True,
+        allow_legacy_workspace_id: bool = False,
     ):
         """Create a TraceStore.
 
@@ -54,14 +223,31 @@ class TraceStore:
         If workspace_id is empty, the AGENT_STRACE_WORKSPACE env var is
         checked. If that is also empty, the flat layout is used.
         """
-        wid = workspace_id or os.environ.get(_WORKSPACE_ENV, "")
+        self.storage_root = Path(base_dir)
+        wid = workspace_id or (
+            os.environ.get(_WORKSPACE_ENV, "") if use_workspace_env else ""
+        )
         if wid:
-            self.base_dir = _workspace_base(base_dir, wid)
-            self.workspace_id = wid
+            validated_wid = (
+                validate_stored_id(wid, "stored workspace ID")
+                if allow_legacy_workspace_id else validate_workspace_id(wid)
+            )
+            workspace_root = self.storage_root / "workspaces"
+            candidate = workspace_root / validated_wid
+            if workspace_root.is_symlink() or candidate.is_symlink():
+                raise ValueError("refusing symlinked workspace path")
+            if candidate.resolve(strict=False).parent != workspace_root.resolve():
+                raise ValueError("workspace path escapes the trace store")
+            self.base_dir = candidate
+            self.workspace_id = validated_wid
         else:
             self.base_dir = Path(base_dir)
             self.workspace_id = ""
         self.redact = redaction_enabled() if redact is None else redact
+        self._erasure_audit_mtime_ns = -1
+        self._erased_session_hashes: set[str] = set()
+        self._recover_tag_journals()
+        self._recover_delete_journals()
 
     def _warn_redacted(self, item: str) -> None:
         sys.stderr.write(f"agent-strace: redacted secrets from {item}\n")
@@ -94,63 +280,758 @@ class TraceStore:
                 self._warn_redacted("session metadata")
 
     def _session_dir(self, session_id: str) -> Path:
-        return self.base_dir / session_id
+        session_id = validate_stored_id(session_id, "stored session ID")
+        candidate = self.base_dir / session_id
+        if candidate.is_symlink():
+            raise ValueError("refusing symlinked session directory")
+        base_resolved = self.base_dir.resolve()
+        candidate_resolved = candidate.resolve(strict=False)
+        if candidate_resolved.parent != base_resolved:
+            raise ValueError("session path escapes the trace store")
+        return candidate
+
+    def _store_file(self, name: str, kind: str) -> Path:
+        """Return a non-symlinked regular-file location under the store."""
+        candidate = self.base_dir / name
+        if candidate.is_symlink():
+            raise ValueError(f"refusing symlinked {kind}")
+        if candidate.resolve(strict=False).parent != self.base_dir.resolve():
+            raise ValueError(f"{kind} escapes the trace store")
+        if candidate.exists() and not candidate.is_file():
+            raise ValueError(f"{kind} is not a regular file")
+        return candidate
+
+    def _auxiliary_dir(self, name: str, kind: str) -> Path:
+        """Return a safe direct child directory without following symlinks."""
+        candidate = self.base_dir / name
+        if candidate.is_symlink():
+            raise ValueError(f"refusing symlinked {kind}")
+        if candidate.resolve(strict=False).parent != self.base_dir.resolve():
+            raise ValueError(f"{kind} escapes the trace store")
+        if candidate.exists() and not candidate.is_dir():
+            raise ValueError(f"{kind} is not a directory")
+        return candidate
+
+    def _session_file(self, session_id: str, name: str, kind: str) -> Path:
+        directory = self._session_dir(session_id)
+        candidate = directory / name
+        if candidate.is_symlink():
+            raise ValueError(f"refusing symlinked {kind}")
+        if candidate.resolve(strict=False).parent != directory.resolve(strict=False):
+            raise ValueError(f"{kind} escapes the session directory")
+        if candidate.exists() and not candidate.is_file():
+            raise ValueError(f"{kind} is not a regular file")
+        return candidate
+
+    def checkpoint_path(self, session_id: str) -> Path:
+        """Return a checkpoint path after rejecting symlink components."""
+        session_id = validate_stored_id(session_id, "stored session ID")
+        directory = self._auxiliary_dir("checkpoints", "checkpoint directory")
+        candidate = directory / f"{session_id}.md"
+        if candidate.is_symlink():
+            raise ValueError("refusing symlinked checkpoint")
+        if candidate.resolve(strict=False).parent != directory.resolve(strict=False):
+            raise ValueError("checkpoint escapes the trace store")
+        if candidate.exists() and not candidate.is_file():
+            raise ValueError("checkpoint is not a regular file")
+        return candidate
+
+    def _external_record_plan(self, session_ids: set[str]) -> tuple[list[dict], list[Path], list[tuple[Path, str]]]:
+        """Collect matching external records and precompute safe deletion edits."""
+        records: list[dict] = []
+        remove_files: list[Path] = []
+        rewrites: list[tuple[Path, str]] = []
+
+        approvals = self._auxiliary_dir(".approvals", "approval directory")
+        if approvals.exists():
+            for path in sorted(approvals.glob("*.json")):
+                if path.is_symlink():
+                    raise ValueError("refusing symlinked approval record")
+                if not path.is_file():
+                    raise ValueError("approval record is not a regular file")
+                try:
+                    record = json.loads(path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict) and record.get("session_id") in session_ids:
+                    records.append({
+                        "kind": "approval",
+                        "path": path.relative_to(self.base_dir).as_posix(),
+                        "record": record,
+                    })
+                    remove_files.append(path)
+
+        def scan_jsonl(path: Path, kind: str) -> None:
+            if path.is_symlink():
+                raise ValueError(f"refusing symlinked {kind} records")
+            if path.exists() and not path.is_file():
+                raise ValueError(f"{kind} records are not a regular file")
+            if not path.exists():
+                return
+            with open(path, "r", encoding="utf-8", newline="") as record_file:
+                lines = record_file.readlines()
+            kept: list[str] = []
+            changed = False
+            for line_number, line in enumerate(lines, 1):
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    kept.append(line)
+                    continue
+                if isinstance(record, dict) and record.get("session_id") in session_ids:
+                    records.append({
+                        "kind": kind,
+                        "path": path.relative_to(self.base_dir).as_posix(),
+                        "line": line_number,
+                        "record": record,
+                    })
+                    changed = True
+                else:
+                    kept.append(line)
+            if changed:
+                rewrites.append((path, "".join(kept)))
+
+        datasets = self._auxiliary_dir("datasets", "dataset directory")
+        if datasets.exists():
+            for path in sorted(datasets.glob("*.jsonl")):
+                scan_jsonl(path, "dataset")
+        scan_jsonl(self._store_file("retention.log", "retention log"), "retention")
+        return records, remove_files, rewrites
+
+    def external_session_records(self, session_ids: set[str]) -> list[dict]:
+        """Return approval, dataset, and retention records for sessions."""
+        records, _, _ = self._external_record_plan(session_ids)
+        return records
+
+    def _delete_external_session_records_locked(self, session_ids: set[str]) -> None:
+        """Atomically filter external per-session records, preserving others."""
+        _, remove_files, rewrites = self._external_record_plan(session_ids)
+        for path, text in rewrites:
+            _write_atomic(path, text)
+        touched_directories: set[Path] = set()
+        for path in remove_files:
+            path.unlink(missing_ok=True)
+            touched_directories.add(path.parent)
+        for directory in touched_directories:
+            _fsync_directory(directory)
+
+    def write_lock(self):
+        """Return the store-wide write lock context manager."""
+        return _store_write_lock(self.base_dir)
+
+    def _session_was_erased(self, session_id: str) -> bool:
+        """Return True when a tenant-erasure tombstone covers session_id."""
+        audit_path = self._store_file(
+            "tenant-deletions.ndjson", "tenant deletion audit"
+        )
+        if not audit_path.exists():
+            return False
+        digest = hashlib.sha256(session_id.encode()).hexdigest()
+        try:
+            mtime_ns = audit_path.stat().st_mtime_ns
+            if mtime_ns == self._erasure_audit_mtime_ns:
+                return digest in self._erased_session_hashes
+            erased_hashes: set[str] = set()
+            for line in audit_path.read_text(encoding="utf-8").splitlines():
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                values = record.get("session_id_sha256", [])
+                if isinstance(values, list):
+                    erased_hashes.update(str(value) for value in values)
+            self._erased_session_hashes = erased_hashes
+            self._erasure_audit_mtime_ns = mtime_ns
+        except OSError:
+            return False
+        return digest in self._erased_session_hashes
+
+    def _journal_dir(self) -> Path:
+        return self._auxiliary_dir(".tenant-journal", "tenant journal directory")
+
+    def _audit_has_operation(self, path: Path, operation_id: str) -> bool:
+        if path.is_symlink():
+            raise ValueError("refusing symlinked tenant audit")
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                try:
+                    if json.loads(line).get("operation_id") == operation_id:
+                        return True
+                except json.JSONDecodeError:
+                    continue
+        except OSError:
+            return False
+        return False
+
+    def _append_tenant_audit(self, record: dict) -> Path:
+        path = self._store_file("tenant-audit.ndjson", "tenant audit")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as audit_file:
+            audit_file.write(json.dumps(record, separators=(",", ":")) + "\n")
+            audit_file.flush()
+            os.fsync(audit_file.fileno())
+        return path
+
+    def _complete_tag_journal_locked(self, journal_path: Path, record: dict) -> int:
+        """Idempotently roll a durable tenant-tag intent forward."""
+        session_id = validate_stored_id(record.get("session_id", ""), "stored session ID")
+        tenant_id = validate_tenant_id(record.get("tenant_id", ""))
+        operation_id = str(record.get("operation_id", ""))
+        if not operation_id:
+            raise ValueError("tenant journal is missing operation_id")
+        path = self._session_file(session_id, "events.ndjson", "event stream")
+        meta_path = self._session_file(session_id, "meta.json", "session metadata")
+        meta = self.load_meta(session_id)
+        if meta.tenant_id and meta.tenant_id != tenant_id:
+            raise ValueError(
+                f"session {session_id} is already assigned to another tenant"
+            )
+        raw_text = path.read_text(encoding="utf-8") if path.exists() else ""
+        raw_lines = [line for line in raw_text.splitlines() if line]
+        tagged_lines: list[str] = []
+        previous_line = ""
+        for raw_line in raw_lines:
+            event = TraceEvent.from_json(raw_line)
+            if event.session_id and event.session_id != session_id:
+                raise ValueError("event session ID does not match its directory")
+            event.session_id = session_id
+            if event.tenant_id and event.tenant_id != tenant_id:
+                raise ValueError(f"event {event.event_id} belongs to another tenant")
+            event.tenant_id = tenant_id
+            event.prev_hash = (
+                hashlib.sha256(previous_line.encode()).hexdigest()
+                if previous_line else ""
+            )
+            serialised = event.to_json()
+            tagged_lines.append(serialised)
+            previous_line = serialised
+        tagged_text = "\n".join(tagged_lines) + ("\n" if tagged_lines else "")
+        new_terminal_hash = (
+            hashlib.sha256(tagged_lines[-1].encode()).hexdigest()
+            if tagged_lines else ""
+        )
+
+        _write_atomic(path, tagged_text)
+        record["phase"] = "events_replaced"
+        record["new_terminal_hash"] = new_terminal_hash
+        _write_atomic(journal_path, json.dumps(record, separators=(",", ":")))
+
+        meta.tenant_id = tenant_id
+        _write_atomic(meta_path, meta.to_json())
+        record["phase"] = "metadata_replaced"
+        _write_atomic(journal_path, json.dumps(record, separators=(",", ":")))
+
+        record["phase"] = "commit"
+        _write_atomic(journal_path, json.dumps(record, separators=(",", ":")))
+
+        audit_path = self._store_file("tenant-audit.ndjson", "tenant audit")
+        if not self._audit_has_operation(audit_path, operation_id):
+            self._append_tenant_audit({
+                "action": "session_tenant_assigned",
+                "assigned_at": time.time(),
+                "operation_id": operation_id,
+                "session_id_sha256": hashlib.sha256(session_id.encode()).hexdigest(),
+                "tenant_id_sha256": hashlib.sha256(tenant_id.encode()).hexdigest(),
+                "previous_terminal_hash": record.get("previous_terminal_hash", ""),
+                "new_terminal_hash": new_terminal_hash,
+            })
+        record["phase"] = "committed"
+        _write_atomic(journal_path, json.dumps(record, separators=(",", ":")))
+        journal_path.unlink(missing_ok=True)
+        _fsync_directory(journal_path.parent)
+        return len(tagged_lines)
+
+    def _recover_tag_journals(self) -> None:
+        journal_dir = self._journal_dir()
+        if not journal_dir.exists() or journal_dir.is_symlink():
+            return
+        with _store_write_lock(self.base_dir):
+            for journal_path in sorted(journal_dir.glob("tag-*.json")):
+                if journal_path.is_symlink():
+                    continue
+                try:
+                    record = json.loads(journal_path.read_text(encoding="utf-8"))
+                    if record.get("operation") != "tag_session":
+                        continue
+                    self._complete_tag_journal_locked(journal_path, record)
+                except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                    # Keep the journal for an operator or a later successful
+                    # recovery attempt; never guess through corrupt intent.
+                    continue
+
+    def _deletion_audit_has(self, operation_id: str, status: str) -> bool:
+        path = self._store_file(
+            "tenant-deletions.ndjson", "tenant deletion audit"
+        )
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    record.get("operation_id") == operation_id
+                    and record.get("status") == status
+                ):
+                    return True
+        except OSError:
+            return False
+        return False
+
+    def _append_deletion_audit(self, record: dict) -> Path:
+        path = self._store_file(
+            "tenant-deletions.ndjson", "tenant deletion audit"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as audit_file:
+            audit_file.write(json.dumps(record, separators=(",", ":")) + "\n")
+            audit_file.flush()
+            os.fsync(audit_file.fileno())
+        return path
+
+    def _hashed_deletion_record(self, journal: dict, status: str) -> dict:
+        tenant_id = journal["tenant_id"]
+        items = journal.get("sessions", [])
+        failed = [item["session_id"] for item in items if item.get("failed")]
+        deleted = [item for item in items if item.get("deleted")]
+        record = {
+            "action": "tenant_data_deletion",
+            "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "operation_id": journal["operation_id"],
+            "tenant_id_sha256": hashlib.sha256(tenant_id.encode()).hexdigest(),
+            "session_id_sha256": [
+                hashlib.sha256(item["session_id"].encode()).hexdigest()
+                for item in items
+            ],
+            "workspace_id_sha256": (
+                hashlib.sha256(self.workspace_id.encode()).hexdigest()
+                if self.workspace_id else ""
+            ),
+            "sessions_deleted": len(deleted),
+            "events_deleted": sum(
+                int(item.get("event_count", 0)) for item in deleted
+            ),
+            "status": status,
+        }
+        if failed:
+            record["failed_session_id_sha256"] = [
+                hashlib.sha256(session_id.encode()).hexdigest()
+                for session_id in failed
+            ]
+        return record
+
+    def _cleanup_deleted_hook_state(self, deleted_ids: set[str]) -> None:
+        """Remove scoped hook state and unambiguous legacy root markers."""
+        def suffix_session_id(suffix: str) -> str | None:
+            if suffix.startswith(".v2."):
+                parts = suffix.split(".")
+                if len(parts) != 5 or not re.fullmatch(r"[0-9a-f]{64}", parts[4]):
+                    return None
+                try:
+                    session_id = bytes.fromhex(parts[3]).decode("utf-8")
+                    return validate_stored_id(session_id, "hook state session ID")
+                except (UnicodeDecodeError, ValueError):
+                    return None
+            if not suffix.startswith("."):
+                return None
+            try:
+                raw_session_id = validate_stored_id(
+                    suffix[1:], "legacy hook state suffix"
+                )
+            except ValueError:
+                return None
+            return raw_session_id[:16]
+
+        def has_surviving_session(session_id: str) -> bool:
+            # Root markers predate workspace-scoped state. Do not guess which
+            # workspace they belong to when the same session ID survives in
+            # any flat or workspace store.
+            flat = self.storage_root / session_id
+            if not flat.is_symlink() and (flat / "meta.json").is_file():
+                return True
+            workspaces = self.storage_root / "workspaces"
+            if not workspaces.exists() or workspaces.is_symlink():
+                return False
+            try:
+                directories = workspaces.iterdir()
+                for workspace in directories:
+                    if workspace.is_symlink() or not workspace.is_dir():
+                        continue
+                    candidate = workspace / session_id
+                    if not candidate.is_symlink() and (candidate / "meta.json").is_file():
+                        return True
+            except OSError:
+                # Preserve legacy state if uniqueness cannot be established.
+                return True
+            return False
+
+        def cleanup(root: Path, *, require_unambiguous: bool) -> None:
+            if not root.exists():
+                return
+            for marker in root.glob(".active-session*"):
+                if marker.is_symlink():
+                    continue
+                try:
+                    session_id = marker.read_text(encoding="utf-8").strip()
+                    if session_id not in deleted_ids:
+                        continue
+                    if require_unambiguous and has_surviving_session(session_id):
+                        continue
+                    suffix = marker.name[len(".active-session"):]
+                    marker.unlink()
+                    (root / f".pending-calls{suffix}.json").unlink(missing_ok=True)
+                except OSError:
+                    continue
+            # Markerless pending calls are deleted only when their safe,
+            # attributable suffix maps to one of the erased local sessions.
+            for pending in root.glob(".pending-calls*.json"):
+                if pending.is_symlink():
+                    continue
+                suffix = pending.name[len(".pending-calls"):-len(".json")]
+                marker = root / f".active-session{suffix}"
+                try:
+                    if (
+                        not marker.exists()
+                        and suffix_session_id(suffix) in deleted_ids
+                    ):
+                        pending.unlink()
+                except OSError:
+                    continue
+
+        if self.base_dir != self.storage_root:
+            cleanup(self.base_dir, require_unambiguous=False)
+        cleanup(self.storage_root, require_unambiguous=True)
+
+    def _complete_delete_journal_locked(
+        self, journal_path: Path, journal: dict,
+    ) -> dict:
+        """Idempotently roll a durable tenant-deletion intent forward."""
+        tenant_id = validate_tenant_id(journal.get("tenant_id", ""))
+        operation_id = str(journal.get("operation_id", ""))
+        if not operation_id:
+            raise ValueError("deletion journal is missing operation_id")
+        items = journal.get("sessions", [])
+        if not isinstance(items, list):
+            raise ValueError("deletion journal sessions must be a list")
+        for item in items:
+            if not isinstance(item, dict):
+                raise ValueError("invalid deletion journal session")
+            validate_stored_id(item.get("session_id", ""), "stored session ID")
+
+        # Validate every remaining core path before removing shared external
+        # records. A symlinked checkpoint, meta, or event stream must leave
+        # both the trace and any outside target untouched.
+        for item in items:
+            if item.get("deleted"):
+                continue
+            session_id = item["session_id"]
+            session_dir = self._session_dir(session_id)
+            self.checkpoint_path(session_id)
+            if session_dir.exists():
+                meta = self.load_meta(session_id)
+                self._session_file(session_id, "events.ndjson", "event stream")
+                if meta.tenant_id != tenant_id:
+                    raise ValueError(
+                        "deletion journal tenant does not match session"
+                    )
+        if not journal.get("external_records_cleaned"):
+            self._external_record_plan({item["session_id"] for item in items})
+
+        # Persist a hash-only tombstone only after every path passes preflight,
+        # but before deleting trace bytes or external records.
+        if not self._deletion_audit_has(operation_id, "pending"):
+            self._append_deletion_audit(
+                self._hashed_deletion_record(journal, "pending")
+            )
+        self._erasure_audit_mtime_ns = -1
+
+        if not journal.get("external_records_cleaned"):
+            self._delete_external_session_records_locked({
+                item["session_id"] for item in items
+            })
+            journal["external_records_cleaned"] = True
+            journal["phase"] = "external_records_cleaned"
+            _write_atomic(journal_path, json.dumps(journal, separators=(",", ":")))
+
+        for item in items:
+            if item.get("deleted"):
+                continue
+            session_id = item["session_id"]
+            try:
+                session_dir = self._session_dir(session_id)
+                if session_dir.exists():
+                    meta = self.load_meta(session_id)
+                    if meta.tenant_id != tenant_id:
+                        raise ValueError(
+                            "deletion journal tenant does not match session"
+                        )
+                    checkpoint = self.checkpoint_path(session_id)
+                    checkpoint.unlink(missing_ok=True)
+                    shutil.rmtree(session_dir)
+                item["deleted"] = True
+                item.pop("failed", None)
+            except (OSError, ValueError):
+                item["failed"] = True
+            _write_atomic(journal_path, json.dumps(journal, separators=(",", ":")))
+
+        deleted_ids = {
+            item["session_id"] for item in items if item.get("deleted")
+        }
+        self._cleanup_deleted_hook_state(deleted_ids)
+        failed = [item["session_id"] for item in items if item.get("failed")]
+        status = "partial" if failed else "completed"
+        if not self._deletion_audit_has(operation_id, status):
+            self._append_deletion_audit(
+                self._hashed_deletion_record(journal, status)
+            )
+        self._erasure_audit_mtime_ns = -1
+        if failed:
+            journal["phase"] = "partial"
+            _write_atomic(journal_path, json.dumps(journal, separators=(",", ":")))
+        else:
+            journal_path.unlink(missing_ok=True)
+            _fsync_directory(journal_path.parent)
+        deleted_items = [item for item in items if item.get("deleted")]
+        return {
+            "tenant_id": tenant_id,
+            "deleted_sessions": len(deleted_items),
+            "deleted_events": sum(
+                int(item.get("event_count", 0)) for item in deleted_items
+            ),
+            "failed_session_ids": tuple(failed),
+            "audit_path": self._store_file(
+                "tenant-deletions.ndjson", "tenant deletion audit"
+            ),
+        }
+
+    def _recover_delete_journals(self) -> None:
+        journal_dir = self._journal_dir()
+        if not journal_dir.exists() or journal_dir.is_symlink():
+            return
+        with _store_write_lock(self.base_dir):
+            for journal_path in sorted(journal_dir.glob("delete-*.json")):
+                if journal_path.is_symlink():
+                    continue
+                try:
+                    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+                    if journal.get("operation") != "delete_tenant":
+                        continue
+                    self._complete_delete_journal_locked(journal_path, journal)
+                except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                    # Keep malformed or temporarily unexecutable intent for
+                    # an operator or a later successful startup.
+                    continue
+
+    def recover_delete_journals(self) -> None:
+        """Retry interrupted tenant deletions for this scoped store."""
+        self._recover_delete_journals()
+
+    def _enforce_parent_tenant(self, meta: SessionMeta, *, inherit: bool) -> None:
+        """Resolve a parent in this store and enforce a safe tenant boundary."""
+        if not meta.parent_session_id:
+            return
+        if meta.parent_session_id == meta.session_id:
+            raise ValueError("a session cannot be its own parent")
+        try:
+            parent = self.load_meta(meta.parent_session_id)
+        except FileNotFoundError as exc:
+            raise ValueError("parent session must exist in the same scoped store") from exc
+        if parent.tenant_id == meta.tenant_id:
+            return  # includes the explicit legacy untagged→untagged case
+        if inherit and parent.tenant_id and not meta.tenant_id:
+            meta.tenant_id = parent.tenant_id
+            return
+        if not parent.tenant_id and meta.tenant_id:
+            raise ValueError("tag the legacy untagged parent before linking a tagged child")
+        raise ValueError("cross-tenant parent link rejected")
+
+    def _enforce_tag_tenant_links(self, meta: SessionMeta, tenant_id: str) -> None:
+        """Reject a tag that would split an existing parent/child tree."""
+        if meta.parent_session_id:
+            try:
+                parent = self.load_meta(meta.parent_session_id)
+            except FileNotFoundError as exc:
+                raise ValueError(
+                    "parent session must exist in the same scoped store"
+                ) from exc
+            if parent.tenant_id != tenant_id:
+                raise ValueError(
+                    "tagging session would create a cross-tenant parent link"
+                )
+        for child in self.list_sessions():
+            if child.parent_session_id != meta.session_id:
+                continue
+            if child.tenant_id != tenant_id:
+                raise ValueError(
+                    "tagging session would create a cross-tenant child link"
+                )
 
     def create_session(self, meta: SessionMeta) -> Path:
         # Stamp workspace_id onto meta so it's visible in exports/reports
-        if self.workspace_id and not getattr(meta, "workspace_id", ""):
-            meta.workspace_id = self.workspace_id
-        self._redact_meta(meta)
-        d = self._session_dir(meta.session_id)
-        d.mkdir(parents=True, exist_ok=True)
-        (d / "meta.json").write_text(meta.to_json())
-        # create empty events file
-        (d / "events.ndjson").touch()
-        return d
+        with _store_write_lock(self.base_dir):
+            _validate_meta_ids(meta, strict_session=True)
+            if self._session_was_erased(meta.session_id):
+                raise ValueError(f"session {meta.session_id} was erased and cannot be recreated")
+            if self.workspace_id and not getattr(meta, "workspace_id", ""):
+                meta.workspace_id = self.workspace_id
+            if not meta.tenant_id:
+                meta.tenant_id = os.environ.get(_TENANT_ENV, "").strip()
+            if meta.tenant_id:
+                meta.tenant_id = validate_tenant_id(meta.tenant_id)
+            self._enforce_parent_tenant(meta, inherit=True)
+            self._redact_meta(meta)
+            d = self._session_dir(meta.session_id)
+            existing_meta_path = self._session_file(
+                meta.session_id, "meta.json", "session metadata"
+            )
+            if existing_meta_path.exists():
+                existing = SessionMeta.from_json(existing_meta_path.read_text())
+                if existing.tenant_id and not meta.tenant_id:
+                    meta.tenant_id = existing.tenant_id
+                elif existing.tenant_id != meta.tenant_id:
+                    raise ValueError(
+                        f"session {meta.session_id} tenant cannot be changed during creation"
+                    )
+                if existing.parent_session_id != meta.parent_session_id:
+                    raise ValueError("use update_meta to change a session parent")
+            d.mkdir(parents=True, exist_ok=True)
+            self._session_file(
+                meta.session_id, "meta.json", "session metadata"
+            ).write_text(meta.to_json())
+            # create empty events file
+            self._session_file(
+                meta.session_id, "events.ndjson", "event stream"
+            ).touch()
+            return d
 
     def append_event(self, session_id: str, event: TraceEvent) -> None:
-        f = self._session_dir(session_id) / "events.ndjson"
-        self._redact_event(event)
-        # Compute hash chain: SHA-256 of the last line in the file
-        if not event.prev_hash:
+        try:
+            session_id = validate_session_id(session_id)
+        except ValueError:
+            session_id = validate_stored_id(session_id, "stored session ID")
+            if not self._session_file(
+                session_id, "meta.json", "session metadata"
+            ).exists():
+                raise
+        if event.session_id and event.session_id != session_id:
+            raise ValueError("event session ID does not match target session")
+        event.session_id = session_id
+        # The only supported empty→tagged metadata transition is tag_session,
+        # which atomically updates historical events and records hash evidence.
+        if event.tenant_id:
+            if self._session_was_erased(session_id):
+                raise ValueError(f"session {session_id} was erased and cannot accept events")
+            existing = self.load_meta(session_id)
+            if not existing.tenant_id:
+                self.tag_session(session_id, event.tenant_id)
+        f = self._session_file(session_id, "events.ndjson", "event stream")
+        with _store_write_lock(self.base_dir):
+            if self._session_was_erased(session_id):
+                raise ValueError(f"session {session_id} was erased and cannot accept events")
+            # Session metadata is authoritative.  This prevents a changed
+            # environment (or malformed remote event) from mixing tenants in
+            # one session. An untagged legacy session adopts its first tag.
             try:
-                import hashlib as _hashlib
-                text = f.read_text() if f.exists() else ""
-                last_line = text.rstrip("\n").rsplit("\n", 1)[-1] if text.strip() else ""
-                event.prev_hash = _hashlib.sha256(last_line.encode()).hexdigest() if last_line else ""
-            except Exception:
-                pass
-        with open(f, "a") as fh:
-            fh.write(event.to_json() + "\n")
+                meta = self.load_meta(session_id)
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                meta = None
+            if meta is not None:
+                if meta.tenant_id:
+                    if event.tenant_id and event.tenant_id != meta.tenant_id:
+                        raise ValueError(
+                            f"event tenant {event.tenant_id!r} does not match "
+                            f"session tenant {meta.tenant_id!r}"
+                        )
+                    event.tenant_id = validate_tenant_id(meta.tenant_id)
+            elif event.tenant_id:
+                event.tenant_id = validate_tenant_id(event.tenant_id)
+            self._redact_event(event)
+            f.parent.mkdir(parents=True, exist_ok=True)
+            with open(f, "a+", encoding="utf-8") as fh:
+                # Compute the hash and append while holding one lock so a
+                # concurrent tenant-tag operation cannot split the chain.
+                if not event.prev_hash:
+                    fh.seek(0)
+                    text = fh.read()
+                    last_line = text.rstrip("\n").rsplit("\n", 1)[-1] if text.strip() else ""
+                    event.prev_hash = hashlib.sha256(last_line.encode()).hexdigest() if last_line else ""
+                fh.write(event.to_json() + "\n")
+                fh.flush()
 
     def update_meta(self, meta: SessionMeta) -> None:
-        f = self._session_dir(meta.session_id) / "meta.json"
-        self._redact_meta(meta)
-        f.write_text(meta.to_json())
+        _validate_meta_ids(meta)
+        with _store_write_lock(self.base_dir):
+            f = self._session_file(
+                meta.session_id, "meta.json", "session metadata"
+            )
+            if not f.exists():
+                raise FileNotFoundError(f"session not found: {meta.session_id}")
+            existing = SessionMeta.from_json(f.read_text())
+            if existing.session_id != meta.session_id:
+                raise ValueError("metadata session ID does not match its directory")
+            if existing.tenant_id != meta.tenant_id:
+                if not existing.tenant_id and meta.tenant_id:
+                    raise ValueError("use tag_session for the first tenant assignment")
+                raise ValueError("session tenant cannot be cleared or changed")
+            if meta.tenant_id:
+                meta.tenant_id = validate_tenant_id(meta.tenant_id)
+            self._enforce_parent_tenant(meta, inherit=False)
+            self._redact_meta(meta)
+            _write_atomic(f, meta.to_json())
 
     def load_meta(self, session_id: str) -> SessionMeta:
-        f = self._session_dir(session_id) / "meta.json"
-        return SessionMeta.from_json(f.read_text())
+        f = self._session_file(session_id, "meta.json", "session metadata")
+        meta = SessionMeta.from_json(f.read_text())
+        if meta.session_id != validate_stored_id(session_id, "stored session ID"):
+            raise ValueError("metadata session ID does not match its directory")
+        _validate_meta_ids(meta)
+        return meta
 
     def load_events(self, session_id: str) -> list[TraceEvent]:
-        f = self._session_dir(session_id) / "events.ndjson"
+        session_id = validate_stored_id(session_id, "stored session ID")
+        f = self._session_file(session_id, "events.ndjson", "event stream")
+        meta = self.load_meta(session_id)
         events = []
         for line in f.read_text().strip().splitlines():
             if line:
-                events.append(TraceEvent.from_json(line))
+                event = TraceEvent.from_json(line)
+                if event.session_id and event.session_id != session_id:
+                    raise ValueError("event session ID does not match its directory")
+                event.session_id = session_id
+                if meta.tenant_id and event.tenant_id and event.tenant_id != meta.tenant_id:
+                    raise ValueError("event tenant does not match session metadata")
+                events.append(event)
+        # Session-level tenancy is authoritative and also makes the single
+        # pre-watch event of an active session tenant-aware to all readers.
+        tenant_id = meta.tenant_id
+        if tenant_id:
+            for event in events:
+                event.tenant_id = tenant_id
         return events
 
-    def list_sessions(self) -> list[SessionMeta]:
+    def list_sessions(self, tenant_id: str | None = None) -> list[SessionMeta]:
         """Return valid sessions sorted newest first by started_at, then descending session ID."""
         if not self.base_dir.exists():
             return []
         sessions = []
         for d in self.base_dir.iterdir():
+            if d.is_symlink() or not d.is_dir():
+                continue
             meta_file = d / "meta.json"
-            if meta_file.exists():
+            if meta_file.is_symlink():
+                continue
+            if meta_file.exists() and meta_file.is_file():
                 try:
-                    sessions.append(SessionMeta.from_json(meta_file.read_text()))
-                except (json.JSONDecodeError, TypeError):
+                    meta = SessionMeta.from_json(meta_file.read_text())
+                    _validate_meta_ids(meta)
+                    validate_stored_id(d.name, "stored session directory")
+                    if meta.session_id != d.name:
+                        continue
+                    if tenant_id is None or meta.tenant_id == tenant_id:
+                        sessions.append(meta)
+                except (json.JSONDecodeError, TypeError, ValueError, OSError):
                     continue
         return sorted(
             sessions,
@@ -158,32 +1039,171 @@ class TraceStore:
             reverse=True,
         )
 
-    def get_latest_session(self) -> SessionMeta | None:
+    def list_sessions_strict(
+        self, tenant_id: str | None = None,
+    ) -> list[SessionMeta]:
+        """Strictly discover sessions for report/export/erasure workflows.
+
+        Ordinary listing intentionally skips corrupt entries. Tenant
+        administration must instead fail closed so it cannot report an
+        incomplete result or claim deletion succeeded while data was omitted.
+        """
+        if self.base_dir.is_symlink():
+            raise ValueError("refusing symlinked trace store")
+        if not self.base_dir.exists():
+            return []
+        if not self.base_dir.is_dir():
+            raise ValueError("trace store is not a directory")
+
+        sessions: list[SessionMeta] = []
+        for entry in sorted(self.base_dir.iterdir(), key=lambda item: item.name):
+            if entry.is_symlink():
+                raise ValueError(f"unsafe symlinked trace store entry: {entry.name}")
+            if not entry.is_dir():
+                continue
+
+            meta_path = entry / "meta.json"
+            events_path = entry / "events.ndjson"
+            is_flat_workspace_root = (
+                not self.workspace_id and entry.name == "workspaces"
+            )
+            is_auxiliary = entry.name in _TENANT_ADMIN_AUXILIARY_DIRS
+            if (is_flat_workspace_root or is_auxiliary) and not (
+                meta_path.exists() or events_path.exists()
+            ):
+                continue
+
+            try:
+                session_id = validate_stored_id(
+                    entry.name, "stored session directory"
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"unsafe session directory in tenant store: {entry.name!r}"
+                ) from exc
+            if not meta_path.exists() or not events_path.exists():
+                raise ValueError(
+                    f"unrecognized or incomplete session directory: {session_id}"
+                )
+            if meta_path.is_symlink() or events_path.is_symlink():
+                raise ValueError(f"unsafe symlinked core file for session {session_id}")
+            if not meta_path.is_file() or not events_path.is_file():
+                raise ValueError(f"invalid core file for session {session_id}")
+            try:
+                meta = self.load_meta(session_id)
+                self.load_events(session_id)
+            except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"corrupt session in tenant store: {session_id}"
+                ) from exc
+            if tenant_id is None or meta.tenant_id == tenant_id:
+                sessions.append(meta)
+
+        return sorted(
+            sessions,
+            key=lambda meta: (meta.started_at, meta.session_id),
+            reverse=True,
+        )
+
+    def get_latest_session(self, tenant_id: str | None = None) -> SessionMeta | None:
         """Return the newest session metadata, or None when the store is empty."""
-        sessions = self.list_sessions()
+        sessions = self.list_sessions(tenant_id=tenant_id)
         if not sessions:
             return None
         return sessions[0]
 
-    def get_latest_session_id(self) -> str | None:
+    def get_latest_session_id(self, tenant_id: str | None = None) -> str | None:
         """Return the newest session ID, or None when the store is empty."""
-        latest = self.get_latest_session()
+        latest = self.get_latest_session(tenant_id=tenant_id)
         if not latest:
             return None
         return latest.session_id
 
     def session_exists(self, session_id: str) -> bool:
-        return (self._session_dir(session_id) / "meta.json").exists()
+        return self._session_file(
+            session_id, "meta.json", "session metadata"
+        ).exists()
 
-    def find_session(self, prefix: str) -> str | None:
+    def find_session(self, prefix: str, tenant_id: str | None = None) -> str | None:
         """Find a session by prefix match."""
+        validate_stored_id(prefix, "session ID prefix")
         if not self.base_dir.exists():
             return None
         for d in self.base_dir.iterdir():
-            if d.name.startswith(prefix) and (d / "meta.json").exists():
-                return d.name
+            if d.is_symlink() or not d.is_dir() or not d.name.startswith(prefix):
+                continue
+            try:
+                validate_stored_id(d.name, "stored session directory")
+                meta = self.load_meta(d.name)
+                if tenant_id is None or meta.tenant_id == tenant_id:
+                    return d.name
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                continue
         return None
+
+    def tag_session(self, session_id: str, tenant_id: str) -> int:
+        """Assign *tenant_id* to a session and every persisted event.
+
+        Returns the number of existing events tagged.  Retagging a session to
+        a different tenant is rejected so a query boundary cannot be moved by
+        accident.  The event hash chain is rebuilt while holding the same
+        advisory lock used by append_event.
+        """
+        session_id = validate_stored_id(session_id, "stored session ID")
+        tenant_id = validate_tenant_id(tenant_id)
+        path = self._session_file(session_id, "events.ndjson", "event stream")
+        meta_path = self._session_file(session_id, "meta.json", "session metadata")
+        with _store_write_lock(self.base_dir):
+            meta = self.load_meta(session_id)
+            self._store_file("tenant-audit.ndjson", "tenant audit")
+            if meta.tenant_id and meta.tenant_id != tenant_id:
+                raise ValueError(
+                    f"session {session_id} is already assigned to tenant {meta.tenant_id!r}"
+                )
+            self._enforce_tag_tenant_links(meta, tenant_id)
+            raw_text = path.read_text(encoding="utf-8") if path.exists() else ""
+            raw_lines = [line for line in raw_text.splitlines() if line]
+            for raw_line in raw_lines:
+                event = TraceEvent.from_json(raw_line)
+                if event.session_id and event.session_id != session_id:
+                    raise ValueError("event session ID does not match its directory")
+                if event.tenant_id and event.tenant_id != tenant_id:
+                    raise ValueError(f"event {event.event_id} belongs to another tenant")
+            previous_terminal_hash = (
+                hashlib.sha256(raw_lines[-1].encode()).hexdigest() if raw_lines else ""
+            )
+            original_meta_text = meta_path.read_text(encoding="utf-8")
+            operation_id = uuid.uuid4().hex
+            journal_dir = self._journal_dir()
+            journal_dir.mkdir(parents=True, exist_ok=True)
+            journal_path = journal_dir / f"tag-{operation_id}.json"
+            record = {
+                "operation": "tag_session",
+                "operation_id": operation_id,
+                "session_id": session_id,
+                "tenant_id": tenant_id,
+                "phase": "intent",
+                "previous_terminal_hash": previous_terminal_hash,
+            }
+            _write_atomic(journal_path, json.dumps(record, separators=(",", ":")))
+            try:
+                return self._complete_tag_journal_locked(journal_path, record)
+            except Exception:
+                # Once both trace files are durable, commit/committed phases
+                # are roll-forward only. This prevents a post-audit failure
+                # from rolling data back while leaving false audit evidence.
+                if record.get("phase") in {"commit", "committed"}:
+                    raise
+                # Pre-commit exceptions can safely restore the exact input.
+                _write_atomic(path, raw_text)
+                if meta_path.read_text(encoding="utf-8") != original_meta_text:
+                    _write_atomic(meta_path, original_meta_text)
+                journal_path.unlink(missing_ok=True)
+                _fsync_directory(journal_path.parent)
+                raise
 
     def annotations_path(self, session_id: str) -> Path:
         """Return the path to the annotations sidecar file."""
-        return self._session_dir(session_id) / "annotations.jsonl"
+        return self._session_file(
+            session_id, "annotations.jsonl", "annotations sidecar"
+        )

--- a/src/agent_trace/subagent.py
+++ b/src/agent_trace/subagent.py
@@ -58,10 +58,20 @@ def build_tree(store: TraceStore, root_session_id: str) -> SessionNode:
     parent_session_id matches a session already in the tree.
     Depth is bounded by MAX_DEPTH.
     """
+    try:
+        root_meta = store.load_meta(root_session_id)
+    except FileNotFoundError as exc:
+        raise KeyError(f"Session not found in store: {root_session_id}") from exc
+    tenant_id = root_meta.tenant_id
     all_meta = store.list_sessions()
 
     # Index by session_id for fast lookup
     meta_by_id: dict[str, SessionMeta] = {m.session_id: m for m in all_meta}
+
+    if root_meta.parent_session_id and root_meta.parent_session_id in meta_by_id:
+        parent = meta_by_id[root_meta.parent_session_id]
+        if parent.tenant_id != tenant_id:
+            raise ValueError("cross-tenant parent link rejected")
 
     # Index children by parent_session_id
     children_of: dict[str, list[SessionMeta]] = {}
@@ -81,6 +91,10 @@ def build_tree(store: TraceStore, root_session_id: str) -> SessionNode:
                 children_of.get(session_id, []),
                 key=lambda m: m.started_at,
             ):
+                if child_meta.tenant_id != tenant_id:
+                    raise ValueError(
+                        f"cross-tenant child link rejected for session {child_meta.session_id}"
+                    )
                 node.children.append(_build(child_meta.session_id, current_depth + 1))
         elif children_of.get(session_id):
             sys.stderr.write(

--- a/src/agent_trace/tenancy.py
+++ b/src/agent_trace/tenancy.py
@@ -1,0 +1,418 @@
+"""Multi-tenant trace reporting, export, and erasure.
+
+Tenant IDs are additive metadata tags.  Local commands scope every operation
+through :class:`TraceStore` before loading event data so one tenant's export or
+cost report cannot accidentally include another tenant's sessions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import calendar
+import hashlib
+import json
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TextIO
+
+from .cost import DEFAULT_MODEL, estimate_cost
+from .store import TraceStore, _write_atomic, validate_stored_id, validate_tenant_id
+
+
+@dataclass(frozen=True)
+class TenantReportRow:
+    tenant_id: str
+    sessions: int
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class TenantReport:
+    month: str
+    rows: list[TenantReportRow]
+
+    @property
+    def total_sessions(self) -> int:
+        return sum(row.sessions for row in self.rows)
+
+    @property
+    def total_cost_usd(self) -> float:
+        return sum(row.cost_usd for row in self.rows)
+
+
+@dataclass(frozen=True)
+class TenantDeletionResult:
+    tenant_id: str
+    deleted_sessions: int
+    deleted_events: int
+    failed_session_ids: tuple[str, ...]
+    audit_path: Path
+    audit_paths: tuple[Path, ...] = ()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _month_bounds(month: str) -> tuple[float, float]:
+    try:
+        parsed = datetime.strptime(month, "%Y-%m").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError("month must use YYYY-MM format") from exc
+    _, days = calendar.monthrange(parsed.year, parsed.month)
+    end = parsed.replace(day=days, hour=23, minute=59, second=59, microsecond=999999)
+    return parsed.timestamp(), end.timestamp()
+
+
+def enumerate_trace_stores(base_dir: str | Path) -> list[TraceStore]:
+    """Return the flat store plus every safe workspace store, without env bias."""
+    root = TraceStore(base_dir, use_workspace_env=False)
+    stores = [root]
+    workspaces = root.storage_root / "workspaces"
+    if workspaces.is_symlink():
+        raise ValueError("refusing symlinked workspaces root")
+    if workspaces.exists():
+        if not workspaces.is_dir():
+            raise ValueError("workspaces root is not a directory")
+        for directory in sorted(workspaces.iterdir(), key=lambda item: item.name):
+            if directory.is_symlink():
+                raise ValueError(
+                    f"refusing symlinked workspace entry: {directory.name}"
+                )
+            if not directory.is_dir():
+                continue
+            workspace_id = validate_stored_id(
+                directory.name, "stored workspace directory"
+            )
+            store = TraceStore(
+                base_dir,
+                workspace_id=workspace_id,
+                use_workspace_env=False,
+                allow_legacy_workspace_id=True,
+            )
+            if store.base_dir.resolve() not in {item.base_dir.resolve() for item in stores}:
+                stores.append(store)
+    for store in stores:
+        _recover_delete_journals(store)
+    return stores
+
+
+def _coerce_stores(value: TraceStore | list[TraceStore]) -> list[TraceStore]:
+    stores = [value] if isinstance(value, TraceStore) else list(value)
+    unique: list[TraceStore] = []
+    seen: set[Path] = set()
+    for store in stores:
+        resolved = store.base_dir.resolve()
+        if resolved not in seen:
+            unique.append(store)
+            seen.add(resolved)
+    return unique
+
+
+def build_tenant_report(
+    store: TraceStore | list[TraceStore],
+    month: str,
+    model: str = DEFAULT_MODEL,
+) -> TenantReport:
+    """Aggregate session counts and estimated cost by tenant for one UTC month."""
+    start, end = _month_bounds(month)
+    grouped: dict[str, list[float | int]] = {}
+    for scoped_store in _coerce_stores(store):
+        for meta in scoped_store.list_sessions_strict():
+            if not start <= meta.started_at <= end:
+                continue
+            values = grouped.setdefault(meta.tenant_id, [0, 0.0])
+            values[0] = int(values[0]) + 1
+            try:
+                result = estimate_cost(scoped_store, meta.session_id, model=model)
+                values[1] = float(values[1]) + result.total_cost
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+
+    rows = [
+        TenantReportRow(
+            tenant_id=tenant_id,
+            sessions=int(values[0]),
+            cost_usd=float(values[1]),
+        )
+        for tenant_id, values in grouped.items()
+    ]
+    rows.sort(key=lambda row: (-row.cost_usd, row.tenant_id or "~"))
+    return TenantReport(month=month, rows=rows)
+
+
+def format_tenant_report(report: TenantReport, out: TextIO = sys.stdout) -> None:
+    """Write a human-readable tenant cost rollup."""
+    title = datetime.strptime(report.month, "%Y-%m").strftime("%B %Y")
+    labels = [row.tenant_id or "(untagged)" for row in report.rows]
+    tenant_width = min(max([len("Tenant"), *(len(label) for label in labels)]), 48)
+    divider = "─" * (tenant_width + 38)
+    out.write(
+        f"Tenant cost report — {title}\n"
+        f"{divider}\n"
+        f"{'Tenant':<{tenant_width}}  {'Sessions':>8}  {'Cost':>11}  {'% of total':>12}\n"
+        f"{divider}\n"
+    )
+    total = report.total_cost_usd
+    for row, label in zip(report.rows, labels):
+        display = label if len(label) <= tenant_width else label[:tenant_width - 1] + "…"
+        percent = row.cost_usd / total * 100 if total else 0.0
+        out.write(
+            f"{display:<{tenant_width}}  {row.sessions:>8}  "
+            f"${row.cost_usd:>10.2f}  {percent:>11.1f}%\n"
+        )
+    out.write(f"{divider}\n")
+    out.write(
+        f"{'Total':<{tenant_width}}  {report.total_sessions:>8}  "
+        f"${report.total_cost_usd:>10.2f}\n"
+    )
+
+
+def _encoded_file(path: Path, relative_to: Path) -> dict:
+    data = path.read_bytes()
+    try:
+        content = data.decode("utf-8")
+        encoding = "utf-8"
+    except UnicodeDecodeError:
+        content = base64.b64encode(data).decode("ascii")
+        encoding = "base64"
+    return {
+        "path": path.relative_to(relative_to).as_posix(),
+        "encoding": encoding,
+        "content": content,
+    }
+
+
+def _relevant_audit_records(store: TraceStore, tenant_hash: str) -> list[dict]:
+    records: list[dict] = []
+    for name in ("tenant-audit.ndjson", "tenant-deletions.ndjson"):
+        path = store._store_file(name, "tenant audit")
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if record.get("tenant_id_sha256") == tenant_hash:
+                records.append({"source": name, "record": record})
+    return records
+
+
+def tenant_export_payload(
+    store: TraceStore | list[TraceStore], tenant_id: str,
+) -> dict:
+    """Return a complete, versioned subject-access export."""
+    tenant_id = validate_tenant_id(tenant_id)
+    sessions = []
+    audit_records: list[dict] = []
+    external_records: list[dict] = []
+    tenant_hash = hashlib.sha256(tenant_id.encode()).hexdigest()
+    for scoped_store in _coerce_stores(store):
+        with scoped_store.write_lock():
+            metas = scoped_store.list_sessions_strict(tenant_id=tenant_id)
+            session_ids = {meta.session_id for meta in metas}
+            for meta in metas:
+                events = scoped_store.load_events(meta.session_id)
+                session_dir = scoped_store._session_dir(meta.session_id)
+                sidecars = []
+                for path in sorted(session_dir.rglob("*")):
+                    if path.is_symlink():
+                        raise ValueError(f"refusing symlinked session sidecar: {path.name}")
+                    if path.is_file() and path.name not in {"meta.json", "events.ndjson"}:
+                        sidecars.append(_encoded_file(path, session_dir))
+                checkpoint_path = scoped_store.checkpoint_path(meta.session_id)
+                checkpoint = (
+                    _encoded_file(checkpoint_path, scoped_store.base_dir)
+                    if checkpoint_path.exists()
+                    else None
+                )
+                sessions.append({
+                    "scope": {
+                        "workspace_id": scoped_store.workspace_id or None,
+                    },
+                    "session": json.loads(meta.to_json()),
+                    "events": [json.loads(event.to_json()) for event in events],
+                    "sidecars": sidecars,
+                    "checkpoint": checkpoint,
+                })
+            for item in scoped_store.external_session_records(session_ids):
+                item["scope"] = {
+                    "workspace_id": scoped_store.workspace_id or None
+                }
+                external_records.append(item)
+            for item in _relevant_audit_records(scoped_store, tenant_hash):
+                item["scope"] = {"workspace_id": scoped_store.workspace_id or None}
+                audit_records.append(item)
+    return {
+        "schema": "agent-strace-tenant-export/v1",
+        "tenant_id": tenant_id,
+        "exported_at": _utc_now(),
+        "session_count": len(sessions),
+        "sessions": sessions,
+        "external_records": {
+            "schema": "agent-strace-tenant-external-records/v1",
+            "records": external_records,
+        },
+        "audit_records": audit_records,
+    }
+
+
+def _execute_delete_journal_locked(
+    store: TraceStore, journal_path: Path, journal: dict,
+) -> TenantDeletionResult:
+    result = store._complete_delete_journal_locked(journal_path, journal)
+    audit_path = result["audit_path"]
+    return TenantDeletionResult(
+        tenant_id=result["tenant_id"],
+        deleted_sessions=result["deleted_sessions"],
+        deleted_events=result["deleted_events"],
+        failed_session_ids=result["failed_session_ids"],
+        audit_path=audit_path,
+        audit_paths=(audit_path,),
+    )
+
+
+def _recover_delete_journals(store: TraceStore) -> None:
+    store.recover_delete_journals()
+
+
+def _delete_tenant_one(store: TraceStore, tenant_id: str) -> TenantDeletionResult:
+    _recover_delete_journals(store)
+    with store.write_lock():
+        metas = store.list_sessions_strict(tenant_id=tenant_id)
+        operation_id = uuid.uuid4().hex
+        journal_dir = store._journal_dir()
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        journal_path = journal_dir / f"delete-{operation_id}.json"
+        sessions = []
+        for meta in metas:
+            try:
+                event_count = len(store.load_events(meta.session_id))
+            except (OSError, ValueError, json.JSONDecodeError):
+                event_count = 0
+            sessions.append({"session_id": meta.session_id, "event_count": event_count})
+        journal = {
+            "operation": "delete_tenant",
+            "operation_id": operation_id,
+            "tenant_id": tenant_id,
+            "workspace_id": store.workspace_id,
+            "phase": "intent",
+            "sessions": sessions,
+        }
+        _write_atomic(journal_path, json.dumps(journal, separators=(",", ":")))
+        return _execute_delete_journal_locked(store, journal_path, journal)
+
+
+def delete_tenant_data(
+    store: TraceStore | list[TraceStore], tenant_id: str,
+) -> TenantDeletionResult:
+    """Hard-delete matching sessions across flat and workspace stores."""
+    tenant_id = validate_tenant_id(tenant_id)
+    stores = _coerce_stores(store)
+    targets = [
+        scoped
+        for scoped in stores
+        if scoped.list_sessions_strict(tenant_id=tenant_id)
+    ]
+    if not targets:
+        targets = stores[:1]
+    results = [_delete_tenant_one(scoped, tenant_id) for scoped in targets]
+    audit_paths = tuple(path for result in results for path in result.audit_paths)
+    failures = tuple(sid for result in results for sid in result.failed_session_ids)
+    return TenantDeletionResult(
+        tenant_id=tenant_id,
+        deleted_sessions=sum(result.deleted_sessions for result in results),
+        deleted_events=sum(result.deleted_events for result in results),
+        failed_session_ids=failures,
+        audit_path=audit_paths[0],
+        audit_paths=audit_paths,
+    )
+
+
+def cmd_tenant(args: argparse.Namespace) -> int:
+    """Handle the ``tenant`` report/export/delete command family."""
+    try:
+        stores = enumerate_trace_stores(args.trace_dir)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"Tenant store discovery failed: {exc}\n")
+        return 1
+    action = getattr(args, "tenant_command", "")
+
+    if action == "report":
+        month = getattr(args, "month", "") or datetime.now(timezone.utc).strftime("%Y-%m")
+        try:
+            report = build_tenant_report(stores, month, model=getattr(args, "model", DEFAULT_MODEL))
+        except ValueError as exc:
+            sys.stderr.write(f"Error: {exc}\n")
+            return 1
+        if getattr(args, "format", "text") == "json":
+            payload = {
+                "month": report.month,
+                "total_sessions": report.total_sessions,
+                "total_cost_usd": report.total_cost_usd,
+                "tenants": [
+                    {
+                        "tenant_id": row.tenant_id or None,
+                        "sessions": row.sessions,
+                        "cost_usd": row.cost_usd,
+                    }
+                    for row in report.rows
+                ],
+            }
+            sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+        else:
+            format_tenant_report(report)
+        return 0
+
+    tenant_id = getattr(args, "tenant_id", "")
+    try:
+        tenant_id = validate_tenant_id(tenant_id)
+    except ValueError as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return 1
+
+    if action == "export":
+        try:
+            payload = tenant_export_payload(stores, tenant_id)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            sys.stderr.write(f"Export failed: {exc}\n")
+            return 1
+        text = json.dumps(payload, indent=2) + "\n"
+        output = getattr(args, "output", "") or ""
+        if output:
+            Path(output).write_text(text, encoding="utf-8")
+            sys.stdout.write(f"Exported {payload['session_count']} session(s) to {output}\n")
+        else:
+            sys.stdout.write(text)
+        return 0
+
+    if action == "delete":
+        if not getattr(args, "confirm", False):
+            sys.stderr.write(
+                "Refusing tenant deletion without --confirm. This operation is irreversible.\n"
+            )
+            return 1
+        try:
+            result = delete_tenant_data(stores, tenant_id)
+        except (OSError, ValueError) as exc:
+            sys.stderr.write(f"Deletion failed: {exc}\n")
+            return 1
+        sys.stdout.write(
+            f"Deleted {result.deleted_sessions} session(s) and "
+            f"{result.deleted_events} event(s) for tenant {tenant_id}.\n"
+            f"Audit record(s): {', '.join(str(path) for path in result.audit_paths)}\n"
+        )
+        if result.failed_session_ids:
+            sys.stderr.write(
+                "Failed to delete session(s): " + ", ".join(result.failed_session_ids) + "\n"
+            )
+            return 1
+        return 0
+
+    sys.stderr.write("Specify a tenant subcommand: report, export, or delete.\n")
+    return 1

--- a/src/agent_trace/watch.py
+++ b/src/agent_trace/watch.py
@@ -527,6 +527,7 @@ class EventStreamer:
         for sid, evs in by_session.items():
             meta = _SessionMeta(agent_name=self.config.service_name)
             meta.session_id = sid
+            meta.tenant_id = next((ev.tenant_id for ev in evs if ev.tenant_id), "")
             try:
                 payload = session_to_otlp_genai(
                     meta, evs, service_name=self.config.service_name
@@ -1118,7 +1119,7 @@ def watch_session(
     stream_config: when set, events are pushed in real-time to the configured
     URL as they arrive (push-based streaming).
     """
-    events_file = store._session_dir(session_id) / "events.ndjson"
+    events_file = store._session_file(session_id, "events.ndjson", "event stream")
     if not events_file.exists():
         out.write(f"[watch] events file not found: {events_file}\n")
         return
@@ -1359,6 +1360,21 @@ def cmd_watch(args: argparse.Namespace) -> int:
     if not full_id:
         sys.stderr.write(f"Session not found: {session_id}\n")
         return 1
+
+    tenant_id = (
+        getattr(args, "tenant_id", None)
+        or os.environ.get("AGENT_STRACE_TENANT_ID", "")
+    )
+    if tenant_id:
+        try:
+            tagged_events = store.tag_session(full_id, tenant_id)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            sys.stderr.write(f"[watch] could not assign tenant: {exc}\n")
+            return 1
+        sys.stderr.write(
+            f"[watch] Tenant {tenant_id.strip()} assigned to "
+            f"{tagged_events} existing event(s).\n"
+        )
 
     checkpoint_watcher: CompactionCheckpointWatcher | None = None
     if getattr(args, "compaction_checkpoint", False):

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from agent_trace.cli import cmd_setup
 from agent_trace.hooks import (
+    _active_session_path,
     _read_active_session,
     handle_file_write,
     handle_post_tool,
@@ -58,7 +59,7 @@ class TestCursorHooks(unittest.TestCase):
         self.assertEqual(events[0].data["mode"], "cursor-agent-hooks")
 
         canonical = Path(self.tmpdir) / ".active-session"
-        scoped = Path(self.tmpdir) / f".active-session.{raw_session_id}"
+        scoped = _active_session_path(provider="cursor")
         self.assertEqual(canonical.read_text(), session_id)
         self.assertEqual(scoped.read_text(), session_id)
 
@@ -101,15 +102,14 @@ class TestCursorHooks(unittest.TestCase):
             {"session_id": raw_session_id, "source": "startup"},
             provider="cursor",
         )
+        scoped = _active_session_path(provider="cursor")
         os.environ.pop("AGENT_TRACE_CURSOR_SESSION_ID", None)
 
         with patch("agent_trace.hooks._product_telemetry.capture"):
             handle_session_end({}, provider="cursor")
 
         self.assertFalse((Path(self.tmpdir) / ".active-session").exists())
-        self.assertFalse(
-            (Path(self.tmpdir) / f".active-session.{raw_session_id}").exists()
-        )
+        self.assertFalse(scoped.exists())
 
     def test_cursor_prompt_response_and_file_edit(self):
         handle_session_start({"session_id": "cursorprompt12345", "source": "startup"}, provider="cursor")
@@ -194,9 +194,7 @@ class TestCursorHooks(unittest.TestCase):
             hook_main(["--provider", "cursor", "sessionEnd"])
 
         self.assertFalse((Path(self.tmpdir) / ".active-session").exists())
-        self.assertFalse(
-            (Path(self.tmpdir) / f".active-session.{conversation_id}").exists()
-        )
+        self.assertFalse(_active_session_path(provider="cursor").exists())
 
 
 class TestCursorSetup(unittest.TestCase):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -5,15 +5,18 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from agent_trace.hooks import (
+    _active_session_path,
     _read_active_session,
     _write_active_session,
     _clear_active_session,
     _read_pending_calls,
     _write_pending_calls,
+    _state_suffix,
     handle_session_start,
     handle_session_end,
     handle_pre_tool,
@@ -494,6 +497,30 @@ class TestConcurrentAgentIsolation(unittest.TestCase):
         os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "agent2session00002"
         _clear_active_session()
         self.assertFalse(os.path.exists(canonical))
+
+    def test_provider_session_state_suffix_is_hashed_and_contained(self):
+        raw = "abcdefghijklmnop/../../outside-marker"
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = raw
+        suffix = _state_suffix("claude")
+        active = _active_session_path("claude")
+
+        self.assertRegex(suffix, r"^\.v2\.claude\.[0-9a-f]+\.[0-9a-f]{64}$")
+        self.assertEqual(active.parent, Path(self.tmpdir))
+        self.assertNotIn(raw, active.name)
+
+        handle_session_start({"session_id": raw, "source": "startup"})
+        self.assertTrue(active.exists())
+        self.assertFalse((Path(self.tmpdir).parent / "outside-marker").exists())
+
+    def test_distinct_raw_provider_ids_cannot_collide(self):
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "same/id"
+        first = _state_suffix("claude")
+        os.environ["AGENT_TRACE_CLAUDE_SESSION_ID"] = "same_id"
+        second = _state_suffix("claude")
+        os.environ["AGENT_TRACE_CURSOR_SESSION_ID"] = "same/id"
+        third = _state_suffix("cursor")
+
+        self.assertEqual(len({first, second, third}), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ import time
 import unittest
 import urllib.request
 import urllib.error
+from urllib.parse import quote
 from pathlib import Path
 
 from agent_trace.models import EventType, SessionMeta, TraceEvent
@@ -181,6 +182,46 @@ class TestPostSessions(unittest.TestCase):
         status, resp = _post(f"{self.base}/sessions", body)
         self.assertEqual(status, 400)
 
+    def test_existing_tenant_cannot_be_cleared_or_changed(self):
+        meta = SessionMeta(session_id="tenant-session", tenant_id="tenant-a")
+        self.store.create_session(meta)
+        for tenant_id in ("", "tenant-b"):
+            body = json.dumps({
+                "session_id": meta.session_id, "tenant_id": tenant_id,
+            }).encode("utf-8")
+            status, _ = _post(f"{self.base}/sessions", body)
+            self.assertEqual(status, 409)
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "tenant-a")
+
+    def test_first_tenant_assignment_retags_existing_events(self):
+        meta = SessionMeta(session_id="legacy-tenant-session", tenant_id="")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, TraceEvent(
+            event_type=EventType.USER_PROMPT,
+            session_id=meta.session_id,
+            data={"prompt": "hello"},
+            tenant_id="",
+        ))
+        body = json.dumps({
+            "session_id": meta.session_id, "tenant_id": "tenant-a",
+        }).encode("utf-8")
+
+        status, _ = _post(f"{self.base}/sessions", body)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "tenant-a")
+        raw = json.loads(
+            (self.store._session_dir(meta.session_id) / "events.ndjson").read_text()
+        )
+        self.assertEqual(raw["tenant_id"], "tenant-a")
+
+    def test_path_traversal_session_id_is_rejected(self):
+        status, _ = _post(
+            f"{self.base}/sessions",
+            json.dumps({"session_id": "../escape"}).encode("utf-8"),
+        )
+        self.assertEqual(status, 400)
+
 
 # ---------------------------------------------------------------------------
 # GET /sessions
@@ -238,6 +279,37 @@ class TestGetSessionEvents(unittest.TestCase):
         self.assertEqual(len(lines), 1)
         parsed = json.loads(lines[0])
         self.assertEqual(parsed["event_type"], "tool_call")
+
+    def test_get_reads_url_decoded_safe_legacy_id_but_post_rejects_it(self):
+        legacy_id = "Legacy café session " + "x" * 130
+        session_dir = self.store.base_dir / legacy_id
+        session_dir.mkdir()
+        meta = SessionMeta(session_id=legacy_id)
+        event = TraceEvent(
+            event_type=EventType.TOOL_CALL,
+            session_id=legacy_id,
+            data={"tool_name": "Read"},
+        )
+        (session_dir / "meta.json").write_text(meta.to_json())
+        (session_dir / "events.ndjson").write_text(event.to_json() + "\n")
+        encoded = quote(legacy_id, safe="")
+
+        status, body = _get(f"{self.base}/sessions/{encoded}")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["session_id"], legacy_id)
+        status, body = _get(f"{self.base}/sessions/{encoded}/events")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["session_id"], legacy_id)
+
+        status, _ = _post(
+            f"{self.base}/sessions", meta.to_json().encode("utf-8")
+        )
+        self.assertEqual(status, 400)
+
+    def test_get_rejects_url_encoded_path_separator(self):
+        encoded = quote("../escape", safe="")
+        status, _ = _get(f"{self.base}/sessions/{encoded}/events")
+        self.assertEqual(status, 400)
 
     def test_get_events_unknown_session_returns_404(self):
         status, body = _get(f"{self.base}/sessions/nonexistent/events")

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -1,0 +1,1053 @@
+"""Tests for multi-tenant session isolation and GDPR workflows."""
+
+import io
+import json
+import os
+import hashlib
+import tempfile
+import unittest
+from dataclasses import fields
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_trace.audit import verify_chain
+from agent_trace.cli import build_parser, cmd_list
+from agent_trace.cost import build_provider_cost_report, build_tenant_cost_report, cmd_cost
+from agent_trace.hooks import handle_pre_tool, handle_session_start
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.otlp import session_to_otlp, session_to_otlp_genai
+from agent_trace.store import TraceStore
+from agent_trace.subagent import build_tree
+from agent_trace.tenancy import (
+    build_tenant_report,
+    cmd_tenant,
+    delete_tenant_data,
+    enumerate_trace_stores,
+    tenant_export_payload,
+)
+from agent_trace.watch import cmd_watch
+
+
+def _event(session_id: str, timestamp: float = 1.0, **kwargs) -> TraceEvent:
+    data = kwargs.pop("data", {"prompt": "hello tenant"})
+    return TraceEvent(
+        event_type=EventType.USER_PROMPT,
+        session_id=session_id,
+        timestamp=timestamp,
+        data=data,
+        **kwargs,
+    )
+
+
+def _attr_values(span: dict) -> dict:
+    values = {}
+    for attr in span.get("attributes", []):
+        value = next(iter(attr["value"].values()))
+        values[attr["key"]] = value
+    return values
+
+
+class TenantTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.store = TraceStore(self.tempdir.name, redact=False)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def create_session(self, session_id: str, tenant_id: str, timestamp: float = 1.0):
+        meta = SessionMeta(
+            session_id=session_id,
+            tenant_id=tenant_id,
+            started_at=timestamp,
+        )
+        self.store.create_session(meta)
+        self.store.append_event(session_id, _event(session_id, timestamp))
+        return meta
+
+    def write_legacy_session(
+        self,
+        base_dir: Path,
+        session_id: str,
+        tenant_id: str,
+        timestamp: float = 1.0,
+        parent_session_id: str = "",
+        workspace_id: str = "",
+    ) -> SessionMeta:
+        """Write a pre-validation session without using the creation API."""
+        session_dir = base_dir / session_id
+        session_dir.mkdir(parents=True)
+        meta = SessionMeta(
+            session_id=session_id,
+            tenant_id=tenant_id,
+            started_at=timestamp,
+            parent_session_id=parent_session_id,
+            workspace_id=workspace_id,
+        )
+        (session_dir / "meta.json").write_text(meta.to_json(), encoding="utf-8")
+        event = _event(session_id, timestamp, tenant_id=tenant_id)
+        (session_dir / "events.ndjson").write_text(
+            event.to_json() + "\n", encoding="utf-8"
+        )
+        return meta
+
+
+class TestTenantModelAndStore(TenantTestCase):
+    def test_environment_tags_new_sessions_and_events(self):
+        with patch.dict(os.environ, {"AGENT_STRACE_TENANT_ID": "customer-acme"}):
+            meta = SessionMeta(session_id="env-session")
+            event = _event(meta.session_id)
+            self.store.create_session(meta)
+            self.store.append_event(meta.session_id, event)
+
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "customer-acme")
+        self.assertEqual(self.store.load_events(meta.session_id)[0].tenant_id, "customer-acme")
+        raw = json.loads(
+            (self.store._session_dir(meta.session_id) / "events.ndjson").read_text()
+        )
+        self.assertEqual(raw["tenant_id"], "customer-acme")
+
+    def test_legacy_deserialisation_does_not_inherit_reader_environment(self):
+        meta_json = '{"session_id":"legacy","started_at":1}'
+        event_json = (
+            '{"event_type":"user_prompt","timestamp":1,"event_id":"e1",'
+            '"session_id":"legacy","data":{}}'
+        )
+        with patch.dict(os.environ, {"AGENT_STRACE_TENANT_ID": "wrong-tenant"}):
+            self.assertEqual(SessionMeta.from_json(meta_json).tenant_id, "")
+            self.assertEqual(TraceEvent.from_json(event_json).tenant_id, "")
+
+    def test_session_metadata_rejects_mixed_tenant_event(self):
+        meta = self.create_session("isolated", "tenant-a")
+        path = self.store._session_dir(meta.session_id) / "events.ndjson"
+        before = path.read_bytes()
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.store.append_event(
+                meta.session_id,
+                _event(meta.session_id, tenant_id="tenant-b"),
+            )
+        self.assertEqual(path.read_bytes(), before)
+
+    def test_scoped_store_iteration_and_prefix_lookup(self):
+        self.create_session("tenant-a-session", "tenant-a", 2.0)
+        self.create_session("tenant-b-session", "tenant-b", 3.0)
+
+        self.assertEqual(
+            [meta.session_id for meta in self.store.list_sessions("tenant-a")],
+            ["tenant-a-session"],
+        )
+        self.assertEqual(self.store.get_latest_session_id("tenant-b"), "tenant-b-session")
+        self.assertIsNone(self.store.find_session("tenant-b", tenant_id="tenant-a"))
+
+    def test_tag_session_preserves_data_and_rebuilds_valid_hash_chain(self):
+        meta = SessionMeta(session_id="watch-session", started_at=1.0, tenant_id="")
+        self.store.create_session(meta)
+        first = _event(meta.session_id, data={"prompt": "first"}, redacted=True)
+        second = TraceEvent(
+            event_type=EventType.ASSISTANT_RESPONSE,
+            session_id=meta.session_id,
+            timestamp=2.0,
+            data={"text": "second"},
+        )
+        self.store.append_event(meta.session_id, first)
+        self.store.append_event(meta.session_id, second)
+        original = [(event.event_id, event.data, event.redacted) for event in self.store.load_events(meta.session_id)]
+
+        count = self.store.tag_session(meta.session_id, "tenant-a")
+
+        tagged = self.store.load_events(meta.session_id)
+        self.assertEqual(count, 2)
+        self.assertEqual([(e.event_id, e.data, e.redacted) for e in tagged], original)
+        self.assertEqual({event.tenant_id for event in tagged}, {"tenant-a"})
+        self.assertTrue(verify_chain(self.store, meta.session_id).ok)
+        audit = json.loads((self.store.base_dir / "tenant-audit.ndjson").read_text())
+        self.assertTrue(audit["previous_terminal_hash"])
+        self.assertTrue(audit["new_terminal_hash"])
+        self.assertNotEqual(audit["previous_terminal_hash"], audit["new_terminal_hash"])
+
+    def test_tag_session_conflict_leaves_trace_unchanged(self):
+        meta = self.create_session("already-tagged", "tenant-a")
+        meta_path = self.store._session_dir(meta.session_id) / "meta.json"
+        events_path = self.store._session_dir(meta.session_id) / "events.ndjson"
+        before = (meta_path.read_bytes(), events_path.read_bytes())
+
+        with self.assertRaisesRegex(ValueError, "already assigned"):
+            self.store.tag_session(meta.session_id, "tenant-b")
+
+        self.assertEqual((meta_path.read_bytes(), events_path.read_bytes()), before)
+
+    def test_failed_metadata_replace_rolls_back_event_rewrite(self):
+        from agent_trace import store as store_module
+
+        meta = SessionMeta(session_id="atomic", started_at=1.0, tenant_id="")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        meta_path = self.store._session_dir(meta.session_id) / "meta.json"
+        events_path = self.store._session_dir(meta.session_id) / "events.ndjson"
+        before = (meta_path.read_bytes(), events_path.read_bytes())
+        original_write = store_module._write_atomic
+
+        def fail_meta(path, text):
+            if Path(path).name == "meta.json":
+                raise OSError("simulated metadata failure")
+            return original_write(path, text)
+
+        with patch("agent_trace.store._write_atomic", side_effect=fail_meta):
+            with self.assertRaisesRegex(OSError, "simulated"):
+                self.store.tag_session(meta.session_id, "tenant-a")
+
+        self.assertEqual((meta_path.read_bytes(), events_path.read_bytes()), before)
+        self.assertFalse((self.store.base_dir / "tenant-audit.ndjson").exists())
+
+    def test_update_meta_cannot_assign_clear_or_change_tenant(self):
+        meta = SessionMeta(session_id="immutable", tenant_id="")
+        self.store.create_session(meta)
+        meta.tenant_id = "tenant-a"
+        with self.assertRaisesRegex(ValueError, "tag_session"):
+            self.store.update_meta(meta)
+        self.store.tag_session(meta.session_id, "tenant-a")
+        tagged = self.store.load_meta(meta.session_id)
+        tagged.tenant_id = ""
+        with self.assertRaisesRegex(ValueError, "cleared or changed"):
+            self.store.update_meta(tagged)
+        tagged.tenant_id = "tenant-b"
+        with self.assertRaisesRegex(ValueError, "cleared or changed"):
+            self.store.update_meta(tagged)
+
+    def test_session_paths_and_metadata_directory_identity_are_strict(self):
+        with self.assertRaises(ValueError):
+            self.store.create_session(SessionMeta(session_id="../escape"))
+        meta = SessionMeta(session_id="directory-id")
+        self.store.create_session(meta)
+        path = self.store._session_dir(meta.session_id) / "meta.json"
+        data = json.loads(path.read_text())
+        data["session_id"] = "different-id"
+        path.write_text(json.dumps(data))
+        with self.assertRaisesRegex(ValueError, "directory"):
+            self.store.load_meta(meta.session_id)
+        self.assertEqual(self.store.list_sessions(), [])
+
+    def test_new_ids_are_strict_while_safe_legacy_ids_remain_readable(self):
+        legacy_id = "Legacy café session " + "x" * 130
+        self.write_legacy_session(
+            self.store.base_dir, legacy_id, "tenant-legacy", 1_781_481_600.0
+        )
+
+        self.assertEqual(self.store.load_meta(legacy_id).session_id, legacy_id)
+        self.assertEqual(self.store.load_events(legacy_id)[0].session_id, legacy_id)
+        self.assertEqual(self.store.find_session("Legacy café"), legacy_id)
+        self.assertIn(legacy_id, {meta.session_id for meta in self.store.list_sessions()})
+        with self.assertRaises(ValueError):
+            self.store.create_session(SessionMeta(session_id="new session"))
+        for unsafe in (
+            "../escape", "nested/name", "nested\\name", "bad\x00id", "bad\x85id"
+        ):
+            with self.assertRaises(ValueError):
+                self.store.load_meta(unsafe)
+
+    def test_parent_tenant_is_enforced_on_create_and_update(self):
+        parent_a = SessionMeta(session_id="parent-a", tenant_id="tenant-a")
+        parent_b = SessionMeta(session_id="parent-b", tenant_id="tenant-b")
+        self.store.create_session(parent_a)
+        self.store.create_session(parent_b)
+
+        with self.assertRaisesRegex(ValueError, "cross-tenant"):
+            self.store.create_session(SessionMeta(
+                session_id="bad-child",
+                tenant_id="tenant-b",
+                parent_session_id=parent_a.session_id,
+            ))
+
+        inherited = SessionMeta(
+            session_id="inherited-child", parent_session_id=parent_a.session_id
+        )
+        self.store.create_session(inherited)
+        self.assertEqual(inherited.tenant_id, "tenant-a")
+
+        inherited.parent_session_id = parent_b.session_id
+        with self.assertRaisesRegex(ValueError, "cross-tenant"):
+            self.store.update_meta(inherited)
+
+        legacy_parent = SessionMeta(session_id="legacy-parent")
+        legacy_child = SessionMeta(
+            session_id="legacy-child", parent_session_id=legacy_parent.session_id
+        )
+        self.store.create_session(legacy_parent)
+        self.store.create_session(legacy_child)
+        self.assertEqual(self.store.load_meta(legacy_child.session_id).tenant_id, "")
+
+    def test_tag_session_cannot_split_existing_parent_child_links(self):
+        parent = SessionMeta(session_id="tag-parent")
+        child = SessionMeta(
+            session_id="tag-child", parent_session_id=parent.session_id
+        )
+        self.store.create_session(parent)
+        self.store.create_session(child)
+
+        with self.assertRaisesRegex(ValueError, "child link"):
+            self.store.tag_session(parent.session_id, "tenant-a")
+        with self.assertRaisesRegex(ValueError, "parent link"):
+            self.store.tag_session(child.session_id, "tenant-a")
+
+        tagged_parent = SessionMeta(session_id="tagged-parent", tenant_id="tenant-a")
+        self.store.create_session(tagged_parent)
+        legacy_child = self.write_legacy_session(
+            self.store.base_dir,
+            "legacy-tag-child",
+            "",
+            parent_session_id=tagged_parent.session_id,
+        )
+        self.assertEqual(
+            self.store.tag_session(legacy_child.session_id, "tenant-a"), 1
+        )
+
+        different_child = self.write_legacy_session(
+            self.store.base_dir,
+            "different-tag-child",
+            "",
+            parent_session_id=tagged_parent.session_id,
+        )
+        with self.assertRaisesRegex(ValueError, "already assigned|parent link"):
+            self.store.tag_session(different_child.session_id, "tenant-b")
+
+    def test_positional_dataclass_fields_remain_backward_compatible(self):
+        self.assertEqual(fields(TraceEvent)[-1].name, "tenant_id")
+        self.assertEqual(fields(SessionMeta)[-1].name, "tenant_id")
+        event = TraceEvent(
+            EventType.USER_PROMPT, 1.0, "event1", "session1", "", None,
+            {"prompt": "hi"}, "previous", True,
+        )
+        self.assertTrue(event.redacted)
+        self.assertEqual(event.prev_hash, "previous")
+
+    def test_tag_journal_is_recovered_and_audit_is_hash_only(self):
+        meta = SessionMeta(session_id="recover-tag", tenant_id="")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        operation_id = "a" * 32
+        journal_dir = self.store.base_dir / ".tenant-journal"
+        journal_dir.mkdir()
+        journal = {
+            "operation": "tag_session", "operation_id": operation_id,
+            "session_id": meta.session_id, "tenant_id": "secret-tenant",
+            "phase": "intent", "previous_terminal_hash": "before",
+        }
+        (journal_dir / f"tag-{operation_id}.json").write_text(json.dumps(journal))
+
+        recovered = TraceStore(self.tempdir.name, redact=False)
+
+        self.assertEqual(recovered.load_meta(meta.session_id).tenant_id, "secret-tenant")
+        self.assertFalse((journal_dir / f"tag-{operation_id}.json").exists())
+        audit_text = (recovered.base_dir / "tenant-audit.ndjson").read_text()
+        self.assertNotIn("secret-tenant", audit_text)
+        self.assertNotIn(meta.session_id, audit_text)
+
+    def test_legacy_empty_event_session_id_is_tagged_and_recovered(self):
+        meta = SessionMeta(session_id="legacy-empty-event")
+        self.store.create_session(meta)
+        events_path = self.store._session_dir(meta.session_id) / "events.ndjson"
+        legacy_event = _event("")
+        events_path.write_text(legacy_event.to_json() + "\n")
+
+        self.assertEqual(self.store.tag_session(meta.session_id, "tenant-a"), 1)
+        raw = json.loads(events_path.read_text())
+        self.assertEqual(raw["session_id"], meta.session_id)
+        self.assertEqual(raw["tenant_id"], "tenant-a")
+
+        mismatch = SessionMeta(session_id="legacy-mismatched-event")
+        self.store.create_session(mismatch)
+        mismatch_path = self.store._session_dir(mismatch.session_id) / "events.ndjson"
+        mismatch_path.write_text(_event("another-session").to_json() + "\n")
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.store.tag_session(mismatch.session_id, "tenant-a")
+        self.assertEqual(self.store.load_meta(mismatch.session_id).tenant_id, "")
+
+        second = SessionMeta(session_id="legacy-empty-recovery")
+        self.store.create_session(second)
+        second_events = self.store._session_dir(second.session_id) / "events.ndjson"
+        second_events.write_text(_event("").to_json() + "\n")
+        operation_id = "e" * 32
+        journal_dir = self.store.base_dir / ".tenant-journal"
+        journal_dir.mkdir(exist_ok=True)
+        journal = {
+            "operation": "tag_session", "operation_id": operation_id,
+            "session_id": second.session_id, "tenant_id": "tenant-b",
+            "phase": "intent", "previous_terminal_hash": "before",
+        }
+        (journal_dir / f"tag-{operation_id}.json").write_text(json.dumps(journal))
+
+        recovered = TraceStore(self.tempdir.name, redact=False)
+        self.assertEqual(recovered.load_meta(second.session_id).tenant_id, "tenant-b")
+        self.assertEqual(
+            recovered.load_events(second.session_id)[0].session_id, second.session_id
+        )
+
+    def test_post_audit_tag_failure_is_roll_forward_only(self):
+        meta = SessionMeta(session_id="tag-commit-fault")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        original_append = self.store._append_tenant_audit
+
+        def append_then_fail(record):
+            original_append(record)
+            raise OSError("failure after durable audit append")
+
+        with patch.object(
+            self.store, "_append_tenant_audit", side_effect=append_then_fail
+        ):
+            with self.assertRaisesRegex(OSError, "durable audit"):
+                self.store.tag_session(meta.session_id, "tenant-a")
+
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "tenant-a")
+        self.assertEqual(
+            self.store.load_events(meta.session_id)[0].tenant_id, "tenant-a"
+        )
+        self.assertEqual(
+            len(list((self.store.base_dir / ".tenant-journal").glob("tag-*.json"))),
+            1,
+        )
+
+        recovered = TraceStore(self.tempdir.name, redact=False)
+        self.assertEqual(recovered.load_meta(meta.session_id).tenant_id, "tenant-a")
+        self.assertEqual(
+            len(list((recovered.base_dir / ".tenant-journal").glob("tag-*.json"))),
+            0,
+        )
+        audits = (recovered.base_dir / "tenant-audit.ndjson").read_text().splitlines()
+        self.assertEqual(len(audits), 1)
+
+
+class TestTenantCostsAndCommands(TenantTestCase):
+    def test_cost_reports_are_exactly_tenant_scoped(self):
+        self.create_session("a", "tenant-a", 2_000.0)
+        self.create_session("b", "tenant-b", 2_000.0)
+
+        report = build_tenant_cost_report(
+            self.store, "tenant-a", since="1d", now=2_100.0
+        )
+        providers = build_provider_cost_report(
+            self.store, since="1d", now=2_100.0, tenant_id="tenant-a"
+        )
+
+        self.assertEqual(report.sessions, 1)
+        self.assertGreater(report.total_cost, 0)
+        self.assertNotIn("b", {row.session_id for row in providers.records})
+
+    def test_monthly_report_includes_tenants_and_untagged(self):
+        june = 1_781_481_600.0  # 2026-06-15 UTC
+        self.create_session("a", "tenant-a", june)
+        self.create_session("untagged", "", june)
+        self.create_session("outside", "tenant-b", 1.0)
+
+        report = build_tenant_report(self.store, "2026-06")
+
+        self.assertEqual(report.total_sessions, 2)
+        self.assertEqual({row.tenant_id for row in report.rows}, {"tenant-a", ""})
+
+    def test_parser_registers_all_tenant_flags(self):
+        parser = build_parser()
+        self.assertEqual(parser.parse_args(["list", "--tenant", "a"]).tenant, "a")
+        self.assertEqual(parser.parse_args(["cost", "--tenant", "a"]).tenant, "a")
+        self.assertEqual(
+            parser.parse_args(["watch", "session", "--tenant-id", "a"]).tenant_id,
+            "a",
+        )
+        report = parser.parse_args(["tenant", "report", "--month", "2026-06"])
+        self.assertEqual((report.command, report.tenant_command), ("tenant", "report"))
+        delete = parser.parse_args(["tenant", "delete", "a", "--confirm"])
+        self.assertTrue(delete.confirm)
+
+    def test_watch_flag_tags_existing_events_before_monitoring(self):
+        meta = SessionMeta(session_id="watch-target", tenant_id="")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        args = build_parser().parse_args([
+            "--trace-dir", self.tempdir.name,
+            "watch", meta.session_id, "--tenant-id", "tenant-a",
+        ])
+
+        with patch("agent_trace.watch.watch_session") as monitor:
+            self.assertEqual(cmd_watch(args), 0)
+
+        monitor.assert_called_once()
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "tenant-a")
+        self.assertEqual(self.store.load_events(meta.session_id)[0].tenant_id, "tenant-a")
+
+    def test_watch_environment_fallback_tags_existing_events(self):
+        meta = SessionMeta(session_id="watch-env", tenant_id="")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        args = build_parser().parse_args([
+            "--trace-dir", self.tempdir.name, "watch", meta.session_id,
+        ])
+
+        with patch.dict(os.environ, {"AGENT_STRACE_TENANT_ID": "tenant-env"}), \
+             patch("agent_trace.watch.watch_session"):
+            self.assertEqual(cmd_watch(args), 0)
+
+        self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "tenant-env")
+
+    def test_list_command_passes_exact_tenant_scope(self):
+        args = build_parser().parse_args([
+            "--trace-dir", self.tempdir.name, "list", "--tenant", "tenant-a",
+        ])
+        with patch("agent_trace.cli.list_sessions") as render:
+            self.assertEqual(cmd_list(args), 0)
+        self.assertEqual(render.call_args.kwargs["tenant_id"], "tenant-a")
+
+    def test_cost_command_uses_aggregate_tenant_path(self):
+        now = __import__("time").time()
+        self.create_session("current-a", "tenant-a", now)
+        self.create_session("current-b", "tenant-b", now)
+        args = build_parser().parse_args([
+            "--trace-dir", self.tempdir.name,
+            "cost", "--tenant", "tenant-a", "--since", "1d",
+        ])
+        with patch("agent_trace.cost.format_tenant_cost") as render:
+            self.assertEqual(cmd_cost(args), 0)
+        result = render.call_args.args[0]
+        self.assertEqual((result.tenant_id, result.sessions), ("tenant-a", 1))
+
+
+class TestTenantExportAndDelete(TenantTestCase):
+    def test_export_contains_only_requested_tenant(self):
+        self.create_session("a", "tenant-a")
+        self.create_session("b", "tenant-b")
+
+        payload = tenant_export_payload(self.store, "tenant-a")
+
+        self.assertEqual(payload["session_count"], 1)
+        self.assertEqual(payload["sessions"][0]["session"]["session_id"], "a")
+        self.assertEqual(payload["sessions"][0]["events"][0]["tenant_id"], "tenant-a")
+        self.assertNotIn("tenant-b", json.dumps(payload))
+
+    def test_admin_operations_fail_closed_on_corrupt_session_metadata(self):
+        good = self.create_session("admin-good", "tenant-a")
+        corrupt = self.store.base_dir / "corrupt-session"
+        corrupt.mkdir()
+        (corrupt / "meta.json").write_text("{not-json")
+        (corrupt / "events.ndjson").write_text("")
+
+        self.assertEqual(
+            [meta.session_id for meta in self.store.list_sessions()],
+            [good.session_id],
+        )
+        with self.assertRaisesRegex(ValueError, "corrupt session"):
+            build_tenant_report(self.store, "2026-01")
+        with self.assertRaisesRegex(ValueError, "corrupt session"):
+            tenant_export_payload(self.store, "tenant-a")
+        with self.assertRaisesRegex(ValueError, "corrupt session"):
+            delete_tenant_data(self.store, "tenant-a")
+        self.assertTrue(self.store.session_exists(good.session_id))
+
+    def test_admin_operations_fail_closed_on_omitted_symlinked_metadata(self):
+        session_id = "hidden-tenant-session"
+        session_dir = self.store.base_dir / session_id
+        session_dir.mkdir()
+        (session_dir / "events.ndjson").write_text("")
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_meta = Path(external_dir) / "meta.json"
+            external_meta.write_text(SessionMeta(
+                session_id=session_id, tenant_id="tenant-a"
+            ).to_json())
+            os.symlink(external_meta, session_dir / "meta.json")
+
+            self.assertEqual(self.store.list_sessions(), [])
+            with self.assertRaisesRegex(ValueError, "symlinked trace store entry|symlinked core"):
+                tenant_export_payload(self.store, "tenant-a")
+            with self.assertRaisesRegex(ValueError, "symlinked trace store entry|symlinked core"):
+                delete_tenant_data(self.store, "tenant-a")
+            self.assertEqual(
+                json.loads(external_meta.read_text())["tenant_id"], "tenant-a"
+            )
+            self.assertTrue(session_dir.exists())
+
+    def test_workspace_enumeration_and_commands_fail_closed_on_symlinks(self):
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_root = Path(external_dir)
+            external_workspaces = external_root / "workspaces"
+            external_workspace = external_workspaces / "outside"
+            self.write_legacy_session(
+                external_workspace, "outside-session", "tenant-a"
+            )
+            workspaces = self.store.storage_root / "workspaces"
+            os.symlink(external_workspaces, workspaces)
+
+            with self.assertRaisesRegex(ValueError, "symlinked workspaces root"):
+                enumerate_trace_stores(self.tempdir.name)
+            for action in ("export", "delete"):
+                argv = [
+                    "--trace-dir", self.tempdir.name, "tenant", action, "tenant-a",
+                ]
+                if action == "delete":
+                    argv.append("--confirm")
+                with patch("sys.stderr", new_callable=io.StringIO) as stderr:
+                    self.assertEqual(cmd_tenant(build_parser().parse_args(argv)), 1)
+                self.assertIn("discovery failed", stderr.getvalue())
+            self.assertTrue((external_workspace / "outside-session").exists())
+
+            workspaces.unlink()
+            workspaces.mkdir()
+            os.symlink(external_workspace, workspaces / "linked-child")
+            with self.assertRaisesRegex(ValueError, "symlinked workspace entry"):
+                enumerate_trace_stores(self.tempdir.name)
+            delete_args = build_parser().parse_args([
+                "--trace-dir", self.tempdir.name,
+                "tenant", "delete", "tenant-a", "--confirm",
+            ])
+            with patch("sys.stderr", new_callable=io.StringIO):
+                self.assertEqual(cmd_tenant(delete_args), 1)
+            self.assertTrue((external_workspace / "outside-session").exists())
+
+    def test_export_and_delete_cover_external_session_records(self):
+        self.create_session("external-a", "tenant-a")
+        self.create_session("external-b", "tenant-b")
+        approvals = self.store.base_dir / ".approvals"
+        approvals.mkdir()
+        approval_a = approvals / "request-a.json"
+        approval_b = approvals / "request-b.json"
+        approval_a.write_text(json.dumps({
+            "request_id": "request-a", "session_id": "external-a",
+            "tool_input": {"secret": "customer-a"},
+        }) + "\n")
+        approval_b.write_text(json.dumps({
+            "request_id": "request-b", "session_id": "external-b",
+            "tool_input": {"keep": True},
+        }) + "\n")
+        datasets = self.store.base_dir / "datasets"
+        datasets.mkdir()
+        dataset = datasets / "default.jsonl"
+        target_dataset = json.dumps({
+            "entry_id": "entry-a", "session_id": "external-a", "label": "private",
+        }) + "\n"
+        malformed = "not-json\n"
+        kept_dataset = json.dumps({
+            "entry_id": "entry-b", "session_id": "external-b", "label": "keep",
+        })
+        dataset.write_text(target_dataset + malformed + kept_dataset)
+        retention = self.store.base_dir / "retention.log"
+        target_retention = json.dumps({
+            "deleted_at": "2026-01-01T00:00:00Z", "session_id": "external-a",
+        }) + "\n"
+        kept_retention = json.dumps({
+            "deleted_at": "2026-01-02T00:00:00Z", "session_id": "external-b",
+        }) + "\n"
+        retention.write_text(target_retention + kept_retention)
+
+        payload = tenant_export_payload(self.store, "tenant-a")
+        external = payload["external_records"]
+        self.assertEqual(
+            external["schema"], "agent-strace-tenant-external-records/v1"
+        )
+        self.assertEqual(
+            {record["kind"] for record in external["records"]},
+            {"approval", "dataset", "retention"},
+        )
+        self.assertIn("customer-a", json.dumps(external))
+        self.assertNotIn("request-b", json.dumps(external))
+
+        delete_tenant_data(self.store, "tenant-a")
+
+        self.assertFalse(approval_a.exists())
+        self.assertTrue(approval_b.exists())
+        self.assertEqual(dataset.read_text(), malformed + kept_dataset)
+        self.assertEqual(retention.read_text(), kept_retention)
+
+    def test_external_record_symlinks_are_rejected_without_following(self):
+        self.create_session("external-link", "tenant-a")
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_root = Path(external_dir)
+            external_approval = external_root / "approval.json"
+            external_approval.write_text(json.dumps({
+                "request_id": "outside", "session_id": "external-link",
+                "tool_input": {"secret": "outside"},
+            }))
+            approvals = self.store.base_dir / ".approvals"
+            approvals.mkdir()
+            approval_link = approvals / "outside.json"
+            os.symlink(external_approval, approval_link)
+            with self.assertRaisesRegex(ValueError, "symlinked approval"):
+                tenant_export_payload(self.store, "tenant-a")
+            approval_link.unlink()
+
+            external_dataset = external_root / "dataset.jsonl"
+            external_dataset.write_text(json.dumps({
+                "entry_id": "outside", "session_id": "external-link",
+            }) + "\n")
+            datasets = self.store.base_dir / "datasets"
+            datasets.mkdir()
+            dataset_link = datasets / "outside.jsonl"
+            os.symlink(external_dataset, dataset_link)
+            with self.assertRaisesRegex(ValueError, "symlinked dataset"):
+                tenant_export_payload(self.store, "tenant-a")
+            dataset_link.unlink()
+
+            external_retention = external_root / "retention.log"
+            external_retention.write_text(json.dumps({
+                "deleted_at": "2026-01-01T00:00:00Z",
+                "session_id": "external-link",
+            }) + "\n")
+            os.symlink(external_retention, self.store.base_dir / "retention.log")
+            with self.assertRaisesRegex(ValueError, "symlinked.*retention"):
+                delete_tenant_data(self.store, "tenant-a")
+
+            self.assertIn("outside", external_approval.read_text())
+            self.assertIn("outside", external_dataset.read_text())
+            self.assertIn("external-link", external_retention.read_text())
+            self.assertTrue(self.store.session_exists("external-link"))
+
+    def test_delete_removes_only_tenant_data_and_writes_audit(self):
+        self.create_session("a", "tenant-a")
+        self.create_session("b", "tenant-b")
+        checkpoints = self.store.base_dir / "checkpoints"
+        checkpoints.mkdir()
+        (checkpoints / "a.md").write_text("private recovery context")
+        (checkpoints / "b.md").write_text("keep")
+        (self.store.base_dir / ".active-session.customer").write_text("a")
+        (self.store.base_dir / ".pending-calls.customer.json").write_text(
+            '{"tool":{"arguments":"private"}}'
+        )
+        orphan_pending = self.store.base_dir / ".pending-calls.a.json"
+        orphan_pending.write_text('{"tool":{"arguments":"stale"}}')
+        other_pending = self.store.base_dir / ".pending-calls.other-session.json"
+        other_pending.write_text('{"tool":{"arguments":"keep"}}')
+
+        result = delete_tenant_data(self.store, "tenant-a")
+
+        self.assertEqual(result.deleted_sessions, 1)
+        self.assertEqual(result.deleted_events, 1)
+        self.assertFalse(self.store._session_dir("a").exists())
+        self.assertFalse((checkpoints / "a.md").exists())
+        self.assertTrue(self.store._session_dir("b").exists())
+        self.assertTrue((checkpoints / "b.md").exists())
+        self.assertFalse((self.store.base_dir / ".active-session.customer").exists())
+        self.assertFalse((self.store.base_dir / ".pending-calls.customer.json").exists())
+        self.assertFalse(orphan_pending.exists())
+        self.assertTrue(other_pending.exists())
+        audits = [json.loads(line) for line in result.audit_path.read_text().splitlines()]
+        audit = audits[-1]
+        self.assertEqual([row["status"] for row in audits], ["pending", "completed"])
+        self.assertEqual(
+            audit["tenant_id_sha256"], hashlib.sha256(b"tenant-a").hexdigest()
+        )
+        self.assertNotIn("tenant-a", result.audit_path.read_text())
+        self.assertNotIn('"a"', result.audit_path.read_text())
+        self.assertEqual(len(audit["session_id_sha256"]), 1)
+        with self.assertRaisesRegex(ValueError, "erased"):
+            self.store.create_session(SessionMeta(session_id="a", tenant_id="tenant-a"))
+        with self.assertRaisesRegex(ValueError, "erased"):
+            self.store.append_event("a", _event("a", tenant_id="tenant-a"))
+
+    def test_delete_command_requires_explicit_confirmation(self):
+        self.create_session("a", "tenant-a")
+        args = build_parser().parse_args([
+            "--trace-dir", self.tempdir.name, "tenant", "delete", "tenant-a",
+        ])
+        with patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            self.assertEqual(cmd_tenant(args), 1)
+        self.assertIn("--confirm", stderr.getvalue())
+        self.assertTrue(self.store.session_exists("a"))
+
+    def test_checkpoint_parent_symlink_fails_without_touching_external_file(self):
+        self.create_session("checkpoint-link", "tenant-a")
+        with tempfile.TemporaryDirectory() as external_dir:
+            external = Path(external_dir) / "checkpoint-link.md"
+            external.write_text("outside-store-private-data")
+            os.symlink(external_dir, self.store.base_dir / "checkpoints")
+
+            with self.assertRaisesRegex(ValueError, "symlinked.*checkpoint"):
+                tenant_export_payload(self.store, "tenant-a")
+            with self.assertRaisesRegex(ValueError, "symlinked.*checkpoint"):
+                delete_tenant_data(self.store, "tenant-a")
+
+            self.assertEqual(external.read_text(), "outside-store-private-data")
+            self.assertTrue(self.store.session_exists("checkpoint-link"))
+            self.assertFalse(
+                (self.store.base_dir / "tenant-deletions.ndjson").exists()
+            )
+
+    def test_core_file_symlinks_are_rejected_without_following(self):
+        event_meta = self.create_session("event-link", "tenant-a")
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_events = Path(external_dir) / "events.ndjson"
+            external_events.write_text("outside-events")
+            events_path = self.store._session_dir(event_meta.session_id) / "events.ndjson"
+            events_path.unlink()
+            os.symlink(external_events, events_path)
+
+            with self.assertRaisesRegex(ValueError, "symlinked event stream"):
+                self.store.load_events(event_meta.session_id)
+            with self.assertRaisesRegex(ValueError, "symlinked.*(event|core)"):
+                delete_tenant_data(self.store, "tenant-a")
+            self.assertEqual(external_events.read_text(), "outside-events")
+            self.assertTrue(self.store._session_dir(event_meta.session_id).exists())
+
+        meta = SessionMeta(session_id="meta-link")
+        self.store.create_session(meta)
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_meta = Path(external_dir) / "meta.json"
+            external_meta.write_text(meta.to_json())
+            meta_path = self.store._session_dir(meta.session_id) / "meta.json"
+            meta_path.unlink()
+            os.symlink(external_meta, meta_path)
+            with self.assertRaisesRegex(ValueError, "symlinked session metadata"):
+                self.store.load_meta(meta.session_id)
+            self.assertEqual(external_meta.read_text(), meta.to_json())
+
+    def test_tenant_audit_symlinks_are_rejected_without_following(self):
+        meta = SessionMeta(session_id="tag-audit-link")
+        self.store.create_session(meta)
+        self.store.append_event(meta.session_id, _event(meta.session_id))
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_audit = Path(external_dir) / "audit.ndjson"
+            external_audit.write_text("outside-audit\n")
+            os.symlink(external_audit, self.store.base_dir / "tenant-audit.ndjson")
+            with self.assertRaisesRegex(ValueError, "symlinked tenant audit"):
+                self.store.tag_session(meta.session_id, "tenant-a")
+            self.assertEqual(external_audit.read_text(), "outside-audit\n")
+            self.assertEqual(self.store.load_meta(meta.session_id).tenant_id, "")
+        (self.store.base_dir / "tenant-audit.ndjson").unlink()
+
+        tagged = self.create_session("delete-audit-link", "tenant-b")
+        with tempfile.TemporaryDirectory() as external_dir:
+            external_audit = Path(external_dir) / "deletions.ndjson"
+            external_audit.write_text("outside-deletions\n")
+            os.symlink(
+                external_audit, self.store.base_dir / "tenant-deletions.ndjson"
+            )
+            with self.assertRaisesRegex(ValueError, "symlinked.*tenant-deletions"):
+                delete_tenant_data(self.store, "tenant-b")
+            self.assertEqual(external_audit.read_text(), "outside-deletions\n")
+            self.assertTrue(self.store._session_dir(tagged.session_id).exists())
+
+    def test_report_export_and_confirmed_delete_command_paths(self):
+        june = 1_781_481_600.0
+        self.create_session("a", "tenant-a", june)
+        parser = build_parser()
+
+        report_args = parser.parse_args([
+            "--trace-dir", self.tempdir.name,
+            "tenant", "report", "--month", "2026-06", "--format", "json",
+        ])
+        with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(cmd_tenant(report_args), 0)
+            report = json.loads(stdout.getvalue())
+        self.assertEqual(report["tenants"][0]["tenant_id"], "tenant-a")
+
+        export_args = parser.parse_args([
+            "--trace-dir", self.tempdir.name, "tenant", "export", "tenant-a",
+        ])
+        with patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(cmd_tenant(export_args), 0)
+            exported = json.loads(stdout.getvalue())
+        self.assertEqual(exported["session_count"], 1)
+
+        delete_args = parser.parse_args([
+            "--trace-dir", self.tempdir.name,
+            "tenant", "delete", "tenant-a", "--confirm",
+        ])
+        with patch("sys.stdout", new_callable=io.StringIO):
+            self.assertEqual(cmd_tenant(delete_args), 0)
+        self.assertFalse(self.store.session_exists("a"))
+
+    def test_flat_and_all_workspaces_are_reported_exported_and_deleted(self):
+        flat = TraceStore(self.tempdir.name, use_workspace_env=False, redact=False)
+        one = TraceStore(
+            self.tempdir.name, workspace_id="one", use_workspace_env=False, redact=False,
+        )
+        two = TraceStore(
+            self.tempdir.name, workspace_id="two", use_workspace_env=False, redact=False,
+        )
+        june = 1_781_481_600.0
+        for index, store in enumerate((flat, one, two)):
+            meta = SessionMeta(session_id=f"scoped-{index}", tenant_id="tenant-global", started_at=june)
+            store.create_session(meta)
+            store.append_event(meta.session_id, _event(meta.session_id, june))
+        sidecar = one._session_dir("scoped-1") / "annotations.jsonl"
+        sidecar.write_text('{"note":"included"}\n')
+        checkpoints = two.base_dir / "checkpoints"
+        checkpoints.mkdir()
+        (checkpoints / "scoped-2.md").write_text("checkpoint")
+        (flat.storage_root / ".active-session.workspace").write_text("scoped-1")
+        (flat.storage_root / ".pending-calls.workspace.json").write_text("private")
+
+        with patch.dict(os.environ, {"AGENT_STRACE_WORKSPACE": "one"}):
+            stores = enumerate_trace_stores(self.tempdir.name)
+            report = build_tenant_report(stores, "2026-06")
+            exported = tenant_export_payload(stores, "tenant-global")
+            deleted = delete_tenant_data(stores, "tenant-global")
+
+        self.assertEqual(report.total_sessions, 3)
+        self.assertEqual(exported["schema"], "agent-strace-tenant-export/v1")
+        self.assertEqual(exported["session_count"], 3)
+        self.assertTrue(any(row["sidecars"] for row in exported["sessions"]))
+        self.assertTrue(any(row["checkpoint"] for row in exported["sessions"]))
+        self.assertEqual(deleted.deleted_sessions, 3)
+        self.assertEqual(len(deleted.audit_paths), 3)
+        self.assertFalse((flat.storage_root / ".active-session.workspace").exists())
+        self.assertFalse((flat.storage_root / ".pending-calls.workspace.json").exists())
+
+    def test_legacy_flat_and_workspace_stores_are_reported_exported_and_deleted(self):
+        june = 1_781_481_600.0
+        legacy_id = "Legacy customer session ü" + "u" * 130
+        workspace_id = "Customer Workspace é" + "w" * 130
+        second_id = "Workspace legacy session " + "z" * 130
+        self.write_legacy_session(
+            self.store.base_dir, legacy_id, "tenant-legacy", june
+        )
+        workspace_base = Path(self.tempdir.name) / "workspaces" / workspace_id
+        self.write_legacy_session(
+            workspace_base,
+            second_id,
+            "tenant-legacy",
+            june,
+            workspace_id=workspace_id,
+        )
+
+        with self.assertRaises(ValueError):
+            TraceStore(
+                self.tempdir.name,
+                workspace_id=workspace_id,
+                use_workspace_env=False,
+                redact=False,
+            )
+        stores = enumerate_trace_stores(self.tempdir.name)
+        report = build_tenant_report(stores, "2026-06")
+        exported = tenant_export_payload(stores, "tenant-legacy")
+
+        self.assertEqual(report.total_sessions, 2)
+        self.assertEqual(exported["session_count"], 2)
+        self.assertEqual(
+            {row["session"]["session_id"] for row in exported["sessions"]},
+            {legacy_id, second_id},
+        )
+        self.assertIn(
+            workspace_id,
+            {row["scope"]["workspace_id"] for row in exported["sessions"]},
+        )
+
+        deleted = delete_tenant_data(stores, "tenant-legacy")
+        self.assertEqual(deleted.deleted_sessions, 2)
+        self.assertFalse((self.store.base_dir / legacy_id).exists())
+        self.assertFalse((workspace_base / second_id).exists())
+
+    def test_deletion_intent_journal_recovers_after_restart(self):
+        self.create_session("recover-delete", "tenant-a")
+        operation_id = "d" * 32
+        journal_dir = self.store.base_dir / ".tenant-journal"
+        journal_dir.mkdir()
+        journal = {
+            "operation": "delete_tenant", "operation_id": operation_id,
+            "tenant_id": "tenant-a", "workspace_id": "", "phase": "intent",
+            "sessions": [{"session_id": "recover-delete", "event_count": 1}],
+        }
+        (journal_dir / f"delete-{operation_id}.json").write_text(json.dumps(journal))
+
+        TraceStore(self.tempdir.name, redact=False)
+
+        self.assertFalse(self.store.session_exists("recover-delete"))
+        self.assertFalse((journal_dir / f"delete-{operation_id}.json").exists())
+        audits = [
+            json.loads(line)
+            for line in (self.store.base_dir / "tenant-deletions.ndjson").read_text().splitlines()
+        ]
+        self.assertEqual([record["status"] for record in audits], ["pending", "completed"])
+
+    def test_cross_tenant_subagent_link_is_rejected(self):
+        root = SessionMeta(session_id="tree-root", tenant_id="tenant-a")
+        self.store.create_session(root)
+        with self.assertRaisesRegex(ValueError, "cross-tenant"):
+            self.store.create_session(SessionMeta(
+                session_id="tree-child", tenant_id="tenant-b",
+                parent_session_id=root.session_id, depth=1,
+            ))
+        child = self.write_legacy_session(
+            self.store.base_dir,
+            "legacy-tree-child",
+            "tenant-b",
+            parent_session_id=root.session_id,
+        )
+        with self.assertRaisesRegex(ValueError, "cross-tenant"):
+            build_tree(self.store, root.session_id)
+
+    def test_workspace_hook_state_and_legacy_root_cleanup_do_not_collide(self):
+        raw_session = "shared-provider-session-123456"
+        local_session = raw_session[:16]
+        root = Path(self.tempdir.name)
+        for workspace, tenant in (("one", "tenant-one"), ("two", "tenant-two")):
+            with patch.dict(os.environ, {
+                "AGENT_TRACE_DIR": self.tempdir.name,
+                "AGENT_STRACE_WORKSPACE": workspace,
+                "AGENT_STRACE_TENANT_ID": tenant,
+            }):
+                handle_session_start({"session_id": raw_session, "source": "startup"})
+                handle_pre_tool({
+                    "session_id": raw_session,
+                    "tool_name": "Read",
+                    "tool_input": {"path": workspace},
+                })
+
+        one = TraceStore(
+            self.tempdir.name, workspace_id="one", use_workspace_env=False, redact=False
+        )
+        two = TraceStore(
+            self.tempdir.name, workspace_id="two", use_workspace_env=False, redact=False
+        )
+        state_digest = hashlib.sha256(f"claude\0{raw_session}".encode()).hexdigest()
+        local_hex = raw_session[:16].encode().hex()
+        state_suffix = f".v2.claude.{local_hex}.{state_digest}"
+        scoped_marker = f".active-session{state_suffix}"
+        pending = f".pending-calls{state_suffix}.json"
+        self.assertTrue((one.base_dir / scoped_marker).exists())
+        self.assertTrue((two.base_dir / scoped_marker).exists())
+        self.assertTrue((one.base_dir / pending).exists())
+        self.assertTrue((two.base_dir / pending).exists())
+
+        legacy_marker = root / ".active-session.legacy"
+        legacy_pending = root / ".pending-calls.legacy.json"
+        legacy_marker.write_text(local_session, encoding="utf-8")
+        legacy_pending.write_text("{}", encoding="utf-8")
+
+        delete_tenant_data(one, "tenant-one")
+        self.assertFalse((one.base_dir / scoped_marker).exists())
+        self.assertFalse((one.base_dir / pending).exists())
+        self.assertTrue((two.base_dir / scoped_marker).exists())
+        self.assertTrue((two.base_dir / pending).exists())
+        self.assertTrue(legacy_marker.exists())
+        self.assertTrue(legacy_pending.exists())
+
+        delete_tenant_data(two, "tenant-two")
+        self.assertFalse(legacy_marker.exists())
+        self.assertFalse(legacy_pending.exists())
+
+
+class TestTenantOTLPAndRemoteHooks(TenantTestCase):
+    def test_tenant_attribute_is_on_every_exported_span_and_resource(self):
+        meta = self.create_session("otlp", "tenant-a")
+        events = self.store.load_events(meta.session_id)
+        for converter in (session_to_otlp, session_to_otlp_genai):
+            payload = converter(meta, events)
+            resource = payload["resourceSpans"][0]
+            self.assertEqual(_attr_values(resource["resource"])["tenant_id"], "tenant-a")
+            for span in resource["scopeSpans"][0]["spans"]:
+                self.assertEqual(_attr_values(span)["tenant_id"], "tenant-a")
+
+    def test_remote_hook_posts_tenant_session_metadata(self):
+        with patch.dict(os.environ, {
+            "AGENT_TRACE_DIR": self.tempdir.name,
+            "AGENT_STRACE_ENDPOINT": "https://collector.invalid",
+            "AGENT_STRACE_TENANT_ID": "tenant-a",
+        }), patch(
+            "agent_trace.server.send_session_meta_to_endpoint", return_value=True
+        ) as send_meta, patch(
+            "agent_trace.server.send_event_to_endpoint", return_value=True
+        ):
+            handle_session_start({"session_id": "remote-session", "source": "startup"})
+
+        sent_meta = send_meta.call_args.args[0]
+        self.assertEqual(sent_meta.tenant_id, "tenant-a")
+        self.assertEqual(sent_meta.session_id, "remote-session"[:16])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds customer-level tenant tagging, cost attribution, reporting, subject-access export, and auditable erasure across flat and workspace trace stores.

## Highlights

- Adds `tenant_id` to session metadata/events with `watch --tenant-id` and `AGENT_STRACE_TENANT_ID` propagation.
- Adds exact tenant filters to `list` and `cost`, plus `tenant report`, `tenant export`, and confirmed `tenant delete` commands.
- Includes tenant attributes in OTLP output and protects collector writes from tenant reassignment.
- Makes export/erasure complete across session sidecars, checkpoints, approvals, eval datasets, retention records, and all workspace stores.
- Adds durable tag/deletion journals, hash-only audit/tombstone records, immutable tenant assignment, cross-tenant tree protection, and fail-closed path/symlink validation.
- Preserves containment-safe legacy session/workspace IDs while keeping new ingress strict.
- Documents GDPR workflows and the collector boundary: one authenticated collector/storage root is one organization. Managed hosted infrastructure remains tracked by #129.

## Version and release

Bumps `agent-strace` from `0.89.0` to `0.90.0`. After merge, the existing release workflow should create `v0.90.0`; the matching PyPI publish will be verified separately.

## Verification

- Ona full suite: 1,814 Python tests passed.
- VS Code extension: 3 tests passed.
- Independent adversarial review completed; all findings were fixed and re-reviewed.
- `git diff --check`, compilation, CLI smoke tests, and README 300-line policy passed.

Closes #216