### PR TITLE
feat: add organization usage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Full setup guide: [docs/setup.md](docs/setup.md)
 | [`agent-strace dashboard`](docs/commands.md#dashboard) | Multi-session overview |
 | [`agent-strace budget-report`](docs/commands.md#budget-report) | Weekly spend digest |
 | [`agent-strace team-report`](docs/commands.md#team-report) | Team spend by author, branch, or PR |
+| [`agent-strace org-report`](docs/org-report.md) | Monthly organization usage and estimated-cost digest |
 | [`agent-strace cost --breakdown provider`](docs/commands.md#cost) | Offline spend by provider and model |
 | [`agent-strace tenant report`](docs/tenancy.md) | Per-customer cost, export, and erasure workflows |
 | [`agent-strace cognitive-debt`](docs/commands.md#cognitive-debt) | Unreviewed agent-written code by session |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -551,6 +551,35 @@ Team cost attribution across recorded sessions. By default it groups spend by gi
 | `--export text|csv|json` | Output format. `csv` is intended for spreadsheets and finance workflows |
 | `--outlier-threshold N` | Flag sessions whose cost is above `N` times the report average; default is `2.0` |
 
+### `org-report`
+```
+agent-strace org-report [--month YYYY-MM] [--team SELECTOR]
+                         [--format text|json|html] [--anonymize]
+                         [--model MODEL] [-o FILE]
+                         [--endpoint URL] [--auth-key-file FILE]
+                         [--ca-file FILE] [--allow-insecure-http]
+```
+Build a monthly organization digest from the flat trace directory plus all
+workspace stores, or from one explicitly selected authenticated collector.
+Spend is an offline estimate for sessions with usable event data; the report
+shows its coverage and labels averages as per cost-estimated session. Task
+types and anomaly callouts are heuristics, not completion or efficiency
+measurements. See the [organization reporting guide](org-report.md) for the
+security boundary and interpretation details.
+
+| Flag | Description |
+|---|---|
+| `--month YYYY-MM` | Half-open UTC calendar month; default is the current UTC month |
+| `--team SELECTOR` | Exact team tag or workspace. Use `tag:NAME` or `workspace:NAME` to resolve a name collision |
+| `--format text\|json\|html` | Terminal text, strict versioned JSON, or self-contained static HTML |
+| `--anonymize` | Replace team/workspace and attributed identity labels with deterministic aliases local to this report |
+| `--model MODEL` | Bundled offline pricing model; default is `sonnet` |
+| `--output FILE`, `-o FILE` | Atomically write the complete report; symlinked destinations are refused |
+| `--endpoint URL` | Explicit collector base URL. This command never infers it from `AGENT_STRACE_ENDPOINT` |
+| `--auth-key-file FILE` | Read the collector bearer key from a file; otherwise use `AGENT_STRACE_AUTH_KEY` |
+| `--ca-file FILE` | Trust a custom CA bundle for the HTTPS collector |
+| `--allow-insecure-http` | Opt in to plain HTTP for a non-loopback collector |
+
 ### `cognitive-debt`
 ```
 agent-strace cognitive-debt [--session ID] [--since DATE] [--until DATE]

--- a/docs/org-report.md
+++ b/docs/org-report.md
@@ -1,0 +1,102 @@
+# Organization reporting
+
+`agent-strace org-report` creates a monthly engineering digest without sending
+trace content to a pricing or analytics service. It reports session volume,
+covered-session estimated spend, attributed-identity coverage, team and
+heuristic task-type breakdowns, and structural anomaly callouts.
+
+## Local shared directory
+
+```bash
+agent-strace --trace-dir /srv/agent-traces org-report --month 2026-08
+agent-strace --trace-dir /srv/agent-traces org-report \
+  --month 2026-08 --team workspace:payments --format html -o august.html
+```
+
+The local command reads the flat store and every workspace under the same
+trace root. Identical session IDs in different workspaces remain separate
+sessions. This filesystem root is the organization boundary. The command does
+not read S3 or another object store directly; mount or synchronize that data
+into a trace directory, or use the collector API.
+
+## Authenticated collector
+
+```bash
+export AGENT_STRACE_AUTH_KEY='ast_...'
+agent-strace org-report --month 2026-08 \
+  --endpoint https://collector.example.com \
+  --ca-file /etc/agent-strace/private-ca.pem \
+  --format json -o august.json
+```
+
+`--endpoint` is required for remote collector input. The command never implicitly uses
+`AGENT_STRACE_ENDPOINT`, so a reporting job cannot silently switch from its
+intended local source. Put the bearer key in `AGENT_STRACE_AUTH_KEY` or a
+size-bounded `--auth-key-file`; do not place it in command history.
+
+One collector instance and key is the organization boundary. Tenant, team,
+and workspace tags are grouping metadata, not authorization. The command
+probes the session-list endpoint without credentials and refuses to report if
+the collector does not enforce authentication.
+
+HTTPS is the default. Plain HTTP is accepted automatically only for
+`localhost` and loopback IP addresses; non-loopback HTTP requires
+`--allow-insecure-http`. Collector URLs cannot contain user information,
+queries, or fragments. Redirects and ambient HTTP proxies are disabled so the
+bearer key is sent only to the explicitly named collector. Responses and JSON
+nesting are bounded, and any malformed, truncated, oversized, mixed-session,
+or mixed-tenant selected stream fails the complete report.
+
+## Scope and interpretation
+
+The month is a half-open UTC range: `2026-08` includes timestamps from
+`2026-08-01T00:00:00Z` up to, but not including, `2026-09-01T00:00:00Z`.
+Metadata is filtered by month and team before remote event streams are fetched.
+
+Team selection is exact:
+
+- `--team tag:platform` selects the persisted team tag.
+- `--team workspace:platform` selects the workspace.
+- `--team platform` works when the name exists in only one domain and fails as
+  ambiguous when it exists as both a team tag and a workspace.
+
+Cost values are offline token-size estimates using the selected bundled model
+and the pricing snapshot date recorded in the report. Unknown or invalid costs
+are excluded from spend and average calculations, and cost coverage shows the
+denominator. They are not provider invoices or actual spend.
+
+Attributed identities come only from persisted actor, engineer, user, git
+author, OS-user, and hostname fields. The reporting machine's git config is
+never consulted. Coverage and confidence counts show how much identity data
+was available; they are not roster coverage.
+
+Task types are keyword heuristics. Anomaly callouts compare group averages only
+when the subject and at least three other eligible peers meet the minimum
+session and cost-coverage floors. Lint signals are structural heuristics. The
+report does not infer task completion, productivity, efficiency, or causes.
+
+Remote collector reports first read session metadata and then one event stream per
+selected session. The input can change between these N+1 requests, so the
+result is not a transactionally consistent snapshot. Local shared directories
+can likewise change while read. Every output records this limitation.
+
+## Output and privacy
+
+```bash
+agent-strace org-report --month 2026-08 --format text
+agent-strace org-report --month 2026-08 --format json --anonymize -o report.json
+agent-strace org-report --month 2026-08 --format html --anonymize -o report.html
+```
+
+JSON uses the `agent-strace-org-report/v1` schema and rejects non-finite
+numbers. HTML is self-contained, contains no external assets, and escapes all
+labels. File output is written atomically with private permissions and refuses
+symlinked output paths.
+
+Aggregate formats have no standalone session ID, filesystem path, branch,
+tenant, hostname, or raw-event fields. Without `--anonymize`, team labels and
+anomaly identity labels can appear, including a persisted `user@hostname`
+identity. Use `--anonymize` before sharing outside the organization. With it,
+complete team/workspace and identity labels become sorted report-local aliases;
+aliases are neither stable cross-report identifiers nor hashes of the original
+labels.

--- a/docs/security.md
+++ b/docs/security.md
@@ -97,6 +97,24 @@ rules:
     replacement: "<internal-ip>"
 ```
 
+### Organization-report anonymization
+
+`agent-strace org-report --anonymize` replaces complete persisted identity
+labels (including `user@hostname` composites) and team/workspace labels with
+deterministic aliases such as `Identity-001` and `Team-001`. Aliases are sorted
+and local to that report; they are not unsalted hashes and never use the
+collector authentication key. Aggregate output has no standalone session ID,
+path, branch, hostname, tenant, or raw-event fields. The default,
+non-anonymized report may show team labels and an attributed identity such as
+`user@hostname` when it appears in an anomaly callout; use `--anonymize` before
+sharing a report outside the organization.
+
+For remote collector input, one authenticated collector instance and key is the
+organization boundary. Team, workspace, and tenant metadata are reporting
+labels, not authorization controls. Use separate authenticated collectors for
+organizations that must be isolated. Static HTML escapes all labels and has no
+external assets.
+
 ---
 
 ## Policy files

--- a/docs/server.md
+++ b/docs/server.md
@@ -109,6 +109,26 @@ one another. Tenant filters are customer-level scoping inside that boundary,
 not an authorization mechanism. Managed multi-organization hosting is tracked
 separately in [issue #129](https://github.com/Siddhant-K-code/agent-trace/issues/129).
 
+### Organization reports from a collector
+
+`agent-strace org-report --endpoint https://collector.example.com` reads the
+existing `GET /sessions` and `GET /sessions/<id>/events` endpoints. It refuses
+collectors that expose the session list without authentication. Supply the key
+through `AGENT_STRACE_AUTH_KEY` or `--auth-key-file`; there is no literal key
+flag, and `AGENT_STRACE_ENDPOINT` is deliberately ignored for this reporting
+command.
+
+The read client requires HTTPS except for loopback HTTP, rejects redirects and
+credential-bearing URLs, disables ambient HTTP proxies, and applies bounded
+response, session, event, line, nesting, and total-byte limits. `--ca-file`
+adds a private CA. `--allow-insecure-http` is an explicit opt-in for a
+non-loopback test collector and should not be used on untrusted networks.
+
+Collector reports use one metadata request followed by one event request for
+each session selected after the month/team metadata filters. These N+1 reads
+are bounded but are not a transactionally consistent snapshot; the generated
+report records that limitation. See [Organization reporting](org-report.md).
+
 **Client side** — set `AGENT_STRACE_AUTH_KEY` alongside `AGENT_STRACE_ENDPOINT` and all outbound requests include the header automatically:
 
 ```bash

--- a/src/agent_trace/__init__.py
+++ b/src/agent_trace/__init__.py
@@ -1,3 +1,3 @@
 """agent-trace: strace for AI agents."""
 
-__version__ = "0.90.0"
+__version__ = "0.91.0"

--- a/src/agent_trace/cli.py
+++ b/src/agent_trace/cli.py
@@ -42,7 +42,7 @@ from .optimize import cmd_optimize
 from .freshness import cmd_freshness
 from .standup import cmd_standup
 from .audit import cmd_audit, verify_chain
-from .cost import cmd_cost
+from .cost import PRICING, cmd_cost
 from .cognitive_debt import cmd_cognitive_debt
 from .context_score import cmd_context_score
 from .curve import cmd_curve
@@ -69,6 +69,7 @@ from .anonymize import cmd_anonymize_export
 from .integrations import detect_and_instrument, _INTEGRATIONS
 from .budget_report import cmd_budget_report
 from .team_report import cmd_team_report
+from .org_report import cmd_org_report
 from .tenancy import cmd_tenant
 from .compare import cmd_compare
 from .compaction import cmd_compaction
@@ -1925,6 +1926,51 @@ def build_parser() -> argparse.ArgumentParser:
     p_team_report.add_argument("--outlier-threshold", type=float, default=2.0,
                                help="flag sessions above N times average cost (default: 2.0)")
 
+    # organization-wide estimated usage/cost digest
+    p_org_report = sub.add_parser(
+        "org-report", help="organization-wide estimated agent usage and cost digest"
+    )
+    p_org_report.add_argument(
+        "--month", metavar="YYYY-MM",
+        help="UTC report month (default: current month)",
+    )
+    p_org_report.add_argument(
+        "--team", metavar="SELECTOR",
+        help="team tag or workspace; use tag:NAME/workspace:NAME if ambiguous",
+    )
+    p_org_report.add_argument(
+        "--format", choices=["text", "json", "html"], default="text",
+        help="output format (default: text)",
+    )
+    p_org_report.add_argument(
+        "--anonymize", action="store_true",
+        help="replace team and attributed identity labels with report-local aliases",
+    )
+    p_org_report.add_argument(
+        "--output", "-o", metavar="FILE",
+        help="atomically write the complete report to a file",
+    )
+    p_org_report.add_argument(
+        "--endpoint", metavar="URL",
+        help="explicit authenticated collector instance to read instead of --trace-dir",
+    )
+    p_org_report.add_argument(
+        "--auth-key-file", metavar="FILE",
+        help="read collector bearer key from FILE (or use AGENT_STRACE_AUTH_KEY)",
+    )
+    p_org_report.add_argument(
+        "--ca-file", metavar="FILE",
+        help="custom CA bundle for an HTTPS collector",
+    )
+    p_org_report.add_argument(
+        "--allow-insecure-http", action="store_true",
+        help="allow plain HTTP to a non-loopback collector",
+    )
+    p_org_report.add_argument(
+        "--model", default="sonnet", choices=sorted(PRICING),
+        help="pricing model for offline estimates (default: sonnet)",
+    )
+
     # lint
     p_lint = sub.add_parser("lint", help="analyse a session for bad behaviour patterns")
     p_lint.add_argument("session_id", nargs="?",
@@ -2281,6 +2327,7 @@ def main() -> None:
         "auto": cmd_auto,
         "budget-report": cmd_budget_report,
         "team-report": cmd_team_report,
+        "org-report": cmd_org_report,
         "compare": cmd_compare,
         "freeze": cmd_freeze,
         "regression": cmd_regression,

--- a/src/agent_trace/collector_client.py
+++ b/src/agent_trace/collector_client.py
@@ -1,0 +1,478 @@
+"""Bounded, authenticated read client for an agent-strace collector.
+
+The client deliberately exposes only the existing collector read API.  It
+does not infer an organization from tags: one authenticated collector
+instance and key are the organization boundary for a remote report.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import http.client
+import json
+import math
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .models import SessionMeta, TraceEvent
+from .store import validate_stored_id
+
+
+MAX_METADATA_BYTES = 16 * 1024 * 1024
+MAX_SESSION_EVENT_BYTES = 32 * 1024 * 1024
+MAX_EVENT_LINE_BYTES = 2 * 1024 * 1024
+MAX_TOTAL_BYTES = 256 * 1024 * 1024
+MAX_SESSIONS = 10_000
+MAX_EVENTS_PER_SESSION = 500_000
+MAX_JSON_DEPTH = 64
+
+_META_STRING_FIELDS = {
+    "agent_name", "command", "parent_session_id", "parent_event_id", "team",
+    "workspace_id", "trace_id", "parent_span_id", "trace_flags", "tenant_id",
+}
+_META_COUNT_FIELDS = {
+    "tool_calls", "llm_requests", "errors", "total_tokens", "depth",
+}
+_EVENT_STRING_FIELDS = {
+    "event_id", "session_id", "parent_id", "prev_hash", "tenant_id",
+}
+
+
+class CollectorClientError(RuntimeError):
+    """Raised when a collector cannot provide one complete trusted snapshot."""
+
+
+class CollectorAuthenticationError(CollectorClientError):
+    """Raised when collector authentication is absent or rejected."""
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number {value!r} is not allowed")
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _strict_json_loads(text: str):  # noqa: ANN201
+    try:
+        value = json.loads(
+            text,
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_unique_json_object,
+        )
+    except RecursionError as exc:
+        raise ValueError("collector JSON nesting exceeds the limit") from exc
+    stack = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        if depth > MAX_JSON_DEPTH:
+            raise ValueError("collector JSON nesting exceeds the limit")
+        if isinstance(item, dict):
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+    return value
+
+
+def _finite_number(value, field: str, *, optional: bool = False) -> float | None:  # noqa: ANN001
+    if optional and value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"{field} must be a finite non-negative number") from exc
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"{field} must be a finite non-negative number")
+    return number
+
+
+def _validate_meta_item(item: object) -> SessionMeta:
+    if not isinstance(item, dict):
+        raise ValueError("session metadata must be an object")
+    if not isinstance(item.get("session_id"), str) or not item["session_id"]:
+        raise ValueError("session_id must be a non-empty string")
+    if "started_at" not in item:
+        raise ValueError("started_at is required")
+    _finite_number(item["started_at"], "started_at")
+    if "ended_at" in item:
+        _finite_number(item["ended_at"], "ended_at", optional=True)
+    if "total_duration_ms" in item:
+        _finite_number(item["total_duration_ms"], "total_duration_ms")
+    for field in _META_STRING_FIELDS:
+        if field in item and not isinstance(item[field], str):
+            raise ValueError(f"{field} must be a string")
+    for field in _META_COUNT_FIELDS:
+        value = item.get(field, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{field} must be a non-negative integer")
+    if "redacted" in item and not isinstance(item["redacted"], bool):
+        raise ValueError("redacted must be a boolean")
+    if "attribution" in item and not isinstance(item["attribution"], dict):
+        raise ValueError("attribution must be an object")
+    if item.get("parent_session_id"):
+        validate_stored_id(item["parent_session_id"], "collector parent session ID")
+    # Serializing the already strictly-decoded object avoids the permissive
+    # json.loads path in the compatibility model constructor.
+    meta = SessionMeta.from_json(json.dumps(item, allow_nan=False))
+    meta.session_id = validate_stored_id(meta.session_id, "collector session ID")
+    return meta
+
+
+def _validate_event_item(item: object, meta: SessionMeta) -> TraceEvent:
+    if not isinstance(item, dict):
+        raise ValueError("event must be an object")
+    if not isinstance(item.get("event_type"), str):
+        raise ValueError("event_type must be a string")
+    if "timestamp" not in item:
+        raise ValueError("timestamp is required")
+    _finite_number(item["timestamp"], "timestamp")
+    for field in _EVENT_STRING_FIELDS:
+        if field not in item and field in {"event_id", "session_id"}:
+            raise ValueError(f"{field} is required")
+        if field in item and not isinstance(item[field], str):
+            raise ValueError(f"{field} must be a string")
+    if not item.get("event_id") or not item.get("session_id"):
+        raise ValueError("event_id and session_id must be non-empty")
+    validate_stored_id(item["session_id"], "collector event session ID")
+    if "duration_ms" in item:
+        _finite_number(item["duration_ms"], "duration_ms", optional=True)
+    if "data" in item and not isinstance(item["data"], dict):
+        raise ValueError("event data must be an object")
+    if "redacted" in item and not isinstance(item["redacted"], bool):
+        raise ValueError("event redacted must be a boolean")
+    event = TraceEvent.from_json(json.dumps(item, allow_nan=False))
+    if event.session_id != meta.session_id:
+        raise ValueError("event session ID does not match its metadata")
+    return event
+
+
+def _is_loopback(hostname: str) -> bool:
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_collector_endpoint(
+    endpoint: str, *, allow_insecure_http: bool = False,
+) -> str:
+    """Validate and normalize an explicit collector base URL."""
+    value = str(endpoint)
+    if not value or value != value.strip() or any(ord(char) < 32 for char in value):
+        raise ValueError("collector endpoint must be a non-empty URL without controls")
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("collector endpoint must use https or http")
+    if not parsed.hostname:
+        raise ValueError("collector endpoint must include a hostname")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("collector endpoint cannot include user information")
+    # urlsplit cannot distinguish an absent delimiter from a present empty
+    # query/fragment. Reject the delimiters themselves before credentials are
+    # ever attached to a derived URL.
+    if "?" in value or "#" in value or parsed.query or parsed.fragment:
+        raise ValueError("collector endpoint cannot include a query or fragment")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("collector endpoint has an invalid port") from exc
+    if (
+        parsed.scheme == "http"
+        and not allow_insecure_http
+        and not _is_loopback(parsed.hostname)
+    ):
+        raise ValueError(
+            "plain HTTP is allowed only for loopback collectors; "
+            "use --allow-insecure-http to opt in"
+        )
+    return value.rstrip("/")
+
+
+class CollectorClient:
+    """Read one complete, size-bounded snapshot from a collector instance."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        auth_key: str,
+        *,
+        allow_insecure_http: bool = False,
+        ca_file: str = "",
+        timeout: float = 15.0,
+        max_metadata_bytes: int = MAX_METADATA_BYTES,
+        max_session_event_bytes: int = MAX_SESSION_EVENT_BYTES,
+        max_event_line_bytes: int = MAX_EVENT_LINE_BYTES,
+        max_total_bytes: int = MAX_TOTAL_BYTES,
+        max_sessions: int = MAX_SESSIONS,
+        max_events_per_session: int = MAX_EVENTS_PER_SESSION,
+        opener=None,
+    ):
+        self.endpoint = validate_collector_endpoint(
+            endpoint, allow_insecure_http=allow_insecure_http
+        )
+        key = str(auth_key).strip()
+        if not key or any(char in key for char in "\r\n"):
+            raise CollectorAuthenticationError(
+                "remote collector org-report requires a single-line auth key"
+            )
+        self._auth_key = key
+        self.timeout = float(timeout)
+        self.max_metadata_bytes = int(max_metadata_bytes)
+        self.max_session_event_bytes = int(max_session_event_bytes)
+        self.max_event_line_bytes = int(max_event_line_bytes)
+        self.max_total_bytes = int(max_total_bytes)
+        self.max_sessions = int(max_sessions)
+        self.max_events_per_session = int(max_events_per_session)
+        self._bytes_read = 0
+        if (
+            not math.isfinite(self.timeout)
+            or self.timeout <= 0
+            or min(
+                self.max_metadata_bytes,
+                self.max_session_event_bytes,
+                self.max_event_line_bytes,
+                self.max_total_bytes,
+                self.max_sessions,
+                self.max_events_per_session,
+            ) <= 0
+        ):
+            raise ValueError("collector timeouts and limits must be positive")
+
+        if opener is not None:
+            self._opener = opener
+        else:
+            # Disable ambient proxy configuration. Otherwise even the explicit
+            # loopback HTTP exception can send the bearer token to http_proxy.
+            handlers: list[urllib.request.BaseHandler] = [
+                urllib.request.ProxyHandler({}),
+                _NoRedirect(),
+            ]
+            if urllib.parse.urlsplit(self.endpoint).scheme == "https":
+                try:
+                    context = ssl.create_default_context(cafile=ca_file or None)
+                except (OSError, ssl.SSLError) as exc:
+                    raise CollectorClientError(
+                        f"could not load collector CA file: {exc}"
+                    ) from exc
+                handlers.append(urllib.request.HTTPSHandler(context=context))
+            self._opener = urllib.request.build_opener(*handlers)
+
+    @property
+    def bytes_read(self) -> int:
+        return self._bytes_read
+
+    def _url(self, path: str) -> str:
+        return self.endpoint + path
+
+    def _read_bounded(self, response, limit: int) -> bytes:  # noqa: ANN001
+        header = response.headers.get("Content-Length", "")
+        declared: int | None = None
+        if header:
+            try:
+                declared = int(header)
+            except ValueError as exc:
+                raise CollectorClientError(
+                    "collector returned an invalid Content-Length"
+                ) from exc
+            if declared < 0 or declared > limit:
+                raise CollectorClientError("collector response exceeds the size limit")
+            if self._bytes_read + declared > self.max_total_bytes:
+                raise CollectorClientError("collector snapshot exceeds the total size limit")
+        remaining = self.max_total_bytes - self._bytes_read
+        allowed = min(limit, remaining)
+        if allowed < 0:
+            raise CollectorClientError("collector snapshot exceeds the total size limit")
+        try:
+            body = response.read(allowed + 1)
+        except (http.client.HTTPException, OSError) as exc:
+            raise CollectorClientError("collector response body was truncated") from exc
+        if len(body) > allowed:
+            raise CollectorClientError("collector response exceeds the size limit")
+        if declared is not None and len(body) != declared:
+            raise CollectorClientError("collector response body was truncated")
+        self._bytes_read += len(body)
+        return body
+
+    def _get(self, path: str, *, authenticated: bool, limit: int) -> bytes:
+        headers = {"Accept": "application/json, application/x-ndjson"}
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self._auth_key}"
+        request = urllib.request.Request(
+            self._url(path), headers=headers, method="GET"
+        )
+        try:
+            with self._opener.open(request, timeout=self.timeout) as response:
+                status = getattr(response, "status", None)
+                if status is None:
+                    status = response.getcode()
+                if status != 200:
+                    raise CollectorClientError(
+                        f"collector returned unexpected HTTP status {status}"
+                    )
+                return self._read_bounded(response, limit)
+        except urllib.error.HTTPError as exc:
+            if exc.code in {401, 403}:
+                raise CollectorAuthenticationError(
+                    "collector authentication was required or rejected"
+                ) from exc
+            if 300 <= exc.code < 400:
+                raise CollectorClientError("collector redirects are not allowed") from exc
+            raise CollectorClientError(
+                f"collector request failed with HTTP {exc.code}"
+            ) from exc
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            http.client.HTTPException,
+            OSError,
+        ) as exc:
+            raise CollectorClientError(f"collector request failed: {exc}") from exc
+
+    def list_sessions(self) -> list[SessionMeta]:
+        """Authenticate and return all metadata visible to this collector key."""
+        # Refuse an instance that exposes session metadata without the key.  A
+        # successful report must be an authenticated snapshot, not merely a
+        # request that happened to include an ignored Authorization header.
+        try:
+            self._get("/sessions", authenticated=False, limit=self.max_metadata_bytes)
+        except CollectorAuthenticationError:
+            pass
+        else:
+            raise CollectorAuthenticationError(
+                "collector does not enforce authentication for session reads"
+            )
+
+        raw = self._get(
+            "/sessions", authenticated=True, limit=self.max_metadata_bytes
+        )
+        try:
+            payload = _strict_json_loads(raw.decode("utf-8", errors="strict"))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise CollectorClientError("collector returned malformed session metadata") from exc
+        if not isinstance(payload, list):
+            raise CollectorClientError("collector session response must be a JSON array")
+        if len(payload) > self.max_sessions:
+            raise CollectorClientError("collector session count exceeds the limit")
+
+        sessions: list[SessionMeta] = []
+        seen: set[str] = set()
+        for item in payload:
+            try:
+                meta = _validate_meta_item(item)
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise CollectorClientError("collector returned invalid session metadata") from exc
+            if meta.session_id in seen:
+                raise CollectorClientError("collector returned a duplicate session ID")
+            seen.add(meta.session_id)
+            sessions.append(meta)
+        return sorted(
+            sessions,
+            key=lambda meta: (meta.started_at, meta.session_id),
+            reverse=True,
+        )
+
+    def load_events(self, meta: SessionMeta) -> list[TraceEvent]:
+        """Load and strictly validate one session's NDJSON event stream."""
+        encoded_id = urllib.parse.quote(meta.session_id, safe="")
+        raw = self._get(
+            f"/sessions/{encoded_id}/events",
+            authenticated=True,
+            limit=self.max_session_event_bytes,
+        )
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise CollectorClientError("collector returned non-UTF-8 event data") from exc
+        events: list[TraceEvent] = []
+        stream_tenant = ""
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            if len(line.encode("utf-8")) > self.max_event_line_bytes:
+                raise CollectorClientError("collector event line exceeds the size limit")
+            if len(events) >= self.max_events_per_session:
+                raise CollectorClientError("collector event count exceeds the limit")
+            try:
+                event = _validate_event_item(_strict_json_loads(line), meta)
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise CollectorClientError("collector returned malformed event data") from exc
+            if meta.tenant_id and event.tenant_id and event.tenant_id != meta.tenant_id:
+                raise CollectorClientError(
+                    "collector event tenant does not match its metadata"
+                )
+            if meta.tenant_id:
+                event.tenant_id = meta.tenant_id
+            elif event.tenant_id:
+                if stream_tenant and event.tenant_id != stream_tenant:
+                    raise CollectorClientError(
+                        "collector event stream contains mixed tenants"
+                    )
+                stream_tenant = event.tenant_id
+            events.append(event)
+        return events
+
+
+class CollectorTraceStore:
+    """Read-only TraceStore-compatible view backed by a CollectorClient."""
+
+    def __init__(self, client: CollectorClient, sessions: list[SessionMeta]):
+        self.client = client
+        self.workspace_id = ""
+        self._metas = {meta.session_id: meta for meta in sessions}
+        self._events: dict[str, list[TraceEvent]] = {}
+
+    @classmethod
+    def load(cls, client: CollectorClient) -> "CollectorTraceStore":
+        return cls(client, client.list_sessions())
+
+    def list_sessions_strict(
+        self,
+        tenant_id: str | None = None,
+        *,
+        validate_events: bool = True,
+    ) -> list[SessionMeta]:
+        # Metadata is already strictly validated. Event loading remains lazy so
+        # org-report can apply its UTC month and team filters first.
+        del validate_events
+        metas = list(self._metas.values())
+        if tenant_id is not None:
+            metas = [meta for meta in metas if meta.tenant_id == tenant_id]
+        return sorted(
+            metas,
+            key=lambda meta: (meta.started_at, meta.session_id),
+            reverse=True,
+        )
+
+    def load_meta(self, session_id: str) -> SessionMeta:
+        try:
+            return self._metas[session_id]
+        except KeyError as exc:
+            raise FileNotFoundError(f"collector session not found: {session_id}") from exc
+
+    def load_events(self, session_id: str) -> list[TraceEvent]:
+        if session_id not in self._events:
+            self._events[session_id] = self.client.load_events(
+                self.load_meta(session_id)
+            )
+        return list(self._events[session_id])
+
+    def release_events(self, session_id: str) -> None:
+        """Release parsed event objects after all per-session analyses finish."""
+        self._events.pop(session_id, None)

--- a/src/agent_trace/curve.py
+++ b/src/agent_trace/curve.py
@@ -60,13 +60,17 @@ SWEET_SPOTS: dict[str, float] = {
 }
 
 
-def _classify_session(agent_name: str, command: str) -> str:
+def classify_session(agent_name: str, command: str) -> str:
     """Return the task type label for a session based on its name/command."""
     text = (agent_name + " " + command).lower()
     for task_type, keywords in TASK_CLASSIFIERS:
         if any(kw in text for kw in keywords):
             return task_type
     return DEFAULT_TASK_TYPE
+
+
+# Backward-compatible alias for callers that imported the original helper.
+_classify_session = classify_session
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +145,7 @@ def analyse_curve(
 
     for meta in all_metas:
         sid = meta.session_id
-        task_type = _classify_session(meta.agent_name, meta.command)
+        task_type = classify_session(meta.agent_name, meta.command)
 
         try:
             cost = estimate_cost(store, sid).total_cost

--- a/src/agent_trace/org_report.py
+++ b/src/agent_trace/org_report.py
@@ -1,0 +1,890 @@
+"""Organization-wide estimated agent usage and cost reporting."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import os
+import re
+import statistics
+import sys
+import tempfile
+import unicodedata
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .collector_client import (
+    CollectorAuthenticationError,
+    CollectorClient,
+    CollectorClientError,
+    CollectorTraceStore,
+    MAX_JSON_DEPTH,
+)
+from .cost import DEFAULT_MODEL, PRICING, PRICING_SNAPSHOT_DATE, estimate_cost
+from .curve import classify_session
+from .lint import lint_session
+from .models import EventType
+from .store import validate_stored_id
+from .team_report import session_engineer_attribution
+from .tenancy import enumerate_trace_stores
+
+
+MIN_ANOMALY_SESSIONS = 3
+MIN_ANOMALY_COVERAGE = 0.80
+MIN_ANOMALY_PEERS = 3
+TEAM_HIGH_COST_RATIO = 1.5
+ENGINEER_HIGH_COST_RATIO = 2.0
+MAX_AUTH_KEY_FILE_BYTES = 16 * 1024
+MAX_REPORT_LABEL_CHARS = 200
+
+
+@dataclass(frozen=True)
+class TeamBreakdown:
+    team: str
+    sessions: int
+    cost_estimated_sessions: int
+    cost_estimate_coverage_percent: float
+    estimated_spend_usd: float
+    avg_estimated_cost_usd: float
+    active_attributed_identities: int
+    lint_findings: int
+    sessions_with_lint_signals: int
+    lint_signals: dict[str, int]
+
+
+@dataclass(frozen=True)
+class TaskTypeBreakdown:
+    task_type: str
+    sessions: int
+    cost_estimated_sessions: int
+    cost_estimate_coverage_percent: float
+    estimated_spend_usd: float
+    avg_estimated_cost_usd: float
+
+
+@dataclass(frozen=True)
+class OrgAnomaly:
+    kind: str
+    subject: str
+    sessions: int
+    cost_estimate_coverage_percent: float
+    ratio_to_peer_median: float
+    eligible_peers: int
+    callout: str
+    details: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OrgReport:
+    generated_at: str
+    month: str
+    source_mode: str
+    organization_boundary: str
+    pricing_model: str
+    pricing_snapshot_date: str
+    cost_estimation_method: str
+    team_filter: str
+    anonymized: bool
+    session_count: int
+    cost_estimated_sessions: int
+    cost_estimate_coverage_percent: float
+    total_estimated_spend_usd: float
+    avg_estimated_cost_usd: float
+    median_estimated_cost_usd: float
+    active_attributed_identities: int
+    identity_attributed_sessions: int
+    identity_coverage_percent: float
+    identity_confidence: dict[str, int]
+    teams: tuple[TeamBreakdown, ...]
+    task_types: tuple[TaskTypeBreakdown, ...]
+    anomalies: tuple[OrgAnomaly, ...]
+    snapshot_limitation: str
+
+
+@dataclass(frozen=True)
+class _SessionMetric:
+    team: str
+    engineer: str
+    identity_confidence: str
+    task_type: str
+    cost: float | None
+    lint_rules: tuple[str, ...]
+
+
+class _SessionSnapshotStore:
+    """Expose one already-loaded session snapshot to existing analyzers."""
+
+    def __init__(self, meta, events: list):  # noqa: ANN001
+        self._meta = meta
+        self._events = tuple(events)
+
+    def load_meta(self, session_id: str):  # noqa: ANN201
+        if session_id != self._meta.session_id:
+            raise FileNotFoundError(f"session not found in report snapshot: {session_id}")
+        return self._meta
+
+    def load_events(self, session_id: str) -> list:
+        self.load_meta(session_id)
+        return list(self._events)
+
+
+def month_bounds_utc(month: str) -> tuple[float, float]:
+    """Return a half-open UTC timestamp range for ``YYYY-MM``."""
+    if not re.fullmatch(r"[0-9]{4}-(?:0[1-9]|1[0-2])", str(month)):
+        raise ValueError("month must use YYYY-MM format")
+    try:
+        start = datetime.strptime(month, "%Y-%m").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError("month must use YYYY-MM format") from exc
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start.timestamp(), end.timestamp()
+
+
+def _clean_label(value: str, fallback: str) -> str:
+    raw = str(value)
+    if len(raw) > MAX_REPORT_LABEL_CHARS:
+        raise ValueError(
+            f"report label cannot exceed {MAX_REPORT_LABEL_CHARS} characters"
+        )
+    if any(
+        unicodedata.category(char) in {"Cc", "Cf", "Zl", "Zp"}
+        for char in raw
+    ):
+        raise ValueError("report label cannot contain control or format characters")
+    cleaned = raw.strip()
+    if raw != cleaned:
+        raise ValueError("report label cannot have leading or trailing whitespace")
+    return cleaned or fallback
+
+
+def _finite_nonnegative(value, field: str, *, optional: bool = False) -> float | None:  # noqa: ANN001
+    if optional and value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"{field} must be finite and non-negative") from exc
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"{field} must be finite and non-negative")
+    return number
+
+
+def _validate_nested_data(value, field: str) -> None:  # noqa: ANN001
+    """Reject hostile nesting before estimates and lint walk event payloads."""
+    stack = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        if depth > MAX_JSON_DEPTH:
+            raise ValueError(f"{field} nesting exceeds the report limit")
+        if isinstance(item, dict):
+            if not all(isinstance(key, str) for key in item):
+                raise ValueError(f"{field} object keys must be strings")
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            stack.extend((child, depth + 1) for child in item)
+        elif isinstance(item, float) and not math.isfinite(item):
+            raise ValueError(f"{field} numbers must be finite")
+        elif not isinstance(item, (str, int, float, bool, type(None))):
+            raise ValueError(f"{field} contains a non-JSON value")
+
+
+def _validate_report_meta(meta) -> None:  # noqa: ANN001
+    """Apply one source-neutral schema contract to report metadata."""
+    if not isinstance(getattr(meta, "session_id", None), str):
+        raise ValueError("session_id must be a string")
+    validate_stored_id(meta.session_id, "report session ID")
+    _finite_nonnegative(getattr(meta, "started_at", None), "started_at")
+    _finite_nonnegative(getattr(meta, "ended_at", None), "ended_at", optional=True)
+    _finite_nonnegative(
+        getattr(meta, "total_duration_ms", None), "total_duration_ms"
+    )
+    for field in (
+        "agent_name", "command", "parent_session_id", "parent_event_id", "team",
+        "workspace_id", "trace_id", "parent_span_id", "trace_flags", "tenant_id",
+    ):
+        if not isinstance(getattr(meta, field, None), str):
+            raise ValueError(f"{field} must be a string")
+    _clean_label(meta.team, "")
+    _clean_label(meta.workspace_id, "")
+    if meta.parent_session_id:
+        validate_stored_id(meta.parent_session_id, "report parent session ID")
+    for field in ("tool_calls", "llm_requests", "errors", "total_tokens", "depth"):
+        value = getattr(meta, field, None)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{field} must be a non-negative integer")
+    if not isinstance(getattr(meta, "redacted", None), bool):
+        raise ValueError("redacted must be a boolean")
+    attribution = getattr(meta, "attribution", None)
+    if not isinstance(attribution, dict):
+        raise ValueError("attribution must be an object")
+    for field in (
+        "actor_id", "engineer_id", "user_id", "git_author",
+        "git_author_email", "os_user", "hostname",
+    ):
+        if field in attribution and attribution[field] is not None and not isinstance(
+            attribution[field], str
+        ):
+            raise ValueError(f"attribution {field} must be a string")
+        if attribution.get(field):
+            _clean_label(attribution[field], "")
+    _validate_nested_data(attribution, "attribution")
+
+
+def _validate_report_events(meta, events: list) -> None:  # noqa: ANN001
+    """Validate selected event objects equally for local and remote stores."""
+    stream_tenant = ""
+    for event in events:
+        if not isinstance(getattr(event, "event_type", None), EventType):
+            raise ValueError("event_type must be a recognized event type")
+        _finite_nonnegative(getattr(event, "timestamp", None), "event timestamp")
+        _finite_nonnegative(
+            getattr(event, "duration_ms", None), "event duration_ms", optional=True
+        )
+        for field in ("event_id", "session_id", "parent_id", "prev_hash", "tenant_id"):
+            if not isinstance(getattr(event, field, None), str):
+                raise ValueError(f"event {field} must be a string")
+        if not event.event_id:
+            raise ValueError("event_id must be non-empty")
+        if event.session_id != meta.session_id:
+            raise ValueError("event session ID does not match its metadata")
+        if not isinstance(getattr(event, "data", None), dict):
+            raise ValueError("event data must be an object")
+        _validate_nested_data(event.data, "event data")
+        if not isinstance(getattr(event, "redacted", None), bool):
+            raise ValueError("event redacted must be a boolean")
+        if meta.tenant_id and event.tenant_id and event.tenant_id != meta.tenant_id:
+            raise ValueError("event tenant does not match its metadata")
+        if not meta.tenant_id and event.tenant_id:
+            if stream_tenant and event.tenant_id != stream_tenant:
+                raise ValueError("event stream contains mixed tenants")
+            stream_tenant = event.tenant_id
+
+
+def _alias_map(kind: str, values: set[str]) -> dict[str, str]:
+    """Build deterministic report-local aliases without reversible hashing."""
+    return {
+        value: f"{kind.title()}-{index:03d}"
+        for index, value in enumerate(
+            sorted(value for value in values if value not in {"(unknown)", "(unassigned)"}),
+            1,
+        )
+    }
+
+
+def _team_for(meta, workspace_id: str) -> tuple[str, str]:  # noqa: ANN001
+    tagged = str(getattr(meta, "team", "") or "").strip()
+    workspace = str(workspace_id or getattr(meta, "workspace_id", "") or "").strip()
+    return tagged or workspace or "(unassigned)", workspace
+
+
+def _matches_team(
+    meta, workspace_id: str, selector_kind: str, selector_value: str,
+) -> bool:  # noqa: ANN001
+    if not selector_kind:
+        return True
+    tagged = str(getattr(meta, "team", "") or "").strip()
+    workspace = str(workspace_id or getattr(meta, "workspace_id", "") or "").strip()
+    return tagged == selector_value if selector_kind == "tag" else workspace == selector_value
+
+
+def _resolve_team_selector(inventory: list[tuple], requested: str) -> tuple[str, str]:
+    if not requested:
+        return "", ""
+    if requested.startswith("tag:"):
+        value = requested[4:].strip()
+        if not value:
+            raise ValueError("team tag selector cannot be empty")
+        return "tag", value
+    if requested.startswith("workspace:"):
+        value = requested[10:].strip()
+        if not value:
+            raise ValueError("workspace selector cannot be empty")
+        return "workspace", value
+    tags = {
+        str(getattr(meta, "team", "") or "").strip()
+        for _, meta, _ in inventory
+    }
+    workspaces = {
+        str(workspace or getattr(meta, "workspace_id", "") or "").strip()
+        for _, meta, workspace in inventory
+    }
+    in_tags = requested in tags
+    in_workspaces = requested in workspaces
+    if in_tags and in_workspaces:
+        raise ValueError(
+            "ambiguous --team selector; use tag:NAME or workspace:NAME"
+        )
+    if in_tags:
+        return "tag", requested
+    if in_workspaces:
+        return "workspace", requested
+    # Preserve empty-report behavior for an unmatched unprefixed selector.
+    return "tag", requested
+
+
+def _group_metrics(metrics: list[_SessionMetric], field: str) -> dict[str, list[_SessionMetric]]:
+    groups: dict[str, list[_SessionMetric]] = {}
+    for metric in metrics:
+        groups.setdefault(str(getattr(metric, field)), []).append(metric)
+    return groups
+
+
+def _lint_counts(rows: list[_SessionMetric]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        for rule in row.lint_rules:
+            counts[rule] = counts.get(rule, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
+def _build_anomalies(
+    metrics: list[_SessionMetric],
+    team_rows: list[TeamBreakdown],
+) -> list[OrgAnomaly]:
+    anomalies: list[OrgAnomaly] = []
+    eligible_teams = [
+        team for team in team_rows
+        if team.cost_estimated_sessions >= MIN_ANOMALY_SESSIONS
+        and team.cost_estimate_coverage_percent >= MIN_ANOMALY_COVERAGE * 100
+    ]
+    if len(eligible_teams) > MIN_ANOMALY_PEERS:
+        for team in eligible_teams:
+            peer_averages = [
+                peer.avg_estimated_cost_usd
+                for peer in eligible_teams
+                if peer is not team
+            ]
+            peer_median = statistics.median(peer_averages)
+            if peer_median <= 0:
+                continue
+            ratio = team.avg_estimated_cost_usd / peer_median
+            if ratio < TEAM_HIGH_COST_RATIO:
+                continue
+            details: tuple[str, ...] = ()
+            if team.lint_signals:
+                rule, count = next(iter(team.lint_signals.items()))
+                details = (
+                    f"Most frequent structural lint signal: {rule} ({count} finding(s)); heuristic only.",
+                )
+            anomalies.append(OrgAnomaly(
+                kind="team-estimated-cost",
+                subject=team.team,
+                sessions=team.cost_estimated_sessions,
+                cost_estimate_coverage_percent=team.cost_estimate_coverage_percent,
+                ratio_to_peer_median=ratio,
+                eligible_peers=len(peer_averages),
+                callout=(
+                    f"Average estimate per cost-estimated session is {ratio:.2f}x "
+                    f"the median of {len(peer_averages)} eligible team peers "
+                    f"({team.cost_estimated_sessions} sessions; "
+                    f"{team.cost_estimate_coverage_percent:.1f}% coverage)."
+                ),
+                details=details,
+            ))
+
+    eligible_engineers: list[tuple[str, list[_SessionMetric], float, float]] = []
+    for engineer, rows in _group_metrics(metrics, "engineer").items():
+        priced = [row for row in rows if row.cost is not None]
+        coverage = len(priced) / len(rows) if rows else 0.0
+        if (
+            engineer == "(unknown)"
+            or len(priced) < MIN_ANOMALY_SESSIONS
+            or coverage < MIN_ANOMALY_COVERAGE
+        ):
+            continue
+        average = sum(row.cost for row in priced if row.cost is not None) / len(priced)
+        eligible_engineers.append((engineer, priced, average, coverage))
+    if len(eligible_engineers) > MIN_ANOMALY_PEERS:
+        for engineer, priced, average, coverage in eligible_engineers:
+            peer_averages = [
+                item[2] for item in eligible_engineers if item[0] != engineer
+            ]
+            peer_median = statistics.median(peer_averages)
+            if peer_median <= 0:
+                continue
+            ratio = average / peer_median
+            if ratio < ENGINEER_HIGH_COST_RATIO:
+                continue
+            anomalies.append(OrgAnomaly(
+                kind="identity-estimated-cost",
+                subject=engineer,
+                sessions=len(priced),
+                cost_estimate_coverage_percent=coverage * 100,
+                ratio_to_peer_median=ratio,
+                eligible_peers=len(peer_averages),
+                callout=(
+                    f"Average estimate per cost-estimated session is {ratio:.2f}x "
+                    f"the median of {len(peer_averages)} eligible identity peers "
+                    f"({len(priced)} sessions; {coverage * 100:.1f}% coverage)."
+                ),
+            ))
+    return sorted(
+        anomalies,
+        key=lambda item: (-item.ratio_to_peer_median, item.kind, item.subject),
+    )
+
+
+def build_org_report(
+    stores: list,
+    month: str,
+    *,
+    team: str = "",
+    anonymize: bool = False,
+    model: str = DEFAULT_MODEL,
+    source_mode: str = "shared-directory",
+    generated_at: str | None = None,
+) -> OrgReport:
+    """Build a deterministic report from strict local or collector stores."""
+    if model not in PRICING:
+        raise ValueError(f"unknown pricing model: {model}")
+    start, end = month_bounds_utc(month)
+    requested_team = str(team or "").strip()
+    metrics: list[_SessionMetric] = []
+    inventory: list[tuple] = []
+    for store in stores:
+        workspace_value = getattr(store, "workspace_id", "")
+        if not isinstance(workspace_value, str):
+            raise ValueError("store workspace_id must be a string")
+        workspace_id = workspace_value
+        # Remote stores return metadata only here.  The month/team filters run
+        # before load_events, estimate_cost, or lint_session fetch any events.
+        try:
+            discovered = store.list_sessions_strict(validate_events=False)
+        except RecursionError as exc:
+            raise ValueError("trace metadata nesting exceeds the report limit") from exc
+        for meta in discovered:
+            _validate_report_meta(meta)
+            timestamp = float(meta.started_at)
+            if start <= timestamp < end:
+                inventory.append((store, meta, workspace_id))
+
+    selector_kind, selector_value = _resolve_team_selector(inventory, requested_team)
+    for store, meta, workspace_id in inventory:
+        if not _matches_team(meta, workspace_id, selector_kind, selector_value):
+            continue
+        team_name, _ = _team_for(meta, workspace_id)
+        engineer, confidence = session_engineer_attribution(meta)
+        engineer = _clean_label(engineer, "(unknown)")
+        team_name = _clean_label(team_name, "(unassigned)")
+        # Force the selected stream to load before analysis. Collector stores
+        # cache it, so cost/lint never trigger duplicate requests.
+        try:
+            events = store.load_events(meta.session_id)
+        except RecursionError as exc:
+            raise ValueError("trace event nesting exceeds the report limit") from exc
+        try:
+            _validate_report_events(meta, events)
+            snapshot = _SessionSnapshotStore(meta, events)
+            try:
+                cost_result = estimate_cost(snapshot, meta.session_id, model=model)
+                cost: float | None = float(cost_result.total_cost)
+                if not math.isfinite(cost) or cost < 0:
+                    cost = None
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                cost = None
+            lint = lint_session(snapshot, meta.session_id)
+        finally:
+            release = getattr(store, "release_events", None)
+            if release is not None:
+                release(meta.session_id)
+        task_type = classify_session(meta.agent_name, meta.command)
+        metrics.append(_SessionMetric(
+            team=team_name,
+            engineer=engineer,
+            identity_confidence=confidence,
+            task_type=task_type,
+            cost=cost,
+            lint_rules=tuple(finding.rule for finding in lint.findings),
+        ))
+
+    costs = [metric.cost for metric in metrics if metric.cost is not None]
+    total_cost = sum(costs)
+    average = total_cost / len(costs) if costs else 0.0
+    median = statistics.median(costs) if costs else 0.0
+
+    team_rows: list[TeamBreakdown] = []
+    for name, rows in _group_metrics(metrics, "team").items():
+        priced = [row.cost for row in rows if row.cost is not None]
+        team_cost = sum(priced)
+        identities = {row.engineer for row in rows if row.engineer != "(unknown)"}
+        team_rows.append(TeamBreakdown(
+            team=name,
+            sessions=len(rows),
+            cost_estimated_sessions=len(priced),
+            cost_estimate_coverage_percent=len(priced) / len(rows) * 100,
+            estimated_spend_usd=team_cost,
+            avg_estimated_cost_usd=team_cost / len(priced) if priced else 0.0,
+            active_attributed_identities=len(identities),
+            lint_findings=sum(len(row.lint_rules) for row in rows),
+            sessions_with_lint_signals=sum(bool(row.lint_rules) for row in rows),
+            lint_signals=_lint_counts(rows),
+        ))
+    team_rows.sort(key=lambda row: (-row.estimated_spend_usd, row.team))
+
+    task_rows: list[TaskTypeBreakdown] = []
+    for task_type, rows in _group_metrics(metrics, "task_type").items():
+        priced = [row.cost for row in rows if row.cost is not None]
+        task_cost = sum(priced)
+        avg_cost = task_cost / len(priced) if priced else 0.0
+        task_rows.append(TaskTypeBreakdown(
+            task_type=task_type,
+            sessions=len(rows),
+            cost_estimated_sessions=len(priced),
+            cost_estimate_coverage_percent=len(priced) / len(rows) * 100,
+            estimated_spend_usd=task_cost,
+            avg_estimated_cost_usd=avg_cost,
+        ))
+    task_rows.sort(key=lambda row: (-row.sessions, row.task_type))
+
+    anomalies = _build_anomalies(metrics, team_rows)
+    if anonymize:
+        team_aliases = _alias_map("team", {row.team for row in team_rows})
+        identity_aliases = _alias_map(
+            "identity", {metric.engineer for metric in metrics}
+        )
+        team_rows = [
+            TeamBreakdown(
+                team=team_aliases.get(row.team, row.team),
+                sessions=row.sessions,
+                cost_estimated_sessions=row.cost_estimated_sessions,
+                cost_estimate_coverage_percent=row.cost_estimate_coverage_percent,
+                estimated_spend_usd=row.estimated_spend_usd,
+                avg_estimated_cost_usd=row.avg_estimated_cost_usd,
+                active_attributed_identities=row.active_attributed_identities,
+                lint_findings=row.lint_findings,
+                sessions_with_lint_signals=row.sessions_with_lint_signals,
+                lint_signals=row.lint_signals,
+            )
+            for row in team_rows
+        ]
+        anomalies = [
+            OrgAnomaly(
+                kind=item.kind,
+                subject=(
+                    team_aliases.get(item.subject, item.subject)
+                    if item.kind == "team-estimated-cost"
+                    else identity_aliases.get(item.subject, item.subject)
+                ),
+                sessions=item.sessions,
+                cost_estimate_coverage_percent=item.cost_estimate_coverage_percent,
+                ratio_to_peer_median=item.ratio_to_peer_median,
+                eligible_peers=item.eligible_peers,
+                callout=item.callout,
+                details=item.details,
+            )
+            for item in anomalies
+        ]
+
+    identities = {metric.engineer for metric in metrics if metric.engineer != "(unknown)"}
+    attributed = sum(1 for metric in metrics if metric.engineer != "(unknown)")
+    confidence: dict[str, int] = {}
+    for metric in metrics:
+        confidence[metric.identity_confidence] = (
+            confidence.get(metric.identity_confidence, 0) + 1
+        )
+    filtered_label = _clean_label(requested_team, "") if requested_team else ""
+    if anonymize and filtered_label:
+        filtered_label = f"anonymized {selector_kind} scope"
+    return OrgReport(
+        generated_at=(
+            generated_at
+            if generated_at is not None
+            else datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        ),
+        month=month,
+        source_mode=source_mode,
+        organization_boundary=(
+            "one authenticated collector instance and key"
+            if source_mode == "collector-instance"
+            else "one shared trace directory and its workspace stores"
+        ),
+        pricing_model=model,
+        pricing_snapshot_date=PRICING_SNAPSHOT_DATE,
+        cost_estimation_method="offline heuristic token estimate with bundled model pricing",
+        team_filter=filtered_label,
+        anonymized=anonymize,
+        session_count=len(metrics),
+        cost_estimated_sessions=len(costs),
+        cost_estimate_coverage_percent=(len(costs) / len(metrics) * 100 if metrics else 0.0),
+        total_estimated_spend_usd=total_cost,
+        avg_estimated_cost_usd=average,
+        median_estimated_cost_usd=median,
+        active_attributed_identities=len(identities),
+        identity_attributed_sessions=attributed,
+        identity_coverage_percent=(attributed / len(metrics) * 100 if metrics else 0.0),
+        identity_confidence=dict(sorted(confidence.items())),
+        teams=tuple(team_rows),
+        task_types=tuple(task_rows),
+        anomalies=tuple(anomalies),
+        snapshot_limitation=(
+            "Collector metadata and event streams use bounded N+1 reads and are not a transactionally consistent snapshot."
+            if source_mode == "collector-instance"
+            else "The shared directory may change while it is read and is not a transactionally consistent snapshot."
+        ),
+    )
+
+
+def org_report_payload(report: OrgReport) -> dict:
+    payload = asdict(report)
+    payload["schema"] = "agent-strace-org-report/v1"
+    payload["spend_is_estimate"] = True
+    payload["task_classification_is_heuristic"] = True
+    payload["anomaly_detection_is_structural"] = True
+    payload["spend_scope"] = "cost-estimated sessions only"
+    payload["average_cost_denominator"] = "cost_estimated_sessions"
+    return payload
+
+
+def format_org_report_json(report: OrgReport) -> str:
+    return json.dumps(
+        org_report_payload(report), indent=2, sort_keys=True, allow_nan=False
+    ) + "\n"
+
+
+def format_org_report_text(report: OrgReport) -> str:
+    title = datetime.strptime(report.month, "%Y-%m").strftime("%B %Y")
+    lines = [
+        f"{title} - Engineering AI Agent Report",
+        "=" * 64,
+        f"Scope: {report.organization_boundary}",
+        f"Covered-session estimated spend ({report.pricing_model}): ${report.total_estimated_spend_usd:.2f}",
+        f"Sessions: {report.session_count}",
+        f"Average estimate/cost-estimated session: ${report.avg_estimated_cost_usd:.2f}",
+        f"Median estimate/cost-estimated session: ${report.median_estimated_cost_usd:.2f}",
+        f"Cost estimate coverage: {report.cost_estimate_coverage_percent:.1f}% "
+        f"({report.cost_estimated_sessions}/{report.session_count} sessions)",
+        f"Active attributed identities: {report.active_attributed_identities}",
+        f"Identity attribution coverage: {report.identity_coverage_percent:.1f}%",
+    ]
+    if report.team_filter:
+        lines.append(f"Team scope: {report.team_filter}")
+    lines.extend(["", "Team breakdown", "-" * 64])
+    if report.teams:
+        lines.append(f"{'Team':<24} {'Sessions':>8} {'Covered est.':>12} {'Avg covered':>11} {'Coverage':>9}")
+        for row in report.teams:
+            lines.append(
+                f"{row.team[:24]:<24} {row.sessions:>8} "
+                f"${row.estimated_spend_usd:>11.2f} ${row.avg_estimated_cost_usd:>10.2f} "
+                f"{row.cost_estimate_coverage_percent:>8.1f}%"
+            )
+    else:
+        lines.append("No sessions matched this scope.")
+
+    lines.extend(["", "Heuristic task type breakdown", "-" * 64])
+    if report.task_types:
+        lines.append(f"{'Task type':<24} {'Sessions':>8} {'Avg covered':>11} {'Coverage':>9}")
+        for row in report.task_types:
+            lines.append(
+                f"{row.task_type[:24]:<24} {row.sessions:>8} "
+                f"${row.avg_estimated_cost_usd:>10.2f} {row.cost_estimate_coverage_percent:>8.1f}%"
+            )
+    else:
+        lines.append("No task types to report.")
+
+    lines.extend(["", "Structural anomaly callouts", "-" * 64])
+    if report.anomalies:
+        for anomaly in report.anomalies:
+            lines.append(
+                f"- {anomaly.subject}: {anomaly.callout} "
+                f"({anomaly.sessions} sessions)"
+            )
+            lines.extend(f"  {detail}" for detail in anomaly.details)
+    else:
+        lines.append(
+            f"No cost outliers met the {MIN_ANOMALY_SESSIONS}-session, "
+            f"{MIN_ANOMALY_PEERS}-peer, and {MIN_ANOMALY_COVERAGE:.0%}-coverage floors."
+        )
+    lines.extend([
+        "",
+        f"Method: {report.cost_estimation_method}; pricing snapshot {report.pricing_snapshot_date}.",
+        "Cost, task classification, and anomaly callouts are estimates or heuristics.",
+        f"Snapshot limitation: {report.snapshot_limitation}",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def format_org_report_html(report: OrgReport) -> str:
+    esc = lambda value: html.escape(str(value), quote=True)
+    title = datetime.strptime(report.month, "%Y-%m").strftime("%B %Y")
+    team_rows = "".join(
+        "<tr>"
+        f"<td>{esc(row.team)}</td><td>{row.sessions}</td>"
+        f"<td>${row.estimated_spend_usd:.2f}</td>"
+        f"<td>${row.avg_estimated_cost_usd:.2f}</td>"
+        f"<td>{row.cost_estimate_coverage_percent:.1f}%</td>"
+        f"<td>{row.active_attributed_identities}</td>"
+        "</tr>"
+        for row in report.teams
+    ) or '<tr><td colspan="6">No sessions matched this scope.</td></tr>'
+    task_rows = "".join(
+        "<tr>"
+        f"<td>{esc(row.task_type)}</td><td>{row.sessions}</td>"
+        f"<td>${row.avg_estimated_cost_usd:.2f}</td>"
+        f"<td>{row.cost_estimate_coverage_percent:.1f}%</td>"
+        "</tr>"
+        for row in report.task_types
+    ) or '<tr><td colspan="4">No task types to report.</td></tr>'
+    anomaly_rows = "".join(
+        "<li>"
+        f"<strong>{esc(row.subject)}</strong>: {esc(row.callout)} "
+        f"<span>({row.sessions} sessions)</span>"
+        + "".join(f"<div>{esc(detail)}</div>" for detail in row.details)
+        + "</li>"
+        for row in report.anomalies
+    ) or (
+        f"<li>No cost outliers met the {MIN_ANOMALY_SESSIONS}-session, "
+        f"{MIN_ANOMALY_PEERS}-peer, and {MIN_ANOMALY_COVERAGE:.0%}-coverage floors.</li>"
+    )
+    team_scope = (
+        f"<p><strong>Team scope:</strong> {esc(report.team_filter)}</p>"
+        if report.team_filter else ""
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{esc(title)} - Engineering AI Agent Report</title>
+<style>
+body{{font-family:system-ui,sans-serif;max-width:1100px;margin:2rem auto;padding:0 1rem;color:#172033;background:#fff}}
+h1,h2{{color:#111827}}.cards{{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem}}
+.card{{border:1px solid #dbe2ea;border-radius:10px;padding:1rem}}.value{{font-size:1.55rem;font-weight:700}}
+table{{border-collapse:collapse;width:100%;margin-bottom:2rem}}th,td{{border-bottom:1px solid #dbe2ea;padding:.65rem;text-align:right}}
+th:first-child,td:first-child{{text-align:left}}.note{{background:#f3f6fa;border-radius:8px;padding:1rem}}li{{margin:.7rem 0}}
+</style></head><body>
+<h1>{esc(title)} - Engineering AI Agent Report</h1>
+<p><strong>Scope:</strong> {esc(report.organization_boundary)}</p>{team_scope}
+<div class="cards">
+<div class="card"><div>Covered-session estimated spend</div><div class="value">${report.total_estimated_spend_usd:.2f}</div></div>
+<div class="card"><div>Sessions</div><div class="value">{report.session_count}</div></div>
+<div class="card"><div>Average per cost-estimated session</div><div class="value">${report.avg_estimated_cost_usd:.2f}</div></div>
+<div class="card"><div>Active attributed identities</div><div class="value">{report.active_attributed_identities}</div></div>
+</div>
+<h2>Team breakdown</h2><table><thead><tr><th>Team</th><th>Sessions</th><th>Covered-session estimate</th><th>Average per covered session</th><th>Coverage</th><th>Attributed identities</th></tr></thead><tbody>{team_rows}</tbody></table>
+<h2>Heuristic task type breakdown</h2><table><thead><tr><th>Task type</th><th>Sessions</th><th>Average per covered session</th><th>Coverage</th></tr></thead><tbody>{task_rows}</tbody></table>
+<h2>Structural anomaly callouts</h2><ul>{anomaly_rows}</ul>
+<p class="note">Cost, task classification, and anomaly callouts are estimates or heuristics. Cost estimate coverage is {report.cost_estimate_coverage_percent:.1f}%; identity attribution coverage is {report.identity_coverage_percent:.1f}%. {esc(report.snapshot_limitation)}</p>
+</body></html>"""
+
+
+def _load_auth_key(auth_key_file: str) -> str:
+    path_value = str(auth_key_file or "").strip()
+    if path_value:
+        path = Path(path_value)
+        if not path.is_file():
+            raise CollectorAuthenticationError("collector auth key file was not found")
+        if path.stat().st_size > MAX_AUTH_KEY_FILE_BYTES:
+            raise CollectorAuthenticationError("collector auth key file is too large")
+        try:
+            value = path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError) as exc:
+            raise CollectorAuthenticationError(
+                "collector auth key file could not be read"
+            ) from exc
+    else:
+        value = os.environ.get("AGENT_STRACE_AUTH_KEY", "").strip()
+    if not value or any(char in value for char in "\r\n"):
+        raise CollectorAuthenticationError(
+            "set AGENT_STRACE_AUTH_KEY or provide --auth-key-file"
+        )
+    return value
+
+
+def _write_atomic(path_value: str, content: str) -> None:
+    path = Path(path_value)
+    if path.is_symlink() or path.parent.is_symlink():
+        raise ValueError("refusing to replace a symlinked report output")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", newline="", dir=path.parent,
+            prefix=f".{path.name}.", delete=False,
+        ) as output:
+            temporary = output.name
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        temporary = ""
+        try:
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            # The report itself was already atomically replaced; directory
+            # fsync is a best-effort durability improvement on supported OSes.
+            pass
+    finally:
+        if temporary:
+            try:
+                Path(temporary).unlink()
+            except OSError:
+                pass
+
+
+def cmd_org_report(args: argparse.Namespace) -> int:
+    endpoint = str(getattr(args, "endpoint", "") or "").strip()
+    month = str(getattr(args, "month", "") or "").strip()
+    if not month:
+        month = datetime.now(timezone.utc).strftime("%Y-%m")
+    try:
+        if endpoint:
+            key = _load_auth_key(getattr(args, "auth_key_file", "") or "")
+            client = CollectorClient(
+                endpoint,
+                key,
+                allow_insecure_http=bool(
+                    getattr(args, "allow_insecure_http", False)
+                ),
+                ca_file=str(getattr(args, "ca_file", "") or ""),
+            )
+            stores = [CollectorTraceStore.load(client)]
+            source_mode = "collector-instance"
+        else:
+            if (
+                getattr(args, "auth_key_file", "")
+                or getattr(args, "ca_file", "")
+                or getattr(args, "allow_insecure_http", False)
+            ):
+                raise ValueError("collector authentication/TLS flags require --endpoint")
+            stores = enumerate_trace_stores(args.trace_dir)
+            source_mode = "shared-directory"
+        report = build_org_report(
+            stores,
+            month,
+            team=str(getattr(args, "team", "") or ""),
+            anonymize=bool(getattr(args, "anonymize", False)),
+            model=str(getattr(args, "model", DEFAULT_MODEL) or DEFAULT_MODEL),
+            source_mode=source_mode,
+        )
+        output_format = str(getattr(args, "format", "text") or "text")
+        if output_format == "json":
+            rendered = format_org_report_json(report)
+        elif output_format == "html":
+            rendered = format_org_report_html(report)
+        else:
+            rendered = format_org_report_text(report)
+        destination = str(getattr(args, "output", "") or "")
+        if destination:
+            _write_atomic(destination, rendered)
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    except (
+        CollectorClientError,
+        OSError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        sys.stderr.write(f"org-report failed: {exc}\n")
+        return 1

--- a/src/agent_trace/store.py
+++ b/src/agent_trace/store.py
@@ -1040,7 +1040,10 @@ class TraceStore:
         )
 
     def list_sessions_strict(
-        self, tenant_id: str | None = None,
+        self,
+        tenant_id: str | None = None,
+        *,
+        validate_events: bool = True,
     ) -> list[SessionMeta]:
         """Strictly discover sessions for report/export/erasure workflows.
 
@@ -1091,7 +1094,8 @@ class TraceStore:
                 raise ValueError(f"invalid core file for session {session_id}")
             try:
                 meta = self.load_meta(session_id)
-                self.load_events(session_id)
+                if validate_events:
+                    self.load_events(session_id)
             except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
                 raise ValueError(
                     f"corrupt session in tenant store: {session_id}"

--- a/src/agent_trace/team_report.py
+++ b/src/agent_trace/team_report.py
@@ -101,6 +101,38 @@ def _working_dir(meta: SessionMeta) -> str:
     return str(wd)
 
 
+def session_engineer_attribution(meta: SessionMeta) -> tuple[str, str]:
+    """Return ``(identifier, confidence)`` from persisted attribution only."""
+    attr = _meta_attr(meta)
+    explicit = (
+        attr.get("actor_id")
+        or attr.get("engineer_id")
+        or attr.get("user_id")
+        or attr.get("git_author")
+        or attr.get("git_author_email")
+    )
+    if explicit:
+        return str(explicit), "explicit"
+    user = str(attr.get("os_user") or "")
+    host = str(attr.get("hostname") or "")
+    if user and host:
+        return f"{user}@{host}", "host-user"
+    if user:
+        return user, "user-only"
+    return "(unknown)", "unavailable"
+
+
+def session_engineer(meta: SessionMeta) -> str:
+    """Return the stable engineer identifier persisted with a session.
+
+    Organization-wide reports must not inspect the reporting machine's git
+    configuration, especially when the session came from a remote collector.
+    This helper therefore uses stored attribution only.  The legacy team
+    report keeps its local-git fallback below for backward compatibility.
+    """
+    return session_engineer_attribution(meta)[0]
+
+
 def _fallback_author(meta: SessionMeta) -> str:
     attr = _meta_attr(meta)
     cwd = _working_dir(meta)

--- a/tests/test_org_report.py
+++ b/tests/test_org_report.py
@@ -1,0 +1,665 @@
+"""Tests for organization-wide local and remote-collector reporting."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import socket
+import tempfile
+import threading
+import unittest
+import urllib.error
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlsplit
+
+from agent_trace.cli import build_parser
+from agent_trace.collector_client import (
+    CollectorAuthenticationError,
+    CollectorClient,
+    CollectorClientError,
+    CollectorTraceStore,
+    validate_collector_endpoint,
+)
+from agent_trace.lint import LintReport, LintResult
+from agent_trace.models import EventType, SessionMeta, TraceEvent
+from agent_trace.org_report import (
+    MIN_ANOMALY_COVERAGE,
+    MIN_ANOMALY_PEERS,
+    MIN_ANOMALY_SESSIONS,
+    TeamBreakdown,
+    _SessionMetric,
+    _build_anomalies,
+    _write_atomic,
+    build_org_report,
+    format_org_report_html,
+    format_org_report_json,
+    format_org_report_text,
+    month_bounds_utc,
+)
+from agent_trace.store import TraceStore
+from agent_trace.team_report import _fallback_author, session_engineer_attribution
+from agent_trace.tenancy import enumerate_trace_stores
+
+
+def _timestamp(year: int, month: int, day: int = 1) -> float:
+    return datetime(year, month, day, tzinfo=timezone.utc).timestamp()
+
+
+def _event(session_id: str, timestamp: float, **kwargs) -> TraceEvent:
+    return TraceEvent(
+        event_type=kwargs.pop("event_type", EventType.USER_PROMPT),
+        event_id=kwargs.pop("event_id", f"event-{session_id}"),
+        session_id=session_id,
+        timestamp=timestamp,
+        data=kwargs.pop("data", {"prompt": "x" * 200}),
+        **kwargs,
+    )
+
+
+def _add_session(
+    store: TraceStore,
+    session_id: str,
+    timestamp: float,
+    *,
+    team: str = "",
+    tenant: str = "",
+    attribution: dict | None = None,
+    agent_name: str = "code review",
+) -> SessionMeta:
+    meta = SessionMeta(
+        session_id=session_id,
+        started_at=timestamp,
+        team=team,
+        tenant_id=tenant,
+        attribution=attribution or {},
+        agent_name=agent_name,
+    )
+    store.create_session(meta)
+    store.append_event(
+        session_id,
+        _event(session_id, timestamp + 1, tenant_id=tenant),
+    )
+    store.append_event(
+        session_id,
+        _event(
+            session_id,
+            timestamp + 2,
+            event_type=EventType.ASSISTANT_RESPONSE,
+            event_id=f"response-{session_id}",
+            tenant_id=tenant,
+            data={"text": "y" * 200},
+        ),
+    )
+    return meta
+
+
+class _MemoryStore:
+    def __init__(self, metas, events=None, workspace_id=""):
+        self.metas = list(metas)
+        self.events = events or {meta.session_id: [] for meta in metas}
+        self.workspace_id = workspace_id
+        self.loads: list[str] = []
+
+    def list_sessions_strict(self, tenant_id=None, *, validate_events=True):
+        del validate_events
+        if tenant_id is None:
+            return list(self.metas)
+        return [meta for meta in self.metas if meta.tenant_id == tenant_id]
+
+    def load_meta(self, session_id):
+        return next(meta for meta in self.metas if meta.session_id == session_id)
+
+    def load_events(self, session_id):
+        self.loads.append(session_id)
+        return list(self.events[session_id])
+
+
+class _Response(io.BytesIO):
+    def __init__(self, body: bytes, *, status: int = 200, length=True):
+        super().__init__(body)
+        self.status = status
+        self.headers = {}
+        if length:
+            self.headers["Content-Length"] = str(len(body))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+class _RouteOpener:
+    def __init__(self, sessions, events, *, enforce_auth=True):
+        self.sessions = sessions
+        self.events = events
+        self.enforce_auth = enforce_auth
+        self.requests: list[tuple[str, bool]] = []
+
+    def open(self, request, timeout=0):
+        del timeout
+        path = urlsplit(request.full_url).path
+        authenticated = bool(request.get_header("Authorization"))
+        self.requests.append((path, authenticated))
+        if path == "/sessions" and not authenticated and self.enforce_auth:
+            raise urllib.error.HTTPError(
+                request.full_url, 401, "unauthorized", {}, io.BytesIO(b"{}")
+            )
+        if path == "/sessions":
+            return _Response(json.dumps(self.sessions).encode())
+        encoded = path.removeprefix("/sessions/").removesuffix("/events")
+        body = self.events[encoded]
+        return _Response(body)
+
+
+class TestMonthAndLocalReport(unittest.TestCase):
+    def test_utc_month_bounds_are_half_open_and_handle_december(self):
+        start, end = month_bounds_utc("2026-12")
+        self.assertEqual(start, _timestamp(2026, 12))
+        self.assertEqual(end, _timestamp(2027, 1))
+        with self.assertRaisesRegex(ValueError, "YYYY-MM"):
+            month_bounds_utc("2026-2")
+        with self.assertRaisesRegex(ValueError, "YYYY-MM"):
+            month_bounds_utc("2026-13")
+
+    def test_flat_and_workspace_sessions_with_same_id_remain_distinct(self):
+        with tempfile.TemporaryDirectory() as directory:
+            flat = TraceStore(directory, use_workspace_env=False, redact=False)
+            workspace = TraceStore(
+                directory, workspace_id="payments", use_workspace_env=False,
+                redact=False,
+            )
+            when = _timestamp(2026, 8, 3)
+            _add_session(flat, "same-id", when, team="platform")
+            _add_session(workspace, "same-id", when, team="payments")
+
+            report = build_org_report(
+                enumerate_trace_stores(directory), "2026-08",
+                generated_at="2026-09-01T00:00:00Z",
+            )
+
+            self.assertEqual(report.session_count, 2)
+            self.assertEqual({row.team for row in report.teams}, {"platform", "payments"})
+
+    def test_month_and_team_filters_run_before_event_loads(self):
+        inside = SessionMeta(
+            session_id="inside", started_at=_timestamp(2026, 8, 2), team="blue"
+        )
+        other_team = SessionMeta(
+            session_id="other", started_at=_timestamp(2026, 8, 3), team="red"
+        )
+        other_month = SessionMeta(
+            session_id="old", started_at=_timestamp(2026, 7, 31), team="blue"
+        )
+        store = _MemoryStore([inside, other_team, other_month])
+        with patch("agent_trace.org_report.estimate_cost", return_value=SimpleNamespace(total_cost=1.0)), patch(
+            "agent_trace.org_report.lint_session", return_value=LintReport("inside")
+        ):
+            report = build_org_report([store], "2026-08", team="tag:blue")
+        self.assertEqual(report.session_count, 1)
+        self.assertEqual(store.loads, ["inside"])
+
+    def test_ambiguous_unprefixed_selector_fails_before_event_loads(self):
+        when = _timestamp(2026, 8, 2)
+        store = _MemoryStore(
+            [SessionMeta(session_id="one", started_at=when, team="same")],
+            workspace_id="same",
+        )
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            build_org_report([store], "2026-08", team="same")
+        self.assertEqual(store.loads, [])
+
+    def test_local_metadata_and_selected_events_use_strict_report_schema(self):
+        when = _timestamp(2026, 8, 2)
+        bad_meta = SessionMeta(session_id="bad-meta", started_at=when)
+        bad_meta.started_at = "2026-08-02"  # type: ignore[assignment]
+        store = _MemoryStore([bad_meta])
+        with self.assertRaisesRegex(ValueError, "started_at must be a number"):
+            build_org_report([store], "2026-08")
+        self.assertEqual(store.loads, [])
+
+        bad_meta.started_at = 10**1000
+        with self.assertRaisesRegex(ValueError, "finite"):
+            build_org_report([store], "2026-08")
+
+        meta = SessionMeta(session_id="bad-event", started_at=when)
+        event = _event("bad-event", when + 1)
+        event.data = {"nested": float("nan")}
+        store = _MemoryStore([meta], {meta.session_id: [event]})
+        with self.assertRaisesRegex(ValueError, "numbers must be finite"):
+            build_org_report([store], "2026-08")
+
+        unsafe = SessionMeta(
+            session_id="unsafe-label", started_at=when, team="team\u202ename"
+        )
+        with self.assertRaisesRegex(ValueError, "control or format"):
+            build_org_report([_MemoryStore([unsafe])], "2026-08")
+        overlong = SessionMeta(
+            session_id="long-label", started_at=when, team="x" * 201
+        )
+        with self.assertRaisesRegex(ValueError, "cannot exceed"):
+            build_org_report([_MemoryStore([overlong])], "2026-08")
+        padded = SessionMeta(
+            session_id="padded-label", started_at=when, team="team "
+        )
+        padded_store = _MemoryStore([padded])
+        with self.assertRaisesRegex(ValueError, "leading or trailing"):
+            build_org_report([padded_store], "2026-08")
+        self.assertEqual(padded_store.loads, [])
+
+    def test_deep_local_event_file_fails_without_recursion_traceback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = TraceStore(directory, use_workspace_env=False, redact=False)
+            meta = SessionMeta(
+                session_id="deep-local", started_at=_timestamp(2026, 8, 2)
+            )
+            store.create_session(meta)
+            payload = (
+                '{"event_type":"user_prompt","timestamp":1,"event_id":"e",'
+                '"session_id":"deep-local","data":{"nested":'
+                + "[" * 10_000 + "0" + "]" * 10_000 + "}}\n"
+            )
+            (store._session_dir(meta.session_id) / "events.ndjson").write_text(
+                payload, encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "nesting exceeds"):
+                build_org_report([store], "2026-08")
+
+    def test_tenants_are_tags_not_org_boundaries_and_are_not_emitted(self):
+        when = _timestamp(2026, 8, 2)
+        metas = [
+            SessionMeta(session_id="a", started_at=when, tenant_id="customer-secret"),
+            SessionMeta(session_id="b", started_at=when, tenant_id="customer-other"),
+        ]
+        store = _MemoryStore(metas)
+        with patch("agent_trace.org_report.estimate_cost", return_value=SimpleNamespace(total_cost=0.5)), patch(
+            "agent_trace.org_report.lint_session", side_effect=lambda _s, sid: LintReport(sid)
+        ):
+            report = build_org_report([store], "2026-08")
+        payload = format_org_report_json(report)
+        self.assertEqual(report.session_count, 2)
+        self.assertNotIn("customer-secret", payload)
+        self.assertNotIn("customer-other", payload)
+
+    def test_unknown_costs_are_excluded_and_lint_counts_are_distinct(self):
+        when = _timestamp(2026, 8, 2)
+        metas = [
+            SessionMeta(session_id="a", started_at=when, team="blue"),
+            SessionMeta(session_id="b", started_at=when, team="blue"),
+        ]
+        store = _MemoryStore(metas)
+
+        def cost(_store, session_id, model="sonnet"):
+            del model
+            if session_id == "b":
+                raise ValueError("unknown")
+            return SimpleNamespace(total_cost=2.0)
+
+        def lint(_store, session_id):
+            findings = []
+            if session_id == "a":
+                findings = [
+                    LintResult("tool-loop", "WARN", "one"),
+                    LintResult("tool-loop", "WARN", "two"),
+                ]
+            return LintReport(session_id, findings)
+
+        with patch("agent_trace.org_report.estimate_cost", side_effect=cost), patch(
+            "agent_trace.org_report.lint_session", side_effect=lint
+        ):
+            report = build_org_report([store], "2026-08")
+        team = report.teams[0]
+        self.assertEqual(report.cost_estimated_sessions, 1)
+        self.assertEqual(report.avg_estimated_cost_usd, 2.0)
+        self.assertEqual(report.cost_estimate_coverage_percent, 50.0)
+        self.assertEqual(team.lint_findings, 2)
+        self.assertEqual(team.sessions_with_lint_signals, 1)
+
+    def test_attribution_uses_persisted_fields_without_changing_legacy_fallback(self):
+        explicit = SessionMeta(attribution={"actor_id": "stable-id"})
+        composite = SessionMeta(attribution={"os_user": "alice", "hostname": "build-1"})
+        self.assertEqual(session_engineer_attribution(explicit), ("stable-id", "explicit"))
+        self.assertEqual(session_engineer_attribution(composite), ("alice@build-1", "host-user"))
+        with patch("agent_trace.team_report._git", return_value="legacy@example.com"):
+            self.assertEqual(_fallback_author(SessionMeta()), "legacy@example.com")
+
+
+class TestAnomaliesAndFormats(unittest.TestCase):
+    @staticmethod
+    def _team(name, average, sessions=MIN_ANOMALY_SESSIONS, coverage=100.0):
+        return TeamBreakdown(
+            team=name,
+            sessions=sessions,
+            cost_estimated_sessions=sessions,
+            cost_estimate_coverage_percent=coverage,
+            estimated_spend_usd=average * sessions,
+            avg_estimated_cost_usd=average,
+            active_attributed_identities=1,
+            lint_findings=0,
+            sessions_with_lint_signals=0,
+            lint_signals={},
+        )
+
+    def test_anomaly_detection_uses_peer_averages_and_floors(self):
+        teams = [
+            self._team("a", 1), self._team("b", 1), self._team("c", 1),
+            self._team("high", 4),
+        ]
+        anomalies = _build_anomalies([], teams)
+        self.assertEqual(MIN_ANOMALY_PEERS, 3)
+        self.assertEqual([item.subject for item in anomalies], ["high"])
+        self.assertEqual(anomalies[0].ratio_to_peer_median, 4)
+        self.assertEqual(anomalies[0].eligible_peers, 3)
+
+        too_small = [self._team("a", 1), self._team("b", 1), self._team("high", 4)]
+        self.assertEqual(_build_anomalies([], too_small), [])
+        low_coverage = [
+            self._team("a", 1), self._team("b", 1), self._team("c", 1),
+            self._team("high", 4, coverage=MIN_ANOMALY_COVERAGE * 100 - 1),
+        ]
+        self.assertEqual(_build_anomalies([], low_coverage), [])
+
+    def test_identity_anomaly_anonymizes_full_composite_stably(self):
+        metrics = []
+        for identity, cost in (
+            ("alice@host-a", 1.0), ("bob@host-b", 1.0),
+            ("carol@host-c", 1.0), ("secret@host-d", 4.0),
+        ):
+            metrics.extend(
+                _SessionMetric("team", identity, "host-user", "other", cost, ())
+                for _ in range(MIN_ANOMALY_SESSIONS)
+            )
+        raw = _build_anomalies(metrics, [])
+        self.assertEqual(raw[0].subject, "secret@host-d")
+
+        metas = [
+            SessionMeta(
+                session_id=f"s{i}", started_at=_timestamp(2026, 8, 2), team="<team>",
+                attribution={"os_user": identity.split("@")[0], "hostname": identity.split("@")[1]},
+            )
+            for i, identity in enumerate(
+                ["alice@host-a"] * 3 + ["bob@host-b"] * 3
+                + ["carol@host-c"] * 3 + ["secret@host-d"] * 3
+            )
+        ]
+        store = _MemoryStore(metas)
+
+        def estimate(_store, sid, model="sonnet"):
+            del model
+            return SimpleNamespace(total_cost=4.0 if int(sid[1:]) >= 9 else 1.0)
+
+        with patch("agent_trace.org_report.estimate_cost", side_effect=estimate), patch(
+            "agent_trace.org_report.lint_session", side_effect=lambda _s, sid: LintReport(sid)
+        ):
+            first = build_org_report(
+                [store], "2026-08", team="tag:<team>", anonymize=True,
+                generated_at="same",
+            )
+            second = build_org_report(
+                [store], "2026-08", team="tag:<team>", anonymize=True,
+                generated_at="same",
+            )
+        self.assertEqual(format_org_report_json(first), format_org_report_json(second))
+        for output in (
+            format_org_report_json(first), format_org_report_text(first),
+            format_org_report_html(first),
+        ):
+            self.assertNotIn("secret@host-d", output)
+            self.assertNotIn("<team>", output)
+            self.assertNotIn("tag:<team>", output)
+            self.assertIn("Identity-004", output)
+
+    def test_html_is_escaped_and_self_contained(self):
+        meta = SessionMeta(
+            session_id="escape", started_at=_timestamp(2026, 8, 2),
+            team='<script src="https://bad.example/x.js">x</script>',
+        )
+        store = _MemoryStore([meta])
+        with patch("agent_trace.org_report.estimate_cost", return_value=SimpleNamespace(total_cost=1)), patch(
+            "agent_trace.org_report.lint_session", return_value=LintReport("escape")
+        ):
+            report = build_org_report([store], "2026-08")
+        rendered = format_org_report_html(report)
+        self.assertNotIn("<script", rendered)
+        self.assertNotIn('src="https://bad.example', rendered)
+        self.assertNotIn("<link", rendered)
+        self.assertIn("&lt;script", rendered)
+
+    def test_json_is_strict_and_declares_estimation_semantics(self):
+        report = build_org_report([], "2026-08", generated_at="2026-09-01T00:00:00Z")
+        payload = json.loads(format_org_report_json(report))
+        self.assertEqual(payload["schema"], "agent-strace-org-report/v1")
+        self.assertTrue(payload["spend_is_estimate"])
+        self.assertIn("snapshot", payload["snapshot_limitation"].lower())
+        self.assertNotIn("NaN", format_org_report_json(report))
+
+
+class TestCollectorClient(unittest.TestCase):
+    def _meta(self, session_id="remote", **values):
+        item = {
+            "session_id": session_id,
+            "started_at": _timestamp(2026, 8, 2),
+            "team": "blue",
+            "attribution": {"actor_id": "alice"},
+        }
+        item.update(values)
+        return item
+
+    def _event_bytes(self, session_id="remote", **values):
+        item = {
+            "event_type": "user_prompt",
+            "timestamp": _timestamp(2026, 8, 2) + 1,
+            "event_id": "event-1",
+            "session_id": session_id,
+            "data": {"prompt": "hello"},
+        }
+        item.update(values)
+        return (json.dumps(item) + "\n").encode()
+
+    def test_endpoint_security_contract(self):
+        self.assertEqual(validate_collector_endpoint("http://localhost:8000/"), "http://localhost:8000")
+        self.assertEqual(validate_collector_endpoint("http://[::1]:8000"), "http://[::1]:8000")
+        for endpoint in (
+            "http://example.com", "ftp://example.com", "https://user:pass@example.com",
+            "https://example.com?q=1", "https://example.com#frag", "https://example.com?",
+            "https://example.com#",
+        ):
+            with self.subTest(endpoint=endpoint), self.assertRaises(ValueError):
+                validate_collector_endpoint(endpoint)
+        self.assertEqual(
+            validate_collector_endpoint("http://example.com/base", allow_insecure_http=True),
+            "http://example.com/base",
+        )
+
+    def test_auth_enforcement_and_percent_encoded_ids(self):
+        meta = self._meta("space id")
+        opener = _RouteOpener([meta], {"space%20id": self._event_bytes("space id")})
+        client = CollectorClient("http://localhost:8000", "secret", opener=opener)
+        sessions = client.list_sessions()
+        events = client.load_events(sessions[0])
+        self.assertEqual(events[0].session_id, "space id")
+        self.assertIn(("/sessions/space%20id/events", True), opener.requests)
+
+        unauthenticated = _RouteOpener([meta], {}, enforce_auth=False)
+        with self.assertRaisesRegex(CollectorAuthenticationError, "does not enforce"):
+            CollectorClient(
+                "http://localhost:8000", "secret", opener=unauthenticated
+            ).list_sessions()
+
+    def test_redirect_size_and_truncation_fail_closed(self):
+        class RedirectOpener:
+            def open(self, request, timeout=0):
+                del timeout
+                raise urllib.error.HTTPError(request.full_url, 302, "redirect", {}, None)
+
+        with self.assertRaisesRegex(CollectorClientError, "redirect"):
+            CollectorClient("http://localhost:8000", "key", opener=RedirectOpener()).list_sessions()
+
+        client = CollectorClient("http://localhost:8000", "key", opener=object(), max_metadata_bytes=1)
+        with self.assertRaisesRegex(CollectorClientError, "size limit"):
+            client._read_bounded(_Response(b"[]"), client.max_metadata_bytes)
+
+        truncated = _Response(b"[]")
+        truncated.headers["Content-Length"] = "20"
+        with self.assertRaisesRegex(CollectorClientError, "truncated"):
+            CollectorClient("http://localhost:8000", "key", opener=object())._read_bounded(
+                truncated, 100
+            )
+
+        no_length = _Response(b"123", length=False)
+        total_limited = CollectorClient(
+            "http://localhost:8000", "key", opener=object(), max_total_bytes=2
+        )
+        with self.assertRaisesRegex(CollectorClientError, "size limit"):
+            total_limited._read_bounded(no_length, 100)
+
+    def test_strict_metadata_and_event_validation(self):
+        bad_payloads = [
+            b'[{"session_id":"x","started_at":NaN}]',
+            b'[{"session_id":"x","session_id":"y","started_at":1}]',
+            b'[{"session_id":"x","started_at":"now"}]',
+            ('[{"session_id":"x","started_at":' + str(10**1000) + '}]').encode(),
+            b'[{"session_id":"x","started_at":1,"attribution":[]}]',
+            ("[" * 10_000 + "0" + "]" * 10_000).encode(),
+        ]
+        for body in bad_payloads:
+            class BadOpener:
+                def open(self, request, timeout=0):
+                    del timeout
+                    if not request.get_header("Authorization"):
+                        raise urllib.error.HTTPError(request.full_url, 401, "no", {}, None)
+                    return _Response(body)
+            with self.subTest(body=body), self.assertRaises(CollectorClientError):
+                CollectorClient("http://localhost:8000", "key", opener=BadOpener()).list_sessions()
+
+        meta = self._meta(tenant_id="")
+        mixed = self._event_bytes(tenant_id="one") + self._event_bytes(
+            event_id="event-2", tenant_id="two"
+        )
+        client = CollectorClient("http://localhost:8000", "key", opener=object())
+        client._get = lambda *args, **kwargs: mixed
+        with self.assertRaisesRegex(CollectorClientError, "mixed tenants"):
+            client.load_events(SessionMeta.from_json(json.dumps(meta)))
+
+        wrong_data = self._event_bytes(data=[])
+        client._get = lambda *args, **kwargs: wrong_data
+        with self.assertRaisesRegex(CollectorClientError, "malformed"):
+            client.load_events(SessionMeta.from_json(json.dumps(meta)))
+
+        deeply_nested = (
+            '{"event_type":"user_prompt","timestamp":1,"event_id":"e",'
+            '"session_id":"remote","data":'
+            + "[" * 10_000 + "0" + "]" * 10_000 + "}\n"
+        ).encode()
+        client._get = lambda *args, **kwargs: deeply_nested
+        with self.assertRaisesRegex(CollectorClientError, "malformed"):
+            client.load_events(SessionMeta.from_json(json.dumps(meta)))
+
+    def test_remote_metadata_filters_before_n_plus_one_event_reads(self):
+        selected = self._meta("selected")
+        outside = self._meta("outside", started_at=_timestamp(2026, 7, 2))
+        other_team = self._meta("red", team="red")
+        opener = _RouteOpener(
+            [selected, outside, other_team],
+            {
+                "selected": self._event_bytes("selected"),
+                "outside": self._event_bytes("outside"),
+                "red": self._event_bytes("red"),
+            },
+        )
+        store = CollectorTraceStore.load(
+            CollectorClient("http://localhost:8000", "key", opener=opener)
+        )
+        report = build_org_report(
+            [store], "2026-08", team="tag:blue", source_mode="collector-instance"
+        )
+        self.assertEqual(report.session_count, 1)
+        event_paths = [path for path, _ in opener.requests if path.endswith("/events")]
+        self.assertEqual(event_paths, ["/sessions/selected/events"])
+        self.assertEqual(store._events, {})
+        self.assertIn("N+1", report.snapshot_limitation)
+
+    def test_ambient_proxy_is_never_used_for_loopback_bearer(self):
+        captured = []
+
+        class ProxyHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                captured.append((self.path, self.headers.get("Authorization")))
+                body = b"[]"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                pass
+
+        proxy = ThreadingHTTPServer(("127.0.0.1", 0), ProxyHandler)
+        thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+        thread.start()
+        unavailable = socket.socket()
+        unavailable.bind(("127.0.0.1", 0))
+        port = unavailable.getsockname()[1]
+        proxy_url = f"http://127.0.0.1:{proxy.server_port}"
+        try:
+            with patch.dict(
+                os.environ,
+                {"http_proxy": proxy_url, "HTTP_PROXY": proxy_url, "NO_PROXY": "", "no_proxy": ""},
+                clear=False,
+            ):
+                with self.assertRaises(CollectorClientError):
+                    CollectorClient(
+                        f"http://127.0.0.1:{port}", "TOPSECRET", timeout=0.2
+                    ).list_sessions()
+            self.assertEqual(captured, [])
+        finally:
+            unavailable.close()
+            proxy.shutdown()
+            proxy.server_close()
+            thread.join(timeout=2)
+
+
+class TestCliAndOutput(unittest.TestCase):
+    def test_cli_registers_org_report_and_does_not_read_endpoint_from_env(self):
+        args = build_parser().parse_args(["org-report", "--month", "2026-08"])
+        self.assertEqual(args.command, "org-report")
+        self.assertIsNone(args.endpoint)
+
+    def test_atomic_output_rejects_symlink_and_preserves_existing_on_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target.txt"
+            target.write_text("old", encoding="utf-8")
+            link = root / "report.txt"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(ValueError, "symlink"):
+                _write_atomic(str(link), "new")
+            self.assertEqual(target.read_text(encoding="utf-8"), "old")
+
+            parent_target = root / "real"
+            parent_target.mkdir()
+            parent_link = root / "linked"
+            parent_link.symlink_to(parent_target, target_is_directory=True)
+            with self.assertRaisesRegex(ValueError, "symlink"):
+                _write_atomic(str(parent_link / "report.txt"), "new")
+
+            private = root / "private.txt"
+            _write_atomic(str(private), "secret")
+            self.assertEqual(private.stat().st_mode & 0o077, 0)
+
+            stable = root / "stable.txt"
+            stable.write_text("original", encoding="utf-8")
+            with patch("agent_trace.org_report.os.replace", side_effect=OSError("stop")):
+                with self.assertRaises(OSError):
+                    _write_atomic(str(stable), "replacement")
+            self.assertEqual(stable.read_text(encoding="utf-8"), "original")
+            self.assertEqual(list(root.glob(".stable.txt.*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds `agent-strace org-report` for monthly organization-wide session volume, offline estimated cost, team/workspace breakdowns, heuristic task categories, and statistically guarded anomaly callouts.

The command reads either a shared trace directory (including workspace stores) or an explicitly selected authenticated remote collector. Remote reads use the existing collector API with strict authentication, TLS/URL/redirect/proxy, response-size, nesting, schema, tenant, and partial-report protections. Reports support text, versioned JSON, self-contained HTML, exact team/workspace scoping, cost/identity coverage, and report-local anonymization.

All cost, classification, and anomaly fields are explicitly labeled as estimates or heuristics. Collector and shared-directory inputs disclose their non-transactional snapshot limitation.

Documentation covers setup, security boundaries, privacy, and interpretation. Version is bumped to `0.91.0`.

Closes #214

## Validation

- Repository Ona `test` task: 1,835 Python tests passed
- VS Code extension: compile plus 3 tests passed
- Focused org-report suite: 21 tests passed
- Independent report/math/privacy review: approved
- Independent collector/security/tenancy review: approved
- `git diff --check` and source compilation passed